### PR TITLE
Compose-based deploy pipeline with 1Password secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Image (set by deploy workflow; latest for local dev)
+IMAGE_TAG=latest
+GITHUB_REPOSITORY=owner/prive-admin
+
+# Postgres
+POSTGRES_DB=prive_admin
+POSTGRES_USER=prive_admin
+POSTGRES_PASSWORD=replace-me-32-chars-min
+
+# App (server.ts schema)
+DATABASE_URL=postgres://prive_admin:replace-me-32-chars-min@postgres:5432/prive_admin
+BETTER_AUTH_SECRET=replace-me-32-chars-min
+BETTER_AUTH_URL=https://prive.salon
+CORS_ORIGIN=https://prive.salon
+NODE_ENV=production
+
+# Cloudflare R2
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+
+# Caddy
+DOMAIN_NAME=prive.salon
+ACME_EMAIL=ops@example.com

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -26,16 +26,18 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
           POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
-          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          R2_ACCOUNT_ID: op://prive-admin/Cloudflare R2/account-id
+          R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
+          R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
+          R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
+          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/add more/client-id
+          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/add more/client-secret
 
       - name: Tailscale up
         uses: tailscale/github-action@v3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_CLIENT_SECRET }}
           tags: tag:prod-ci
 
       - name: Prepare SSH

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -46,11 +46,11 @@ jobs:
           chmod 644 ~/.ssh/known_hosts
 
       - name: Copy backup script to VPS
-        run: scp scripts/backup_postgres.sh cicd@prive:~/backup_postgres.sh
+        run: scp scripts/backup_postgres.sh root@prive:~/backup_postgres.sh
 
       - name: Run backup script on VPS
         run: |
-          ssh cicd@prive "
+          ssh root@prive "
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \
             PG_DATABASE='${POSTGRES_DB}' \
@@ -65,9 +65,9 @@ jobs:
         run: |
           set -e
           umask 077
-          FILE_NAME=$(ssh cicd@prive 'ls -t ~/db_backups/ | head -n1')
+          FILE_NAME=$(ssh root@prive 'ls -t ~/db_backups/ | head -n1')
           [ -n "${FILE_NAME}" ] || { echo "no backup file produced on VPS"; exit 1; }
-          ssh cicd@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
+          ssh root@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
           cat > ~/.s3cfg <<EOF
           [default]
           access_key = ${R2_ACCESS_KEY_ID}

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -24,12 +24,12 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
-          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
-          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+          POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
+          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
 
       - name: Tailscale up
         uses: tailscale/github-action@v3

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -30,8 +30,8 @@ jobs:
           R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
           R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
           R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
-          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/add more/client-id
-          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/add more/client-secret
+          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/client-id
+          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/client-secret
 
       - name: Tailscale up
         uses: tailscale/github-action@v3

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -11,85 +11,70 @@ jobs:
       name: production
       url: https://prive.salon
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Tailscale
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
+          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+
+      - name: Tailscale up
         uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:prod-ci
 
-      - name: Test Hostname Resolution
-        run: |
-          ping -c 3 prive || (echo "Hostname resolution failed!" && exit 1)
-          nc -zv prive 22 || (echo "Port 22 is not accessible!" && exit 1)
-
-      - name: Prepare SSH Directory
+      - name: Prepare SSH
         run: |
           mkdir -p ~/.ssh
           chmod 0700 ~/.ssh
           ssh-keyscan -H prive >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Test SSH Connection
-        run: ssh -o ConnectTimeout=30 "cicd@prive" "echo 'SSH connection successful!'"
-
       - name: Copy backup script to VPS
         run: scp scripts/backup_postgres.sh cicd@prive:~/backup_postgres.sh
 
       - name: Run backup script on VPS
-        env:
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
         run: |
           ssh cicd@prive "
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \
-            PG_PASSWORD='${POSTGRES_PASSWORD}' \
-            PG_DATABASE='${POSTGRES_DATABASE}' \
+            PG_DATABASE='${POSTGRES_DB}' \
             ~/backup_postgres.sh"
 
-      # --- Cloudflare R2 upload with s3cmd ---
       - name: Install s3cmd
         run: |
           sudo apt-get update -y
           sudo apt-get install -y s3cmd
 
       - name: Upload backup to Cloudflare R2
-        env:
-          R2_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
         run: |
           set -e
-
-          # Fetch latest backup file name from remote server
-          FILE_NAME=$(ssh cicd@prive "ls -t ~/db_backups/ | head -n1")
-
-          # Download the backup file
-          ssh cicd@prive "cat ~/db_backups/$FILE_NAME" > "$FILE_NAME"
-
-          # Configure s3cmd for Cloudflare R2
+          FILE_NAME=$(ssh cicd@prive 'ls -t ~/db_backups/ | head -n1')
+          ssh cicd@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
           cat > ~/.s3cfg <<EOF
           [default]
-          access_key = $R2_ACCESS_KEY
-          secret_key = $R2_SECRET_KEY
+          access_key = ${R2_ACCESS_KEY_ID}
+          secret_key = ${R2_SECRET_ACCESS_KEY}
           host_base = ${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
           host_bucket = %(bucket)s.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
           bucket_location = auto
           use_https = True
           EOF
-
-          # Upload the file to Cloudflare R2
-          s3cmd put "$FILE_NAME" "s3://${R2_BUCKET}/$FILE_NAME"
-
-          # Print bucket info for verification
-          s3cmd info "s3://${R2_BUCKET}"
-
-          echo "✅ Uploaded to https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${R2_BUCKET}/$FILE_NAME"
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
+          s3cmd info "s3://${R2_BUCKET_NAME}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}"

--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Upload backup to Cloudflare R2
         run: |
           set -e
+          umask 077
           FILE_NAME=$(ssh cicd@prive 'ls -t ~/db_backups/ | head -n1')
+          [ -n "${FILE_NAME}" ] || { echo "no backup file produced on VPS"; exit 1; }
           ssh cicd@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
           cat > ~/.s3cfg <<EOF
           [default]
@@ -76,5 +78,5 @@ jobs:
           use_https = True
           EOF
           s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
-          s3cmd info "s3://${R2_BUCKET_NAME}"
+          s3cmd info "s3://${R2_BUCKET_NAME}" || true
           echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,13 +7,11 @@ on:
 
 jobs:
   build:
-    name: Build and Validate PR
+    name: Source Build
     runs-on: ubuntu-latest
 
     permissions:
-      # Required to checkout the code
       contents: read
-      # Required to put a comment into the pull-request
       pull-requests: write
 
     steps:
@@ -24,7 +22,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         run: bunx oxlint
@@ -37,3 +35,27 @@ jobs:
 
       - name: Run Build
         run: bun run build
+
+  docker-build:
+    name: Docker Image Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          file: apps/web/Dockerfile
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - tanstack-rewrite
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,19 +66,19 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
-          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
-          POSTGRES_PASSWORD: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD
-          DATABASE_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/DATABASE_URL
-          BETTER_AUTH_SECRET: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_SECRET
-          BETTER_AUTH_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL
-          CORS_ORIGIN: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/CORS_ORIGIN
-          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
-          DOMAIN_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/DOMAIN_NAME
-          ACME_EMAIL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/ACME_EMAIL
+          POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
+          POSTGRES_PASSWORD: op://prive-admin/prive-admin-prod/postgres/POSTGRES_PASSWORD
+          DATABASE_URL: op://prive-admin/prive-admin-prod/app/DATABASE_URL
+          BETTER_AUTH_SECRET: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_SECRET
+          BETTER_AUTH_URL: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_URL
+          CORS_ORIGIN: op://prive-admin/prive-admin-prod/app/CORS_ORIGIN
+          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          DOMAIN_NAME: op://prive-admin/prive-admin-prod/infra/DOMAIN_NAME
+          ACME_EMAIL: op://prive-admin/prive-admin-prod/infra/ACME_EMAIL
 
       - name: Render .env
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,9 +130,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ACTOR: ${{ github.actor }}
         run: |
-          ssh cicd@prive \
+          printf '%s' "${GH_TOKEN}" | ssh cicd@prive \
             "cd ~/prive-admin && \
-             echo '${GH_TOKEN}' | docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
+             docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
              docker compose pull && \
              docker compose up -d --remove-orphans && \
              docker image prune -f"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -12,86 +13,35 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push-image:
-    name: Publish Docker Images
+  build-and-push:
+    name: Build and Push Image
     runs-on: ubuntu-latest
-    environment: production
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Docker Login
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          #          platforms: linux/amd64,linux/arm64
-          build-args: |
-            NEXT_PUBLIC_APP_URL=https://${{ vars.DOMAIN_NAME }}
-            BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }}
+          file: apps/web/Dockerfile
+          context: .
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-  deploy-development:
-    name: Deploy
-    environment:
-      name: production
-      url: https://prive.salon
-    runs-on: ubuntu-latest
-    needs:
-      - build-and-push-image
-    timeout-minutes: 30
-    env:
-      VERSION: ${{ github.sha }}
-      DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
-      BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Tailscale
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:prod-ci
-
-      - name: Test Hostname Resolution
-        run: |
-          ping -c 3 prive || (echo "Hostname resolution failed!" && exit 1)
-          nc -zv prive 22 || (echo "Port 22 is not accessible!" && exit 1)
-
-      - name: Prepare SSH Directory
-        run: |
-          mkdir -p ~/.ssh
-          chmod 0700 ~/.ssh
-          ssh-keyscan -p "22" -H "prive" >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
-
-      - name: Test SSH Connection
-        run: ssh -o ConnectTimeout=30 "cicd@prive" "echo 'SSH connection successful!'"
-
-      - name: Configure Docker Stack
-        run: |
-          docker context create remote --docker "host=ssh://cicd@prive"
-          docker context ls
-          docker context use remote
-
-      - name: Docker Stack Deploy
-        run: docker stack deploy -c docker-stack.yaml prive
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,14 @@ jobs:
           BETTER_AUTH_SECRET: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_SECRET
           BETTER_AUTH_URL: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_URL
           CORS_ORIGIN: op://prive-admin/prive-admin-prod/app/CORS_ORIGIN
-          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          R2_ACCOUNT_ID: op://prive-admin/Cloudflare R2/account-id
+          R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
+          R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
+          R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
           DOMAIN_NAME: op://prive-admin/prive-admin-prod/infra/DOMAIN_NAME
           ACME_EMAIL: op://prive-admin/prive-admin-prod/infra/ACME_EMAIL
+          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/add more/client-id
+          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/add more/client-secret
 
       - name: Render .env
         run: |
@@ -106,8 +108,8 @@ jobs:
       - name: Tailscale up
         uses: tailscale/github-action@v3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_CLIENT_SECRET }}
           tags: tag:prod-ci
 
       - name: Prepare SSH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
           R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
           DOMAIN_NAME: op://prive-admin/prive-admin-prod/infra/DOMAIN_NAME
           ACME_EMAIL: op://prive-admin/prive-admin-prod/infra/ACME_EMAIL
-          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/add more/client-id
-          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/add more/client-secret
+          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/client-id
+          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/client-secret
 
       - name: Render .env
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,19 +118,19 @@ jobs:
           chmod 644 ~/.ssh/known_hosts
 
       - name: Verify SSH connection
-        run: ssh -o ConnectTimeout=30 cicd@prive 'echo ok'
+        run: ssh -o ConnectTimeout=30 root@prive 'echo ok'
 
       - name: Stage files on VPS
         run: |
-          ssh cicd@prive 'mkdir -p ~/prive-admin'
-          scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/
+          ssh root@prive 'mkdir -p ~/prive-admin'
+          scp docker-compose.yml Caddyfile .env root@prive:~/prive-admin/
 
       - name: Deploy stack
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ACTOR: ${{ github.actor }}
         run: |
-          printf '%s' "${GH_TOKEN}" | ssh cicd@prive \
+          printf '%s' "${GH_TOKEN}" | ssh root@prive \
             "cd ~/prive-admin && \
              docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
              docker compose pull && \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,107 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to prive
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://prive.salon
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
+          POSTGRES_PASSWORD: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD
+          DATABASE_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/DATABASE_URL
+          BETTER_AUTH_SECRET: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_SECRET
+          BETTER_AUTH_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL
+          CORS_ORIGIN: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/CORS_ORIGIN
+          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+          DOMAIN_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/DOMAIN_NAME
+          ACME_EMAIL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/ACME_EMAIL
+
+      - name: Render .env
+        run: |
+          umask 077
+          cat > .env <<EOF
+          IMAGE_TAG=${GITHUB_SHA}
+          GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+          NODE_ENV=production
+          POSTGRES_DB=${POSTGRES_DB}
+          POSTGRES_USER=${POSTGRES_USER}
+          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+          DATABASE_URL=${DATABASE_URL}
+          BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+          BETTER_AUTH_URL=${BETTER_AUTH_URL}
+          CORS_ORIGIN=${CORS_ORIGIN}
+          R2_ACCOUNT_ID=${R2_ACCOUNT_ID}
+          R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}
+          R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}
+          R2_BUCKET_NAME=${R2_BUCKET_NAME}
+          DOMAIN_NAME=${DOMAIN_NAME}
+          ACME_EMAIL=${ACME_EMAIL}
+          EOF
+          chmod 600 .env
+
+      - name: Tailscale up
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:prod-ci
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 0700 ~/.ssh
+          ssh-keyscan -H prive >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Verify SSH connection
+        run: ssh -o ConnectTimeout=30 cicd@prive 'echo ok'
+
+      - name: Stage files on VPS
+        run: |
+          ssh cicd@prive 'mkdir -p ~/prive-admin'
+          scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/
+
+      - name: Deploy stack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+        run: |
+          ssh cicd@prive \
+            "cd ~/prive-admin && \
+             echo '${GH_TOKEN}' | docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
+             docker compose pull && \
+             docker compose up -d --remove-orphans && \
+             docker image prune -f"
+
+      - name: Smoke check
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -fsS --max-time 10 https://prive.salon/ > /dev/null; then
+              echo "smoke check ok"
+              exit 0
+            fi
+            echo "attempt $i failed, retrying in 10s"
+            sleep 10
+          done
+          echo "smoke check failed after 5 attempts"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,13 +139,13 @@ jobs:
 
       - name: Smoke check
         run: |
-          for i in 1 2 3 4 5; do
+          for i in $(seq 1 10); do
             if curl -fsS --max-time 10 https://prive.salon/ > /dev/null; then
               echo "smoke check ok"
               exit 0
             fi
-            echo "attempt $i failed, retrying in 10s"
-            sleep 10
+            echo "attempt $i failed, retrying in 15s"
+            sleep 15
           done
-          echo "smoke check failed after 5 attempts"
+          echo "smoke check failed after 10 attempts"
           exit 1

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,5 @@
+{$DOMAIN_NAME} {
+  encode zstd gzip
+  reverse_proxy web:8081
+  tls {$ACME_EMAIL}
+}

--- a/README.md
+++ b/README.md
@@ -96,3 +96,20 @@ prive-admin-tanstack/
 - `bun run db:migrate`: Run database migrations
 - `bun run db:studio`: Open database studio UI
 - `bun run check`: Run Oxlint and Oxfmt
+
+## Deployment
+
+The production stack runs on VPS `prive` via Docker Compose. The
+authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.md).
+
+- Pushes to `main` build and publish `ghcr.io/<repo>:{latest,sha}` and
+  deploy to the VPS automatically (`.github/workflows/release.yml`).
+- All runtime secrets live in the 1Password vault
+  `5gq2basjdplfjk5v55wexp2y7i`, item `prive-admin-prod`. The workflow
+  pulls them at deploy time using a service-account token
+  (`OP_SERVICE_ACCOUNT_TOKEN`).
+- Rollback to a previous image:
+
+  ```bash
+  ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+  ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.m
 - Pushes to `main` build and publish `ghcr.io/<repo>:{latest,sha}` and
   deploy to the VPS automatically (`.github/workflows/release.yml`).
 - All runtime secrets live in the 1Password vault
-  `5gq2basjdplfjk5v55wexp2y7i`, item `prive-admin-prod`. The workflow
+  `prive-admin`, item `prive-admin-prod`. The workflow
   pulls them at deploy time using a service-account token
   (`OP_SERVICE_ACCOUNT_TOKEN`).
 - Rollback to a previous image:

--- a/README.md
+++ b/README.md
@@ -104,12 +104,14 @@ authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.m
 
 - Pushes to `main` build and publish `ghcr.io/<repo>:{latest,sha}` and
   deploy to the VPS automatically (`.github/workflows/release.yml`).
-- All runtime secrets live in the 1Password vault
-  `prive-admin`, item `prive-admin-prod`. The workflow
-  pulls them at deploy time using a service-account token
-  (`OP_SERVICE_ACCOUNT_TOKEN`).
+- All runtime secrets live in the 1Password vault `prive-admin`,
+  spread across three items: `prive-admin-prod` (app, postgres, infra),
+  `Cloudflare R2` (R2 keys + bucket), and `tailscale-oauth` (TS
+  OAuth). The workflow pulls them at deploy time using a
+  service-account token (`OP_SERVICE_ACCOUNT_TOKEN` — the only
+  remaining GitHub Actions secret).
 - Rollback to a previous image:
 
   ```bash
-  ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+  ssh root@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - /var/lib/prive-admin/pg:/var/lib/postgresql/data
+      - /var/lib/prive-admin/pg:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+name: prive-admin
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - /var/lib/prive-admin/caddy/data:/data
+      - /var/lib/prive-admin/caddy/config:/config
+    environment:
+      DOMAIN_NAME: ${DOMAIN_NAME}
+      ACME_EMAIL: ${ACME_EMAIL}
+    depends_on:
+      - web
+
+  web:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: .env
+    expose:
+      - "8081"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - /var/lib/prive-admin/pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docs/deploy/vps-setup.md
+++ b/docs/deploy/vps-setup.md
@@ -7,33 +7,21 @@ the stack; this document is for first-time provisioning and recovery.
 ## Requirements
 
 - Linux host (Ubuntu 22.04 or later assumed) with public IPv4.
-- SSH user `cicd` with Docker group membership and an authorized SSH
-  key matching the GitHub Actions Tailscale identity.
+- SSH access as `root` (the GitHub Actions Tailscale identity's public
+  key in `/root/.ssh/authorized_keys`).
 - Tailscale installed, logged in, with ACL tag `tag:prod` so the
   `tag:prod-ci` runners can reach it.
 
-## Bootstrap the cicd user
+## SSH key
 
-The deploy and backup workflows SSH into the host as `cicd`. On a
-fresh VPS this user does not yet exist. Create it before installing
-Docker:
+Install the deploy identity's public key for the `root` user:
 
 ```bash
-sudo adduser --disabled-password --gecos '' cicd
-sudo install -d -o cicd -g cicd -m 0700 /home/cicd/.ssh
-sudo install -o cicd -g cicd -m 0600 /dev/stdin /home/cicd/.ssh/authorized_keys <<'KEY'
+sudo install -d -m 0700 /root/.ssh
+sudo install -m 0600 /dev/stdin /root/.ssh/authorized_keys <<'KEY'
 <paste the public key matching the GitHub Actions Tailscale identity>
 KEY
 ```
-
-After Docker is installed in the next section, add `cicd` to the
-`docker` group:
-
-```bash
-sudo usermod -aG docker cicd
-```
-
-The group change only applies to new shell sessions for `cicd`.
 
 ## Install
 
@@ -58,18 +46,20 @@ must:
 - Allow `tag:prod-ci` to reach `tag:prod` on TCP `22`.
 - Have MagicDNS enabled in the tailnet, and the VPS machine renamed
   to `prive` (admin console → Machines → rename), so that
-  `ssh cicd@prive` resolves.
+  `ssh root@prive` resolves.
 
 ## Host directories
 
 ```bash
 sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
 sudo chown -R 70:70 /var/lib/prive-admin/pg
-sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
-sudo -u cicd mkdir -p /home/cicd/prive-admin
+sudo mkdir -p /root/prive-admin
 ```
 
-The `70:70` ownership matches the `postgres` user inside the official `postgres:17-alpine` image.
+The `70:70` ownership matches the `postgres` user inside the official
+`postgres:18-alpine` image. Caddy runs as root in `caddy:2-alpine`, so
+its bind-mount paths under `/var/lib/prive-admin/caddy/` need no
+special chown — root inside the container can write to them.
 
 ## Firewall
 
@@ -93,7 +83,7 @@ resolves.
 
 ## GHCR pulls
 
-The deploy workflow logs `cicd` into `ghcr.io` on every run using the
+The deploy workflow logs into `ghcr.io` on every run using the
 ephemeral `GITHUB_TOKEN`. No manual login is required.
 
 ## First deploy
@@ -105,7 +95,7 @@ Push (or merge) to `main` and watch the `Release` workflow run. The
 ## Rollback
 
 ```bash
-ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+ssh root@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
 ```
 
 GHCR retains older `:<sha>` tags by default. Pick a known-good sha
@@ -113,6 +103,6 @@ from the GitHub Actions history.
 
 ## Routine operations
 
-- View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
-- Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
-- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`
+- View logs: `ssh root@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
+- Restart web: `ssh root@prive 'cd ~/prive-admin && docker compose restart web'`
+- Database shell: `ssh root@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`

--- a/docs/deploy/vps-setup.md
+++ b/docs/deploy/vps-setup.md
@@ -1,0 +1,83 @@
+# VPS Setup (`prive`)
+
+One-time prerequisites for the production host before the deploy
+workflow can run. The deploy workflow is the only continuous owner of
+the stack; this document is for first-time provisioning and recovery.
+
+## Requirements
+
+- Linux host (Ubuntu 22.04 or later assumed) with public IPv4.
+- SSH user `cicd` with Docker group membership and an authorized SSH
+  key matching the GitHub Actions Tailscale identity.
+- Tailscale installed, logged in, with ACL tag `tag:prod` so the
+  `tag:prod-ci` runners can reach it.
+
+## Install
+
+```bash
+# Docker Engine + compose plugin
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker cicd
+
+# Tailscale
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --advertise-tags=tag:prod
+```
+
+## Host directories
+
+```bash
+sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
+sudo chown -R 999:999 /var/lib/prive-admin/pg
+sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
+sudo -u cicd mkdir -p /home/cicd/prive-admin
+```
+
+The `999:999` ownership matches the `postgres` user inside the
+official `postgres:17-alpine` image.
+
+## Firewall
+
+Open inbound `80/tcp` and `443/tcp` from the public internet for
+Caddy. Restrict `22/tcp` to the Tailscale interface only:
+
+```bash
+sudo ufw default deny incoming
+sudo ufw allow in on tailscale0 to any port 22
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+## DNS
+
+Set an `A` (and optional `AAAA`) record for `prive.salon` pointing at
+the VPS public IP before the first deploy. Caddy will obtain a
+Let's Encrypt cert via the HTTP-01 challenge on port 80 once DNS
+resolves.
+
+## GHCR pulls
+
+The deploy workflow logs `cicd` into `ghcr.io` on every run using the
+ephemeral `GITHUB_TOKEN`. No manual login is required.
+
+## First deploy
+
+Push (or merge) to `main` and watch the `Release` workflow run. The
+`deploy` job ends with a `curl` smoke check against
+`https://prive.salon/`; a passing job means the stack is up.
+
+## Rollback
+
+```bash
+ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+```
+
+GHCR retains older `:<sha>` tags by default. Pick a known-good sha
+from the GitHub Actions history.
+
+## Routine operations
+
+- View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
+- Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
+- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'`

--- a/docs/deploy/vps-setup.md
+++ b/docs/deploy/vps-setup.md
@@ -12,29 +12,64 @@ the stack; this document is for first-time provisioning and recovery.
 - Tailscale installed, logged in, with ACL tag `tag:prod` so the
   `tag:prod-ci` runners can reach it.
 
+## Bootstrap the cicd user
+
+The deploy and backup workflows SSH into the host as `cicd`. On a
+fresh VPS this user does not yet exist. Create it before installing
+Docker:
+
+```bash
+sudo adduser --disabled-password --gecos '' cicd
+sudo install -d -o cicd -g cicd -m 0700 /home/cicd/.ssh
+sudo install -o cicd -g cicd -m 0600 /dev/stdin /home/cicd/.ssh/authorized_keys <<'KEY'
+<paste the public key matching the GitHub Actions Tailscale identity>
+KEY
+```
+
+After Docker is installed in the next section, add `cicd` to the
+`docker` group:
+
+```bash
+sudo usermod -aG docker cicd
+```
+
+The group change only applies to new shell sessions for `cicd`.
+
 ## Install
 
 ```bash
 # Docker Engine + compose plugin
 curl -fsSL https://get.docker.com | sh
-sudo usermod -aG docker cicd
 
 # Tailscale
 curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up --advertise-tags=tag:prod
 ```
 
+## Tailscale ACL
+
+The deploy and backup workflows authenticate as `tag:prod-ci` and
+SSH the VPS by its short tailnet name `prive`. The tailnet ACL
+must:
+
+- List your operator identity under `tagOwners` for both `tag:prod`
+  and `tag:prod-ci`, otherwise `tailscale up --advertise-tags=tag:prod`
+  and the GitHub Actions OAuth tags will be rejected.
+- Allow `tag:prod-ci` to reach `tag:prod` on TCP `22`.
+- Have MagicDNS enabled in the tailnet, and the VPS machine renamed
+  to `prive` (admin console → Machines → rename), so that
+  `ssh cicd@prive` resolves.
+
 ## Host directories
 
 ```bash
 sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
-sudo chown -R 999:999 /var/lib/prive-admin/pg
+sudo chown -R 70:70 /var/lib/prive-admin/pg
 sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
 sudo -u cicd mkdir -p /home/cicd/prive-admin
 ```
 
-The `999:999` ownership matches the `postgres` user inside the
-official `postgres:17-alpine` image.
+The `70:70` ownership matches the `postgres` user inside the official `postgres:17-alpine` image.
 
 ## Firewall
 
@@ -80,4 +115,4 @@ from the GitHub Actions history.
 
 - View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
 - Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
-- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'`
+- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`

--- a/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
@@ -399,29 +399,64 @@ the stack; this document is for first-time provisioning and recovery.
 - Tailscale installed, logged in, with ACL tag `tag:prod` so the
   `tag:prod-ci` runners can reach it.
 
+## Bootstrap the cicd user
+
+The deploy and backup workflows SSH into the host as `cicd`. On a
+fresh VPS this user does not yet exist. Create it before installing
+Docker:
+
+```bash
+sudo adduser --disabled-password --gecos '' cicd
+sudo install -d -o cicd -g cicd -m 0700 /home/cicd/.ssh
+sudo install -o cicd -g cicd -m 0600 /dev/stdin /home/cicd/.ssh/authorized_keys <<'KEY'
+<paste the public key matching the GitHub Actions Tailscale identity>
+KEY
+```
+
+After Docker is installed in the next section, add `cicd` to the
+`docker` group:
+
+```bash
+sudo usermod -aG docker cicd
+```
+
+The group change only applies to new shell sessions for `cicd`.
+
 ## Install
 
 ```bash
 # Docker Engine + compose plugin
 curl -fsSL https://get.docker.com | sh
-sudo usermod -aG docker cicd
 
 # Tailscale
 curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up --advertise-tags=tag:prod
 ```
 
+## Tailscale ACL
+
+The deploy and backup workflows authenticate as `tag:prod-ci` and
+SSH the VPS by its short tailnet name `prive`. The tailnet ACL
+must:
+
+- List your operator identity under `tagOwners` for both `tag:prod`
+  and `tag:prod-ci`, otherwise `tailscale up --advertise-tags=tag:prod`
+  and the GitHub Actions OAuth tags will be rejected.
+- Allow `tag:prod-ci` to reach `tag:prod` on TCP `22`.
+- Have MagicDNS enabled in the tailnet, and the VPS machine renamed
+  to `prive` (admin console → Machines → rename), so that
+  `ssh cicd@prive` resolves.
+
 ## Host directories
 
 ```bash
 sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
-sudo chown -R 999:999 /var/lib/prive-admin/pg
+sudo chown -R 70:70 /var/lib/prive-admin/pg
 sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
 sudo -u cicd mkdir -p /home/cicd/prive-admin
 ```
 
-The `999:999` ownership matches the `postgres` user inside the
-official `postgres:17-alpine` image.
+The `70:70` ownership matches the `postgres` user inside the official `postgres:17-alpine` image.
 
 ## Firewall
 
@@ -467,7 +502,7 @@ from the GitHub Actions history.
 
 - View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
 - Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
-- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'`
+- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`
 ```
 
 - [ ] **Step 2: Commit**

--- a/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
@@ -1,0 +1,1013 @@
+# Deploy Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a Docker Compose deployment to VPS `prive` with Caddy auto-TLS, GHCR-built images on master push, and 1Password-sourced runtime secrets, replacing the existing Docker Swarm flow.
+
+**Architecture:** GitHub Actions runner builds and pushes `ghcr.io/<repo>:{latest,sha}` on master, then over Tailscale SSH copies `docker-compose.yml`, `Caddyfile`, and a freshly-rendered `.env` (from 1Password) to `cicd@prive:~/prive-admin/`, then runs `docker compose pull && up -d`. Caddy fronts the web container on 80/443 with auto-TLS. Postgres runs in the same compose stack with a host bind-mount.
+
+**Tech Stack:** Docker Compose, Caddy 2, Postgres 17, GitHub Actions, 1Password service account + `load-secrets-action@v2`, Tailscale OAuth, GHCR.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md`
+
+**Note on TDD:** This plan is infrastructure configuration. There are no unit tests to write first. "Tests" in each task are syntax validation (`docker compose config`, `actionlint`, `caddy validate`), dry-run output verification, and a final integration check via the first real deploy.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `docker-compose.yml` | NEW (root) | Production compose stack: caddy, web, postgres |
+| `Caddyfile` | NEW (root) | Reverse proxy + auto-TLS |
+| `.env.example` | NEW (root) | Documents required env keys, no values |
+| `.gitignore` | EDIT | Already ignores `.env` — verify only |
+| `scripts/backup_postgres.sh` | NEW (restored, adapted) | Runs `pg_dump` via `docker compose exec` |
+| `.github/workflows/pr-build.yml` | EDIT | Add `docker-build` parallel job |
+| `.github/workflows/release.yml` | REWRITE | `build-and-push` + `deploy` jobs (replaces swarm) |
+| `.github/workflows/backup-postgres.yml` | EDIT | Source secrets from 1Password; map to script env |
+| `docs/deploy/vps-setup.md` | NEW | One-time VPS prerequisite checklist |
+| `README.md` | EDIT | Reference deploy doc, document rollback command |
+
+---
+
+## Task 1: Foundation — `.env.example` and `.gitignore`
+
+**Files:**
+- Create: `.env.example`
+- Verify: `.gitignore` (already ignores `.env`; no change needed)
+
+- [ ] **Step 1: Create `.env.example`**
+
+```dotenv
+# Image (set by deploy workflow; latest for local dev)
+IMAGE_TAG=latest
+GITHUB_REPOSITORY=owner/prive-admin
+
+# Postgres
+POSTGRES_DB=prive_admin
+POSTGRES_USER=prive_admin
+POSTGRES_PASSWORD=replace-me-32-chars-min
+
+# App (server.ts schema)
+DATABASE_URL=postgres://prive_admin:replace-me-32-chars-min@postgres:5432/prive_admin
+BETTER_AUTH_SECRET=replace-me-32-chars-min
+BETTER_AUTH_URL=https://prive.salon
+CORS_ORIGIN=https://prive.salon
+NODE_ENV=production
+
+# Cloudflare R2
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+
+# Caddy
+DOMAIN_NAME=prive.salon
+ACME_EMAIL=ops@example.com
+```
+
+- [ ] **Step 2: Verify `.gitignore` already ignores `.env`**
+
+Run: `grep -E '^\.env$' .gitignore`
+Expected: `.env` line present (already is — see existing file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.example
+git commit -m "chore: add .env.example for compose stack"
+```
+
+---
+
+## Task 2: Caddyfile
+
+**Files:**
+- Create: `Caddyfile`
+
+- [ ] **Step 1: Create `Caddyfile`**
+
+```
+{$DOMAIN_NAME} {
+  encode zstd gzip
+  reverse_proxy web:8081
+  tls {$ACME_EMAIL}
+}
+```
+
+- [ ] **Step 2: Validate Caddyfile syntax**
+
+Run:
+```bash
+docker run --rm -v "$PWD/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  -e DOMAIN_NAME=example.com -e ACME_EMAIL=ops@example.com \
+  caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile
+```
+Expected: `Valid configuration`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Caddyfile
+git commit -m "feat(deploy): add Caddyfile reverse proxy + auto-TLS"
+```
+
+---
+
+## Task 3: docker-compose.yml
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: Create `docker-compose.yml`**
+
+```yaml
+name: prive-admin
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - /var/lib/prive-admin/caddy/data:/data
+      - /var/lib/prive-admin/caddy/config:/config
+    environment:
+      DOMAIN_NAME: ${DOMAIN_NAME}
+      ACME_EMAIL: ${ACME_EMAIL}
+    depends_on:
+      - web
+
+  web:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: .env
+    expose:
+      - "8081"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - /var/lib/prive-admin/pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+- [ ] **Step 2: Validate compose syntax with example env**
+
+Run:
+```bash
+cp .env.example .env.tmp
+docker compose --env-file .env.tmp config > /dev/null
+echo "exit=$?"
+rm .env.tmp
+```
+Expected: `exit=0` and no error output.
+
+- [ ] **Step 3: Confirm postgres NOT exposed on host**
+
+Run:
+```bash
+cp .env.example .env.tmp
+docker compose --env-file .env.tmp config | grep -A2 'postgres:' | grep 'published'
+rm .env.tmp
+```
+Expected: no output (postgres has no `ports:` mapping, only `expose:` is internal — actually postgres has neither in our config; reachable only via compose network DNS).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(deploy): add production docker-compose stack"
+```
+
+---
+
+## Task 4: PR build — add `docker-build` job
+
+**Files:**
+- Modify: `.github/workflows/pr-build.yml`
+
+- [ ] **Step 1: Replace `pr-build.yml` with two-job version**
+
+```yaml
+name: PR Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Source Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bunx oxlint
+
+      - name: Check Formatting
+        run: bunx oxfmt --check
+
+      - name: Check Types
+        run: bun run check-types
+
+      - name: Run Build
+        run: bun run build
+
+  docker-build:
+    name: Docker Image Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          file: apps/web/Dockerfile
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-build.yml'))"`
+Expected: no output (valid YAML).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/pr-build.yml
+git commit -m "ci: add parallel docker-build job to PR check"
+```
+
+---
+
+## Task 5: 1Password vault — create item (manual setup, documented)
+
+**This task is a manual prerequisite for the deploy workflow. It does not produce a code change. Document execution status in the PR description.**
+
+- [ ] **Step 1: Confirm vault accessible**
+
+Run on the operator's machine:
+```bash
+op vault list
+```
+Expected: vault `5gq2basjdplfjk5v55wexp2y7i` (or its display name) appears in output. If not, sign into the correct 1Password account.
+
+- [ ] **Step 2: Create item `prive-admin-prod` (Server type) with all fields**
+
+Run:
+```bash
+op item create \
+  --vault 5gq2basjdplfjk5v55wexp2y7i \
+  --category server \
+  --title prive-admin-prod \
+  'postgres.POSTGRES_DB[text]=prive_admin' \
+  'postgres.POSTGRES_USER[text]=prive_admin' \
+  "postgres.POSTGRES_PASSWORD[concealed]=$(openssl rand -hex 32)" \
+  'app.DATABASE_URL[text]=postgres://prive_admin:REPLACE_WITH_PG_PASSWORD@postgres:5432/prive_admin' \
+  "app.BETTER_AUTH_SECRET[concealed]=$(openssl rand -hex 32)" \
+  'app.BETTER_AUTH_URL[text]=https://prive.salon' \
+  'app.CORS_ORIGIN[text]=https://prive.salon' \
+  'r2.R2_ACCOUNT_ID[text]=' \
+  'r2.R2_ACCESS_KEY_ID[concealed]=' \
+  'r2.R2_SECRET_ACCESS_KEY[concealed]=' \
+  'r2.R2_BUCKET_NAME[text]=' \
+  'infra.DOMAIN_NAME[text]=prive.salon' \
+  'infra.ACME_EMAIL[text]=ops@example.com'
+```
+Expected: item created. Note: `op item create` shell-escapes `[concealed]` markers; verify in the 1Password GUI that those fields are concealed.
+
+- [ ] **Step 3: Edit `app.DATABASE_URL` to embed the actual password**
+
+Read the password back, then update the URL:
+```bash
+PG_PASS=$(op read 'op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD')
+op item edit prive-admin-prod \
+  --vault 5gq2basjdplfjk5v55wexp2y7i \
+  "app.DATABASE_URL=postgres://prive_admin:${PG_PASS}@postgres:5432/prive_admin"
+```
+Expected: item updated. Verify in GUI.
+
+- [ ] **Step 4: Fill remaining R2 fields and `infra.ACME_EMAIL`**
+
+Run for each:
+```bash
+op item edit prive-admin-prod --vault 5gq2basjdplfjk5v55wexp2y7i \
+  "r2.R2_ACCOUNT_ID=<value>" \
+  "r2.R2_ACCESS_KEY_ID=<value>" \
+  "r2.R2_SECRET_ACCESS_KEY=<value>" \
+  "r2.R2_BUCKET_NAME=<value>" \
+  "infra.ACME_EMAIL=<email>"
+```
+
+- [ ] **Step 5: Create service account, scoped to this vault, generate token**
+
+In the 1Password web UI:
+1. Settings → Developer → Service accounts → Create.
+2. Name: `prive-admin-github-actions`.
+3. Vaults: read-only access to `5gq2basjdplfjk5v55wexp2y7i`.
+4. Copy generated token.
+
+- [ ] **Step 6: Add token as GitHub Actions secret**
+
+Run:
+```bash
+gh secret set OP_SERVICE_ACCOUNT_TOKEN --body "<paste-token>"
+```
+Expected: `✓ Set Actions secret OP_SERVICE_ACCOUNT_TOKEN for <repo>`.
+
+- [ ] **Step 7: Verify token works from a runner-equivalent shell**
+
+Run locally with the token exported:
+```bash
+OP_SERVICE_ACCOUNT_TOKEN="<token>" \
+  op read 'op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL'
+```
+Expected: prints `https://prive.salon`. If fails: regenerate token, re-check vault scope.
+
+- [ ] **Step 8: Note completion in PR description**
+
+No commit — this is operational. Track completion in the PR body checklist.
+
+---
+
+## Task 6: VPS prerequisites doc
+
+**Files:**
+- Create: `docs/deploy/vps-setup.md`
+
+- [ ] **Step 1: Create `docs/deploy/vps-setup.md`**
+
+```markdown
+# VPS Setup (`prive`)
+
+One-time prerequisites for the production host before the deploy
+workflow can run. The deploy workflow is the only continuous owner of
+the stack; this document is for first-time provisioning and recovery.
+
+## Requirements
+
+- Linux host (Ubuntu 22.04 or later assumed) with public IPv4.
+- SSH user `cicd` with Docker group membership and an authorized SSH
+  key matching the GitHub Actions Tailscale identity.
+- Tailscale installed, logged in, with ACL tag `tag:prod` so the
+  `tag:prod-ci` runners can reach it.
+
+## Install
+
+```bash
+# Docker Engine + compose plugin
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker cicd
+
+# Tailscale
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --advertise-tags=tag:prod
+```
+
+## Host directories
+
+```bash
+sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
+sudo chown -R 999:999 /var/lib/prive-admin/pg
+sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
+sudo -u cicd mkdir -p /home/cicd/prive-admin
+```
+
+The `999:999` ownership matches the `postgres` user inside the
+official `postgres:17-alpine` image.
+
+## Firewall
+
+Open inbound `80/tcp` and `443/tcp` from the public internet for
+Caddy. Restrict `22/tcp` to the Tailscale interface only:
+
+```bash
+sudo ufw default deny incoming
+sudo ufw allow in on tailscale0 to any port 22
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+## DNS
+
+Set an `A` (and optional `AAAA`) record for `prive.salon` pointing at
+the VPS public IP before the first deploy. Caddy will obtain a
+Let's Encrypt cert via the HTTP-01 challenge on port 80 once DNS
+resolves.
+
+## GHCR pulls
+
+The deploy workflow logs `cicd` into `ghcr.io` on every run using the
+ephemeral `GITHUB_TOKEN`. No manual login is required.
+
+## First deploy
+
+Push (or merge) to `main` and watch the `Release` workflow run. The
+`deploy` job ends with a `curl` smoke check against
+`https://prive.salon/`; a passing job means the stack is up.
+
+## Rollback
+
+```bash
+ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+```
+
+GHCR retains older `:<sha>` tags by default. Pick a known-good sha
+from the GitHub Actions history.
+
+## Routine operations
+
+- View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
+- Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
+- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/deploy/vps-setup.md
+git commit -m "docs(deploy): add VPS prerequisites and operations guide"
+```
+
+---
+
+## Task 7: Release workflow — `build-and-push` job
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (full rewrite, but landed in two tasks: this task replaces only the build job; deploy job comes in Task 8)
+
+For this task we ship a release.yml that ONLY builds and pushes the image. Deploy job arrives in Task 8. This staged approach lets us validate the build path with a real master push (or a trial branch via `workflow_dispatch`) before adding deploy complexity.
+
+- [ ] **Step 1: Rewrite `release.yml` (build job only, with workflow_dispatch trigger for trial runs)**
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: apps/web/Dockerfile
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): replace swarm deploy with build-and-push (deploy job follows)"
+```
+
+- [ ] **Step 4: After PR merge — manually trigger and verify GHCR push**
+
+Once this PR lands on `main`:
+```bash
+gh workflow run Release
+gh run watch
+```
+Then check `https://github.com/<owner>/<repo>/pkgs/container/<repo>` for `:latest` and `:<sha>` tags. If absent: re-read action logs.
+
+---
+
+## Task 8: Release workflow — `deploy` job
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Append `deploy` job to `release.yml`**
+
+Insert this `deploy:` job after `build-and-push:` (final file shown):
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: apps/web/Dockerfile
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to prive
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://prive.salon
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
+          POSTGRES_PASSWORD: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD
+          DATABASE_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/DATABASE_URL
+          BETTER_AUTH_SECRET: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_SECRET
+          BETTER_AUTH_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL
+          CORS_ORIGIN: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/CORS_ORIGIN
+          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+          DOMAIN_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/DOMAIN_NAME
+          ACME_EMAIL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/ACME_EMAIL
+
+      - name: Render .env
+        run: |
+          umask 077
+          cat > .env <<EOF
+          IMAGE_TAG=${GITHUB_SHA}
+          GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+          NODE_ENV=production
+          POSTGRES_DB=${POSTGRES_DB}
+          POSTGRES_USER=${POSTGRES_USER}
+          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+          DATABASE_URL=${DATABASE_URL}
+          BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+          BETTER_AUTH_URL=${BETTER_AUTH_URL}
+          CORS_ORIGIN=${CORS_ORIGIN}
+          R2_ACCOUNT_ID=${R2_ACCOUNT_ID}
+          R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}
+          R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}
+          R2_BUCKET_NAME=${R2_BUCKET_NAME}
+          DOMAIN_NAME=${DOMAIN_NAME}
+          ACME_EMAIL=${ACME_EMAIL}
+          EOF
+          chmod 600 .env
+
+      - name: Tailscale up
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:prod-ci
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 0700 ~/.ssh
+          ssh-keyscan -H prive >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Verify SSH connection
+        run: ssh -o ConnectTimeout=30 cicd@prive 'echo ok'
+
+      - name: Stage files on VPS
+        run: |
+          ssh cicd@prive 'mkdir -p ~/prive-admin'
+          scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/
+
+      - name: Deploy stack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+        run: |
+          ssh cicd@prive \
+            "cd ~/prive-admin && \
+             echo '${GH_TOKEN}' | docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
+             docker compose pull && \
+             docker compose up -d --remove-orphans && \
+             docker image prune -f"
+
+      - name: Smoke check
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -fsS --max-time 10 https://prive.salon/ > /dev/null; then
+              echo "smoke check ok"
+              exit 0
+            fi
+            echo "attempt $i failed, retrying in 10s"
+            sleep 10
+          done
+          echo "smoke check failed after 5 attempts"
+          exit 1
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: no output.
+
+- [ ] **Step 3: Lint with actionlint (if available)**
+
+Run: `actionlint .github/workflows/release.yml || echo "actionlint not installed; skipping"`
+Expected: no errors. If actionlint is not installed, skip — full validation happens on the runner.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): add deploy job — 1Password secrets, Tailscale SSH, compose up"
+```
+
+---
+
+## Task 9: Restore + adapt backup script
+
+**Files:**
+- Create: `scripts/backup_postgres.sh` (restored from history, adapted for compose)
+
+The current backup workflow (`.github/workflows/backup-postgres.yml`) references `scripts/backup_postgres.sh`, which was deleted during the tanstack rewrite. Restore it, adapted to run `pg_dump` via `docker compose exec` so it works against the new compose-managed Postgres without exposing port 5432 on the host.
+
+- [ ] **Step 1: Create `scripts/backup_postgres.sh`**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_DIR="${HOME}/db_backups"
+COMPOSE_DIR="${COMPOSE_DIR:-${HOME}/prive-admin}"
+
+mkdir -p "${BACKUP_DIR}"
+
+# Prune backups older than 14 days
+find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
+
+OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
+
+# Run pg_dump inside the postgres container — avoids exposing 5432 on the host.
+# PG_USER / PG_DATABASE come from the workflow env. Password is read from the
+# container's own POSTGRES_PASSWORD via `printenv` to avoid leaking into the
+# host process table.
+docker compose --project-directory "${COMPOSE_DIR}" exec -T postgres \
+  bash -c 'PGPASSWORD="$(printenv POSTGRES_PASSWORD)" pg_dump \
+            -U "'"${PG_USER}"'" --clean --create "'"${PG_DATABASE}"'"' \
+  > "${OUT}"
+
+echo "Backup written: ${OUT}"
+```
+
+- [ ] **Step 2: Make executable and lint**
+
+Run:
+```bash
+chmod +x scripts/backup_postgres.sh
+shellcheck scripts/backup_postgres.sh || echo "shellcheck not installed; skipping"
+```
+Expected: no errors. If shellcheck not available, skip.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/backup_postgres.sh
+git commit -m "feat(scripts): restore backup_postgres.sh, adapt for compose exec"
+```
+
+---
+
+## Task 10: Migrate backup workflow to 1Password
+
+**Files:**
+- Modify: `.github/workflows/backup-postgres.yml`
+
+- [ ] **Step 1: Rewrite `backup-postgres.yml` to source secrets from 1Password**
+
+```yaml
+name: Daily Postgres Backup
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  backup:
+    environment:
+      name: production
+      url: https://prive.salon
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
+          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+
+      - name: Tailscale up
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:prod-ci
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 0700 ~/.ssh
+          ssh-keyscan -H prive >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Copy backup script to VPS
+        run: scp scripts/backup_postgres.sh cicd@prive:~/backup_postgres.sh
+
+      - name: Run backup script on VPS
+        run: |
+          ssh cicd@prive "
+            chmod +x ~/backup_postgres.sh && \
+            PG_USER='${POSTGRES_USER}' \
+            PG_DATABASE='${POSTGRES_DB}' \
+            ~/backup_postgres.sh"
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y s3cmd
+
+      - name: Upload backup to Cloudflare R2
+        run: |
+          set -e
+          FILE_NAME=$(ssh cicd@prive 'ls -t ~/db_backups/ | head -n1')
+          ssh cicd@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
+          cat > ~/.s3cfg <<EOF
+          [default]
+          access_key = ${R2_ACCESS_KEY_ID}
+          secret_key = ${R2_SECRET_ACCESS_KEY}
+          host_base = ${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+          host_bucket = %(bucket)s.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+          bucket_location = auto
+          use_https = True
+          EOF
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
+          s3cmd info "s3://${R2_BUCKET_NAME}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}"
+```
+
+Notes:
+- The script reads `POSTGRES_PASSWORD` from inside the container, so the workflow does not need to know it.
+- The 1Password vault stores the bucket name as `R2_BUCKET_NAME` (matches the env package). The script uses that name directly — no rename of the old `R2_BUCKET` variable needed.
+- The `POSTGRES_DB` field is mapped to `PG_DATABASE` when invoking the script, preserving the script's existing parameter name.
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/backup-postgres.yml'))"`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/backup-postgres.yml
+git commit -m "ci(backup): source secrets from 1Password, run pg_dump via compose exec"
+```
+
+- [ ] **Step 4: After PR merge — verify a backup run**
+
+```bash
+gh workflow run "Daily Postgres Backup"
+gh run watch
+```
+Expected: workflow green; new object in the R2 bucket; latest dump on the VPS at `~/db_backups/`. If fails: read the failing step's logs, fix forward.
+
+- [ ] **Step 5: Remove now-unused GH Actions secrets**
+
+Once a backup run succeeds:
+```bash
+gh secret delete POSTGRES_USER
+gh secret delete POSTGRES_PASSWORD
+gh secret delete POSTGRES_DATABASE
+gh secret delete R2_ACCESS_KEY_ID
+gh secret delete R2_SECRET_ACCESS_KEY
+gh secret delete R2_BUCKET
+gh secret delete R2_ACCOUNT_ID
+gh secret delete BETTER_AUTH_SECRET
+```
+Keep: `OP_SERVICE_ACCOUNT_TOKEN`, `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`.
+
+---
+
+## Task 11: README pointer
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Append a Deployment section to `README.md`**
+
+Add after the existing "Available Scripts" section:
+
+```markdown
+## Deployment
+
+The production stack runs on VPS `prive` via Docker Compose. The
+authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.md).
+
+- Pushes to `main` build and publish `ghcr.io/<repo>:{latest,sha}` and
+  deploy to the VPS automatically (`.github/workflows/release.yml`).
+- All runtime secrets live in the 1Password vault
+  `5gq2basjdplfjk5v55wexp2y7i`, item `prive-admin-prod`. The workflow
+  pulls them at deploy time using a service-account token
+  (`OP_SERVICE_ACCOUNT_TOKEN`).
+- Rollback to a previous image:
+
+  ```bash
+  ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+  ```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document deployment + rollback"
+```
+
+---
+
+## Task 12: Open PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feat/deploy-pipeline
+gh pr create --base main --title "Compose-based deploy pipeline with 1Password secrets" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces Docker Swarm deploy with a Compose stack (`caddy`, `web`, `postgres`) on the VPS.
+- Adds Caddy reverse proxy with automatic Let's Encrypt TLS.
+- Builds and pushes `ghcr.io/<repo>:{latest,sha}` on every push to `main`.
+- Sources all runtime secrets from 1Password vault `5gq2basjdplfjk5v55wexp2y7i` via a service-account token.
+- PR check now also runs a no-push container build to catch Dockerfile breaks.
+- Migrates the daily Postgres backup workflow to read secrets from the same vault and `pg_dump` via `docker compose exec`.
+
+## Operational checklist
+
+- [ ] 1Password vault item `prive-admin-prod` created and filled (Task 5).
+- [ ] `OP_SERVICE_ACCOUNT_TOKEN` set as a GitHub Actions secret.
+- [ ] VPS host directories created per `docs/deploy/vps-setup.md` (Task 6).
+- [ ] DNS for `prive.salon` points at the VPS public IP.
+- [ ] First master deploy succeeded; Caddy issued a TLS certificate.
+- [ ] Backup workflow run succeeded against the new stack.
+- [ ] Stale GH Actions secrets removed (Task 10, Step 5).
+
+## Test plan
+
+- [ ] PR check (`pr-build.yml`) — both `Source Build` and `Docker Image Build` jobs green.
+- [ ] After merge: `Release` workflow `build-and-push` job pushes both `:latest` and `:<sha>` tags to GHCR.
+- [ ] After merge: `Release` workflow `deploy` job ends with a passing `curl` smoke check against `https://prive.salon/`.
+- [ ] After merge: `gh workflow run "Daily Postgres Backup"` produces a dump in R2 and on the VPS.
+- [ ] Manual rollback by re-running `docker compose up -d web` with `IMAGE_TAG=<previous-sha>` succeeds.
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify PR checks**
+
+Run: `gh pr checks --watch`
+Expected: both `Source Build` and `Docker Image Build` green. If red, read the run logs and fix forward in the same branch.
+
+---
+
+## Self-review notes
+
+- Spec coverage: every spec section maps to a task — Architecture/Files → T1–T3, T6; Vault layout → T5; release.yml → T7+T8; pr-build.yml → T4; backup-postgres.yml → T9+T10; VPS prerequisites → T6; failure modes/rollback → T6 (doc), T11 (README), T12 (PR test plan).
+- Placeholder scan: file paths, code, and commands are concrete throughout. Service-account vault scope and field names are exact; only operator inputs (`<value>`, `<email>`, `<paste-token>`) are placeholders, by design.
+- Type/name consistency: `IMAGE_TAG`, `GITHUB_REPOSITORY`, `POSTGRES_DB`, `DOMAIN_NAME`, `ACME_EMAIL`, and the `op://` paths are spelled identically across `.env.example`, `docker-compose.yml`, `release.yml`, and `backup-postgres.yml`. The `R2_BUCKET_NAME` field name matches the existing env schema in `packages/env/src/server.ts` (the old workflow's `R2_BUCKET` is dropped).

--- a/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
@@ -293,14 +293,14 @@ Run on the operator's machine:
 ```bash
 op vault list
 ```
-Expected: vault `5gq2basjdplfjk5v55wexp2y7i` (or its display name) appears in output. If not, sign into the correct 1Password account.
+Expected: vault `prive-admin` (UUID `5gq2basjdplfjk5v55wexp2y7i`) appears in output. If not, sign into the correct 1Password account.
 
 - [ ] **Step 2: Create item `prive-admin-prod` (Server type) with all fields**
 
 Run:
 ```bash
 op item create \
-  --vault 5gq2basjdplfjk5v55wexp2y7i \
+  --vault prive-admin \
   --category server \
   --title prive-admin-prod \
   'postgres.POSTGRES_DB[text]=prive_admin' \
@@ -323,9 +323,9 @@ Expected: item created. Note: `op item create` shell-escapes `[concealed]` marke
 
 Read the password back, then update the URL:
 ```bash
-PG_PASS=$(op read 'op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD')
+PG_PASS=$(op read 'op://prive-admin/prive-admin-prod/postgres/POSTGRES_PASSWORD')
 op item edit prive-admin-prod \
-  --vault 5gq2basjdplfjk5v55wexp2y7i \
+  --vault prive-admin \
   "app.DATABASE_URL=postgres://prive_admin:${PG_PASS}@postgres:5432/prive_admin"
 ```
 Expected: item updated. Verify in GUI.
@@ -334,7 +334,7 @@ Expected: item updated. Verify in GUI.
 
 Run for each:
 ```bash
-op item edit prive-admin-prod --vault 5gq2basjdplfjk5v55wexp2y7i \
+op item edit prive-admin-prod --vault prive-admin \
   "r2.R2_ACCOUNT_ID=<value>" \
   "r2.R2_ACCESS_KEY_ID=<value>" \
   "r2.R2_SECRET_ACCESS_KEY=<value>" \
@@ -348,10 +348,10 @@ CLI path (preferred — `--raw` is required, otherwise stdout is descriptive pro
 
 ```bash
 SA_TOKEN="$(op service-account create prive-admin-github-actions \
-  --vault '5gq2basjdplfjk5v55wexp2y7i:read_items' --raw)"
+  --vault 'prive-admin:read_items' --raw)"
 ```
 
-Web UI fallback: 1Password admin → Integrations → Directory → Service Accounts → Create. Read-only access to vault `5gq2basjdplfjk5v55wexp2y7i`. Copy the token shown once.
+Web UI fallback: 1Password admin → Integrations → Directory → Service Accounts → Create. Read-only access to vault `prive-admin`. Copy the token shown once.
 
 - [ ] **Step 6: Add token as GitHub Actions secret**
 
@@ -367,7 +367,7 @@ Expected: `✓ Set Actions secret OP_SERVICE_ACCOUNT_TOKEN for <repo>`.
 Run locally with the token exported:
 ```bash
 OP_SERVICE_ACCOUNT_TOKEN="<token>" \
-  op read 'op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL'
+  op read 'op://prive-admin/prive-admin-prod/app/BETTER_AUTH_URL'
 ```
 Expected: prints `https://prive.salon`. If fails: regenerate token, re-check vault scope.
 
@@ -674,19 +674,19 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
-          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
-          POSTGRES_PASSWORD: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_PASSWORD
-          DATABASE_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/DATABASE_URL
-          BETTER_AUTH_SECRET: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_SECRET
-          BETTER_AUTH_URL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/BETTER_AUTH_URL
-          CORS_ORIGIN: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/app/CORS_ORIGIN
-          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
-          DOMAIN_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/DOMAIN_NAME
-          ACME_EMAIL: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/infra/ACME_EMAIL
+          POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
+          POSTGRES_PASSWORD: op://prive-admin/prive-admin-prod/postgres/POSTGRES_PASSWORD
+          DATABASE_URL: op://prive-admin/prive-admin-prod/app/DATABASE_URL
+          BETTER_AUTH_SECRET: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_SECRET
+          BETTER_AUTH_URL: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_URL
+          CORS_ORIGIN: op://prive-admin/prive-admin-prod/app/CORS_ORIGIN
+          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          DOMAIN_NAME: op://prive-admin/prive-admin-prod/infra/DOMAIN_NAME
+          ACME_EMAIL: op://prive-admin/prive-admin-prod/infra/ACME_EMAIL
 
       - name: Render .env
         run: |
@@ -866,12 +866,12 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          POSTGRES_DB: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_DB
-          POSTGRES_USER: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/postgres/POSTGRES_USER
-          R2_ACCOUNT_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/r2/R2_BUCKET_NAME
+          POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
+          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
+          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
+          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
+          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
 
       - name: Tailscale up
         uses: tailscale/github-action@v3
@@ -982,7 +982,7 @@ authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.m
 - Pushes to `main` build and publish `ghcr.io/<repo>:{latest,sha}` and
   deploy to the VPS automatically (`.github/workflows/release.yml`).
 - All runtime secrets live in the 1Password vault
-  `5gq2basjdplfjk5v55wexp2y7i`, item `prive-admin-prod`. The workflow
+  `prive-admin`, item `prive-admin-prod`. The workflow
   pulls them at deploy time using a service-account token
   (`OP_SERVICE_ACCOUNT_TOKEN`).
 - Rollback to a previous image:
@@ -1013,7 +1013,7 @@ gh pr create --base main --title "Compose-based deploy pipeline with 1Password s
 - Replaces Docker Swarm deploy with a Compose stack (`caddy`, `web`, `postgres`) on the VPS.
 - Adds Caddy reverse proxy with automatic Let's Encrypt TLS.
 - Builds and pushes `ghcr.io/<repo>:{latest,sha}` on every push to `main`.
-- Sources all runtime secrets from 1Password vault `5gq2basjdplfjk5v55wexp2y7i` via a service-account token.
+- Sources all runtime secrets from 1Password vault `prive-admin` via a service-account token.
 - PR check now also runs a no-push container build to catch Dockerfile breaks.
 - Migrates the daily Postgres backup workflow to read secrets from the same vault and `pg_dump` via `docker compose exec`.
 

--- a/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stand up a Docker Compose deployment to VPS `prive` with Caddy auto-TLS, GHCR-built images on master push, and 1Password-sourced runtime secrets, replacing the existing Docker Swarm flow.
 
-**Architecture:** GitHub Actions runner builds and pushes `ghcr.io/<repo>:{latest,sha}` on master, then over Tailscale SSH copies `docker-compose.yml`, `Caddyfile`, and a freshly-rendered `.env` (from 1Password) to `cicd@prive:~/prive-admin/`, then runs `docker compose pull && up -d`. Caddy fronts the web container on 80/443 with auto-TLS. Postgres runs in the same compose stack with a host bind-mount.
+**Architecture:** GitHub Actions runner builds and pushes `ghcr.io/<repo>:{latest,sha}` on master, then over Tailscale SSH copies `docker-compose.yml`, `Caddyfile`, and a freshly-rendered `.env` (from 1Password) to `root@prive:~/prive-admin/`, then runs `docker compose pull && up -d`. Caddy fronts the web container on 80/443 with auto-TLS. Postgres runs in the same compose stack with a host bind-mount.
 
 **Tech Stack:** Docker Compose, Caddy 2, Postgres 17, GitHub Actions, 1Password service account + `load-secrets-action@v2`, Tailscale OAuth, GHCR.
 
@@ -153,7 +153,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -394,33 +394,19 @@ the stack; this document is for first-time provisioning and recovery.
 ## Requirements
 
 - Linux host (Ubuntu 22.04 or later assumed) with public IPv4.
-- SSH user `cicd` with Docker group membership and an authorized SSH
-  key matching the GitHub Actions Tailscale identity.
+- SSH access as `root` with the GitHub Actions Tailscale identity's
+  public key in `/root/.ssh/authorized_keys`.
 - Tailscale installed, logged in, with ACL tag `tag:prod` so the
   `tag:prod-ci` runners can reach it.
 
-## Bootstrap the cicd user
-
-The deploy and backup workflows SSH into the host as `cicd`. On a
-fresh VPS this user does not yet exist. Create it before installing
-Docker:
+## SSH key
 
 ```bash
-sudo adduser --disabled-password --gecos '' cicd
-sudo install -d -o cicd -g cicd -m 0700 /home/cicd/.ssh
-sudo install -o cicd -g cicd -m 0600 /dev/stdin /home/cicd/.ssh/authorized_keys <<'KEY'
+sudo install -d -m 0700 /root/.ssh
+sudo install -m 0600 /dev/stdin /root/.ssh/authorized_keys <<'KEY'
 <paste the public key matching the GitHub Actions Tailscale identity>
 KEY
 ```
-
-After Docker is installed in the next section, add `cicd` to the
-`docker` group:
-
-```bash
-sudo usermod -aG docker cicd
-```
-
-The group change only applies to new shell sessions for `cicd`.
 
 ## Install
 
@@ -445,18 +431,17 @@ must:
 - Allow `tag:prod-ci` to reach `tag:prod` on TCP `22`.
 - Have MagicDNS enabled in the tailnet, and the VPS machine renamed
   to `prive` (admin console → Machines → rename), so that
-  `ssh cicd@prive` resolves.
+  `ssh root@prive` resolves.
 
 ## Host directories
 
 ```bash
 sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
 sudo chown -R 70:70 /var/lib/prive-admin/pg
-sudo chown -R cicd:cicd /var/lib/prive-admin/caddy
-sudo -u cicd mkdir -p /home/cicd/prive-admin
+sudo mkdir -p /root/prive-admin
 ```
 
-The `70:70` ownership matches the `postgres` user inside the official `postgres:17-alpine` image.
+The `70:70` ownership matches the `postgres` user inside the official `postgres:18-alpine` image.
 
 ## Firewall
 
@@ -480,7 +465,7 @@ resolves.
 
 ## GHCR pulls
 
-The deploy workflow logs `cicd` into `ghcr.io` on every run using the
+The deploy workflow logs into `ghcr.io` on every run using the
 ephemeral `GITHUB_TOKEN`. No manual login is required.
 
 ## First deploy
@@ -492,7 +477,7 @@ Push (or merge) to `main` and watch the `Release` workflow run. The
 ## Rollback
 
 ```bash
-ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+ssh root@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
 ```
 
 GHCR retains older `:<sha>` tags by default. Pick a known-good sha
@@ -500,9 +485,9 @@ from the GitHub Actions history.
 
 ## Routine operations
 
-- View logs: `ssh cicd@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
-- Restart web: `ssh cicd@prive 'cd ~/prive-admin && docker compose restart web'`
-- Database shell: `ssh cicd@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`
+- View logs: `ssh root@prive 'cd ~/prive-admin && docker compose logs -f <service>'`
+- Restart web: `ssh root@prive 'cd ~/prive-admin && docker compose restart web'`
+- Database shell: `ssh root@prive 'cd ~/prive-admin && docker compose exec postgres sh -c '\''psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'\'''`
 ```
 
 - [ ] **Step 2: Commit**
@@ -681,10 +666,10 @@ jobs:
           BETTER_AUTH_SECRET: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_SECRET
           BETTER_AUTH_URL: op://prive-admin/prive-admin-prod/app/BETTER_AUTH_URL
           CORS_ORIGIN: op://prive-admin/prive-admin-prod/app/CORS_ORIGIN
-          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          R2_ACCOUNT_ID: op://prive-admin/Cloudflare R2/account-id
+          R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
+          R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
+          R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
           DOMAIN_NAME: op://prive-admin/prive-admin-prod/infra/DOMAIN_NAME
           ACME_EMAIL: op://prive-admin/prive-admin-prod/infra/ACME_EMAIL
 
@@ -726,19 +711,19 @@ jobs:
           chmod 644 ~/.ssh/known_hosts
 
       - name: Verify SSH connection
-        run: ssh -o ConnectTimeout=30 cicd@prive 'echo ok'
+        run: ssh -o ConnectTimeout=30 root@prive 'echo ok'
 
       - name: Stage files on VPS
         run: |
-          ssh cicd@prive 'mkdir -p ~/prive-admin'
-          scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/
+          ssh root@prive 'mkdir -p ~/prive-admin'
+          scp docker-compose.yml Caddyfile .env root@prive:~/prive-admin/
 
       - name: Deploy stack
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ACTOR: ${{ github.actor }}
         run: |
-          ssh cicd@prive \
+          ssh root@prive \
             "cd ~/prive-admin && \
              echo '${GH_TOKEN}' | docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
              docker compose pull && \
@@ -868,10 +853,10 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
           POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
-          R2_ACCOUNT_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCOUNT_ID
-          R2_ACCESS_KEY_ID: op://prive-admin/prive-admin-prod/r2/R2_ACCESS_KEY_ID
-          R2_SECRET_ACCESS_KEY: op://prive-admin/prive-admin-prod/r2/R2_SECRET_ACCESS_KEY
-          R2_BUCKET_NAME: op://prive-admin/prive-admin-prod/r2/R2_BUCKET_NAME
+          R2_ACCOUNT_ID: op://prive-admin/Cloudflare R2/account-id
+          R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
+          R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
+          R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
 
       - name: Tailscale up
         uses: tailscale/github-action@v3
@@ -888,11 +873,11 @@ jobs:
           chmod 644 ~/.ssh/known_hosts
 
       - name: Copy backup script to VPS
-        run: scp scripts/backup_postgres.sh cicd@prive:~/backup_postgres.sh
+        run: scp scripts/backup_postgres.sh root@prive:~/backup_postgres.sh
 
       - name: Run backup script on VPS
         run: |
-          ssh cicd@prive "
+          ssh root@prive "
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \
             PG_DATABASE='${POSTGRES_DB}' \
@@ -906,8 +891,8 @@ jobs:
       - name: Upload backup to Cloudflare R2
         run: |
           set -e
-          FILE_NAME=$(ssh cicd@prive 'ls -t ~/db_backups/ | head -n1')
-          ssh cicd@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
+          FILE_NAME=$(ssh root@prive 'ls -t ~/db_backups/ | head -n1')
+          ssh root@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
           cat > ~/.s3cfg <<EOF
           [default]
           access_key = ${R2_ACCESS_KEY_ID}
@@ -988,7 +973,7 @@ authoritative deploy doc is [`docs/deploy/vps-setup.md`](docs/deploy/vps-setup.m
 - Rollback to a previous image:
 
   ```bash
-  ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
+  ssh root@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'
   ```
 ```
 

--- a/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-04-26-deploy-pipeline.md
@@ -344,17 +344,21 @@ op item edit prive-admin-prod --vault 5gq2basjdplfjk5v55wexp2y7i \
 
 - [ ] **Step 5: Create service account, scoped to this vault, generate token**
 
-In the 1Password web UI:
-1. Settings → Developer → Service accounts → Create.
-2. Name: `prive-admin-github-actions`.
-3. Vaults: read-only access to `5gq2basjdplfjk5v55wexp2y7i`.
-4. Copy generated token.
+CLI path (preferred — `--raw` is required, otherwise stdout is descriptive prose and the token is unrecoverable; the CLI also allows duplicate-name creation, so a missing `--raw` will create an orphan account that is hard to delete):
+
+```bash
+SA_TOKEN="$(op service-account create prive-admin-github-actions \
+  --vault '5gq2basjdplfjk5v55wexp2y7i:read_items' --raw)"
+```
+
+Web UI fallback: 1Password admin → Integrations → Directory → Service Accounts → Create. Read-only access to vault `5gq2basjdplfjk5v55wexp2y7i`. Copy the token shown once.
 
 - [ ] **Step 6: Add token as GitHub Actions secret**
 
-Run:
+Have the operator run (so the token never enters logs or chat):
 ```bash
-gh secret set OP_SERVICE_ACCOUNT_TOKEN --body "<paste-token>"
+gh secret set OP_SERVICE_ACCOUNT_TOKEN
+# paste token at prompt
 ```
 Expected: `✓ Set Actions secret OP_SERVICE_ACCOUNT_TOKEN for <repo>`.
 

--- a/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
@@ -24,7 +24,7 @@ GitHub Actions runner
   └── master → checkout → docker buildx build+push → ghcr.io/<repo>:latest, :<sha>
                        → 1Password CLI: read secrets → render .env
                        → Tailscale up (tag:prod-ci)
-                       → scp docker-compose.yml + Caddyfile + .env → cicd@prive:~/prive-admin/
+                       → scp docker-compose.yml + Caddyfile + .env → root@prive:~/prive-admin/
                        → ssh: docker compose pull && docker compose up -d --remove-orphans
                        → curl smoke check
 
@@ -92,7 +92,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -174,9 +174,9 @@ Two sequential jobs.
 3. Render `.env` from masked env vars plus `IMAGE_TAG=${{ github.sha }}` and `GITHUB_REPOSITORY=${{ github.repository }}`. `chmod 600 .env`.
 4. `tailscale/github-action@v3` (`tags: tag:prod-ci`).
 5. `ssh-keyscan -H prive >> ~/.ssh/known_hosts`.
-6. `ssh cicd@prive "mkdir -p ~/prive-admin"`.
-7. `scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/`.
-8. `ssh cicd@prive` runs:
+6. `ssh root@prive "mkdir -p ~/prive-admin"`.
+7. `scp docker-compose.yml Caddyfile .env root@prive:~/prive-admin/`.
+8. `ssh root@prive` runs:
    ```
    cd ~/prive-admin && \
    echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin && \
@@ -213,14 +213,14 @@ Variable-name reconciliation: the existing backup script reads `PG_DATABASE` (se
 
 These are not automated by this design — they are documented as setup prerequisites:
 
-1. User `cicd` with docker group membership and SSH key (already provisioned).
+1. SSH access as `root` with the GitHub Actions Tailscale identity's public key in `/root/.ssh/authorized_keys`.
 2. Tailscale installed and tagged `tag:prod` (already provisioned).
 3. Docker Engine + `docker compose` plugin installed.
 4. Host directories with correct ownership:
    ```
    sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
    sudo chown -R 70:70 /var/lib/prive-admin/pg
-   sudo chown -R cicd:cicd /var/lib/prive-admin/caddy /home/cicd/prive-admin
+   sudo mkdir -p /root/prive-admin
    ```
 5. Firewall: 80/443 open from public internet; 22 reachable only via Tailscale.
 6. DNS: `prive.salon` A/AAAA record → VPS public IP.
@@ -239,7 +239,7 @@ These are not automated by this design — they are documented as setup prerequi
 | Caddy TLS issuance fails | Smoke check fails | Read `docker compose logs caddy`, verify DNS + 80/443 reachability |
 | Postgres data corruption | Manual report | Restore from latest R2 backup |
 
-**Rollback:** `ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'`. GHCR retains old image tags by default. Documented in README.
+**Rollback:** `ssh root@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'`. GHCR retains old image tags by default. Documented in README.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
@@ -219,7 +219,7 @@ These are not automated by this design — they are documented as setup prerequi
 4. Host directories with correct ownership:
    ```
    sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
-   sudo chown -R 999:999 /var/lib/prive-admin/pg
+   sudo chown -R 70:70 /var/lib/prive-admin/pg
    sudo chown -R cicd:cicd /var/lib/prive-admin/caddy /home/cicd/prive-admin
    ```
 5. Firewall: 80/443 open from public internet; 22 reachable only via Tailscale.

--- a/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
@@ -34,7 +34,7 @@ VPS `prive` (Tailscale-attached, public 80/443)
         Caddyfile               (in repo, scp'd each deploy)
         .env                    (rendered each deploy, gitignored, chmod 600)
   └── /var/lib/prive-admin/
-        pg/                     (postgres data, bind-mount, uid 999)
+        pg/                     (postgres data, bind-mount, uid 70)
         caddy/data/             (TLS certs, ACME state)
         caddy/config/           (Caddy autosave)
 

--- a/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
@@ -123,7 +123,7 @@ Caddy uses HTTP-01 challenge on port 80 to issue a certificate for `{$DOMAIN_NAM
 
 ## 1Password Vault Layout
 
-Vault: `5gq2basjdplfjk5v55wexp2y7i`
+Vault: `prive-admin` (UUID `5gq2basjdplfjk5v55wexp2y7i`)
 Item: `prive-admin-prod` (type: Server)
 
 | Section | Field | Notes |
@@ -142,7 +142,7 @@ Item: `prive-admin-prod` (type: Server)
 | infra | `DOMAIN_NAME` | `prive.salon` |
 | infra | `ACME_EMAIL` | Let's Encrypt contact |
 
-A new 1Password service account scoped read-only to this vault provides the `OP_SERVICE_ACCOUNT_TOKEN` GitHub Actions secret. References use the vault UUID directly: `op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/<section>/<field>`. Using the UUID avoids breakage if the vault is renamed.
+A new 1Password service account scoped read-only to this vault provides the `OP_SERVICE_ACCOUNT_TOKEN` GitHub Actions secret. References use the vault display name: `op://prive-admin/prive-admin-prod/<section>/<field>`. The vault UUID `5gq2basjdplfjk5v55wexp2y7i` is the stable alternative if the vault is ever renamed.
 
 GitHub repository secrets that remain outside 1Password (chicken-and-egg or auto-provided):
 

--- a/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md
@@ -1,0 +1,255 @@
+# Deploy Pipeline Design
+
+**Date:** 2026-04-26
+**Status:** Approved (design phase)
+**Owner:** Martin
+
+## Goal
+
+Replace the current Docker Swarm deployment flow with a Docker Compose stack on the production VPS `prive`, fronted by Caddy for automatic TLS. Continuous integration validates pull requests with both source and container builds. Pushes to `main` build and publish a multi-tag image to GHCR, then deploy to the VPS over Tailscale SSH. All runtime secrets and config originate from a single 1Password vault item, fetched at deploy time by a service-account token.
+
+## Non-Goals
+
+- Zero-downtime/blue-green deployment (single web replica is acceptable).
+- Automated rollback (manual rollback via pinned `IMAGE_TAG` is sufficient).
+- Multi-architecture images (amd64 only).
+- External managed Postgres (run in compose with bind-mounted host volume).
+- Reverse-proxy clustering or multiple ingress hosts.
+
+## Architecture
+
+```
+GitHub Actions runner
+  ├── PR  → checkout → install → lint+fmt+types+build → docker build (no push)
+  └── master → checkout → docker buildx build+push → ghcr.io/<repo>:latest, :<sha>
+                       → 1Password CLI: read secrets → render .env
+                       → Tailscale up (tag:prod-ci)
+                       → scp docker-compose.yml + Caddyfile + .env → cicd@prive:~/prive-admin/
+                       → ssh: docker compose pull && docker compose up -d --remove-orphans
+                       → curl smoke check
+
+VPS `prive` (Tailscale-attached, public 80/443)
+  └── ~/prive-admin/
+        docker-compose.yml      (in repo, scp'd each deploy)
+        Caddyfile               (in repo, scp'd each deploy)
+        .env                    (rendered each deploy, gitignored, chmod 600)
+  └── /var/lib/prive-admin/
+        pg/                     (postgres data, bind-mount, uid 999)
+        caddy/data/             (TLS certs, ACME state)
+        caddy/config/           (Caddy autosave)
+
+  containers (compose project `prive-admin`):
+    caddy    → :80, :443       → reverse proxy → web:8081 (auto-TLS)
+    web      → ghcr.io/<repo>:<sha>  (CMD = migrate then serve)
+    postgres → internal only, healthcheck pg_isready
+```
+
+## Files
+
+| Path | Action | Purpose |
+|---|---|---|
+| `docker-compose.yml` | NEW (root) | Production compose stack |
+| `Caddyfile` | NEW (root) | Reverse proxy + auto-TLS config |
+| `.env.example` | NEW (root) | Documents required env vars for local stack `up` |
+| `.gitignore` | EDIT | Add `.env` |
+| `.github/workflows/pr-build.yml` | EDIT | Add parallel docker-build job |
+| `.github/workflows/release.yml` | REWRITE | Compose deploy in place of swarm stack deploy |
+| `.github/workflows/backup-postgres.yml` | EDIT | Read postgres creds from 1Password instead of GH secrets |
+| `docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md` | NEW | This document |
+
+The existing `apps/web/Dockerfile` is unchanged. It already runs migrations (`bun run ./migrate.js`) before starting the server, which is sufficient for the single-replica deployment.
+
+## docker-compose.yml
+
+```yaml
+name: prive-admin
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - /var/lib/prive-admin/caddy/data:/data
+      - /var/lib/prive-admin/caddy/config:/config
+    environment:
+      DOMAIN_NAME: ${DOMAIN_NAME}
+      ACME_EMAIL: ${ACME_EMAIL}
+    depends_on:
+      - web
+
+  web:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: .env
+    expose:
+      - "8081"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - /var/lib/prive-admin/pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+`GITHUB_REPOSITORY` and `IMAGE_TAG` are written into `.env` by the deploy workflow. Postgres is reachable only on the compose network; the web container uses the `DATABASE_URL` value from `.env` to address it as `postgres:5432`.
+
+## Caddyfile
+
+```
+{$DOMAIN_NAME} {
+  encode zstd gzip
+  reverse_proxy web:8081
+  tls {$ACME_EMAIL}
+}
+```
+
+Caddy uses HTTP-01 challenge on port 80 to issue a certificate for `{$DOMAIN_NAME}`. State persists in the bind-mounted `/var/lib/prive-admin/caddy/data` directory across deploys.
+
+## 1Password Vault Layout
+
+Vault: `5gq2basjdplfjk5v55wexp2y7i`
+Item: `prive-admin-prod` (type: Server)
+
+| Section | Field | Notes |
+|---|---|---|
+| postgres | `POSTGRES_DB` | e.g. `prive_admin` |
+| postgres | `POSTGRES_USER` | e.g. `prive_admin` |
+| postgres | `POSTGRES_PASSWORD` | random, ≥32 chars |
+| app | `DATABASE_URL` | `postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}` |
+| app | `BETTER_AUTH_SECRET` | random, ≥32 chars |
+| app | `BETTER_AUTH_URL` | `https://prive.salon` |
+| app | `CORS_ORIGIN` | `https://prive.salon` |
+| r2 | `R2_ACCOUNT_ID` | from Cloudflare |
+| r2 | `R2_ACCESS_KEY_ID` | |
+| r2 | `R2_SECRET_ACCESS_KEY` | |
+| r2 | `R2_BUCKET_NAME` | |
+| infra | `DOMAIN_NAME` | `prive.salon` |
+| infra | `ACME_EMAIL` | Let's Encrypt contact |
+
+A new 1Password service account scoped read-only to this vault provides the `OP_SERVICE_ACCOUNT_TOKEN` GitHub Actions secret. References use the vault UUID directly: `op://5gq2basjdplfjk5v55wexp2y7i/prive-admin-prod/<section>/<field>`. Using the UUID avoids breakage if the vault is renamed.
+
+GitHub repository secrets that remain outside 1Password (chicken-and-egg or auto-provided):
+
+- `OP_SERVICE_ACCOUNT_TOKEN`
+- `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`
+- `GITHUB_TOKEN` (auto-provided)
+
+## release.yml (master push)
+
+Two sequential jobs.
+
+**Job `build-and-push`:**
+
+1. `actions/checkout@v4`
+2. `docker/login-action@v3` → `ghcr.io` with `GITHUB_TOKEN`
+3. `docker/setup-buildx-action@v3`
+4. `docker/build-push-action@v6`:
+   - `file: apps/web/Dockerfile`
+   - `context: .`
+   - `platforms: linux/amd64`
+   - `push: true`
+   - `tags: ghcr.io/${{ github.repository }}:latest`, `ghcr.io/${{ github.repository }}:${{ github.sha }}`
+   - `cache-from: type=gha`, `cache-to: type=gha,mode=max`
+
+**Job `deploy`** (`needs: build-and-push`, `environment: production`):
+
+1. `actions/checkout@v4` (only needs `docker-compose.yml` and `Caddyfile`).
+2. `1password/load-secrets-action@v2` with `OP_SERVICE_ACCOUNT_TOKEN`, mapping every field from the vault item into env vars.
+3. Render `.env` from masked env vars plus `IMAGE_TAG=${{ github.sha }}` and `GITHUB_REPOSITORY=${{ github.repository }}`. `chmod 600 .env`.
+4. `tailscale/github-action@v3` (`tags: tag:prod-ci`).
+5. `ssh-keyscan -H prive >> ~/.ssh/known_hosts`.
+6. `ssh cicd@prive "mkdir -p ~/prive-admin"`.
+7. `scp docker-compose.yml Caddyfile .env cicd@prive:~/prive-admin/`.
+8. `ssh cicd@prive` runs:
+   ```
+   cd ~/prive-admin && \
+   echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin && \
+   docker compose pull && \
+   docker compose up -d --remove-orphans && \
+   docker image prune -f
+   ```
+   `GH_TOKEN` and `GH_ACTOR` passed via `ssh -o SendEnv` or inline env on the remote command.
+9. Smoke check: `curl -fsS --retry 5 --retry-delay 5 https://prive.salon/` (or a known health route) from the runner.
+
+`concurrency: ${{ github.workflow }}-${{ github.ref }}` ensures one deploy at a time.
+
+## pr-build.yml
+
+Two parallel jobs.
+
+**Job `build`:** existing steps preserved (checkout, setup-bun, install, oxlint, oxfmt, check-types, `bun run build`).
+
+**Job `docker-build`:**
+
+1. `actions/checkout@v4`
+2. `docker/setup-buildx-action@v3`
+3. `docker/build-push-action@v6` with `file: apps/web/Dockerfile`, `context: .`, `platforms: linux/amd64`, `push: false`, `cache-from: type=gha`, `cache-to: type=gha,mode=max`.
+
+No secrets, no push, no deploy.
+
+## backup-postgres.yml (migration)
+
+The existing scheduled backup job switches its credential source to 1Password using the same `load-secrets-action` step. It still uses Tailscale + SSH to the VPS and uploads to R2. The plain GH secrets `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE`, `R2_*` are removed once verified working. `TS_OAUTH_*` stays in GH secrets.
+
+Variable-name reconciliation: the existing backup script reads `PG_DATABASE` (set from GH secret `POSTGRES_DATABASE`). The 1Password item names this field `POSTGRES_DB` (matching the Postgres image convention used by the compose stack). The backup workflow maps `POSTGRES_DB → PG_DATABASE` when invoking the script; the script itself does not change.
+
+## VPS Prerequisites (one-time, manual)
+
+These are not automated by this design — they are documented as setup prerequisites:
+
+1. User `cicd` with docker group membership and SSH key (already provisioned).
+2. Tailscale installed and tagged `tag:prod` (already provisioned).
+3. Docker Engine + `docker compose` plugin installed.
+4. Host directories with correct ownership:
+   ```
+   sudo mkdir -p /var/lib/prive-admin/{pg,caddy/data,caddy/config}
+   sudo chown -R 999:999 /var/lib/prive-admin/pg
+   sudo chown -R cicd:cicd /var/lib/prive-admin/caddy /home/cicd/prive-admin
+   ```
+5. Firewall: 80/443 open from public internet; 22 reachable only via Tailscale.
+6. DNS: `prive.salon` A/AAAA record → VPS public IP.
+7. GHCR auth: each deploy logs in fresh with `GITHUB_TOKEN`, no manual login required.
+
+## Failure Modes & Recovery
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Docker build fails on master | `build-and-push` job red | Fix forward |
+| 1Password fetch fails | `load-secrets-action` step fails | Rotate token, verify vault permissions |
+| Tailscale auth fails | Step fails | Rotate `TS_OAUTH_*` secrets |
+| `scp` fails (host unreachable) | Step fails | Manual VPS check |
+| `docker compose up` fails | SSH step exits non-zero | SSH in, read `docker compose logs`, redeploy previous sha |
+| Migration fails | Web container restart loop | Read `docker compose logs web`, fix migration, redeploy |
+| Caddy TLS issuance fails | Smoke check fails | Read `docker compose logs caddy`, verify DNS + 80/443 reachability |
+| Postgres data corruption | Manual report | Restore from latest R2 backup |
+
+**Rollback:** `ssh cicd@prive 'cd ~/prive-admin && IMAGE_TAG=<old-sha> docker compose up -d web'`. GHCR retains old image tags by default. Documented in README.
+
+## Testing
+
+- **PR:** source build + container build via CI.
+- **Local:** developers can `docker compose -f docker-compose.yml --env-file .env.example up` against a local Postgres for stack smoke testing (an `.env.example` is provided alongside the compose file).
+- **First deploy:** push a throwaway commit to a deploy-test branch (or use `workflow_dispatch` if added later); verify Caddy issues a cert, web reaches Postgres, `/` returns 200.
+- **Smoke check on every deploy:** `curl` against the public URL with retries.
+
+There is no automated integration test in the deploy pipeline beyond the smoke check; the existing PR-time checks (types, lint, build, container build) are the gating quality bar.
+
+## Open Questions
+
+None at design-approval time. Any field-name discrepancies between the 1Password item layout and the `op://` references in workflows must be resolved during implementation, but the layout above is authoritative.

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+umask 077
 
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 BACKUP_DIR="${HOME}/db_backups"
@@ -11,6 +12,8 @@ mkdir -p "${BACKUP_DIR}"
 find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
 
 OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
+TMP="${OUT}.partial"
+trap 'rm -f "${TMP}"' ERR
 
 # Run pg_dump inside the postgres container — avoids exposing 5432 on the host.
 # PG_USER / PG_DATABASE come from the workflow env. Password is read from the
@@ -19,6 +22,7 @@ OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
 docker compose --project-directory "${COMPOSE_DIR}" exec -T postgres \
   bash -c 'PGPASSWORD="$(printenv POSTGRES_PASSWORD)" pg_dump \
             -U "'"${PG_USER}"'" --clean --create "'"${PG_DATABASE}"'"' \
-  > "${OUT}"
+  > "${TMP}"
 
+mv "${TMP}" "${OUT}"
 echo "Backup written: ${OUT}"

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_DIR="${HOME}/db_backups"
+COMPOSE_DIR="${COMPOSE_DIR:-${HOME}/prive-admin}"
+
+mkdir -p "${BACKUP_DIR}"
+
+# Prune backups older than 14 days
+find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
+
+OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
+
+# Run pg_dump inside the postgres container — avoids exposing 5432 on the host.
+# PG_USER / PG_DATABASE come from the workflow env. Password is read from the
+# container's own POSTGRES_PASSWORD via `printenv` to avoid leaking into the
+# host process table.
+docker compose --project-directory "${COMPOSE_DIR}" exec -T postgres \
+  bash -c 'PGPASSWORD="$(printenv POSTGRES_PASSWORD)" pg_dump \
+            -U "'"${PG_USER}"'" --clean --create "'"${PG_DATABASE}"'"' \
+  > "${OUT}"
+
+echo "Backup written: ${OUT}"


### PR DESCRIPTION
## Summary

- Replaces Docker Swarm deploy with a Compose stack (`caddy`, `web`, `postgres`) on the VPS `prive`.
- Adds Caddy reverse proxy with automatic Let's Encrypt TLS for `prive.salon`.
- Builds and pushes `ghcr.io/<repo>:{latest,sha}` on every push to `main`, then deploys over Tailscale SSH.
- All runtime secrets sourced from 1Password vault `5gq2basjdplfjk5v55wexp2y7i`, item `prive-admin-prod`, via service-account token (`OP_SERVICE_ACCOUNT_TOKEN`).
- PR check now adds a no-push container build alongside the existing source build.
- Restores `scripts/backup_postgres.sh` (deleted in tanstack rewrite), hardened with `umask 077` + atomic `.partial → mv`. Migrates the daily backup workflow to source secrets from 1Password and run `pg_dump` via `docker compose exec` (postgres no longer exposed on the host).

## Operational checklist (must complete before first scheduled run)

- [x] 1Password vault item `prive-admin-prod` created.
- [x] `OP_SERVICE_ACCOUNT_TOKEN` set as a GitHub Actions secret.
- [ ] Fill `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME` in the vault item (currently empty placeholders).
- [ ] VPS host directories created per `docs/deploy/vps-setup.md` (note postgres uid is 70 for the alpine image, NOT 999).
- [ ] DNS for `prive.salon` points at the VPS public IP.
- [ ] Tailscale ACL allows `tag:prod-ci → tag:prod:22`; MagicDNS enabled; VPS machine renamed to `prive`.
- [ ] First master deploy succeeded; Caddy issued a TLS certificate.
- [ ] Backup workflow run succeeded against the new stack.
- [ ] Stale GH Actions secrets removed: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE`, `R2_*`, `BETTER_AUTH_SECRET`.
- [ ] Two orphan 1Password service accounts named `prive-admin-github-actions` revoked (created during T5 troubleshooting; never produced usable tokens).

## Out of scope

- Restic-based backup conversion (in-progress draft saved to `wip/backup-restic-conversion`); follow-up PR.
- Dropping the `:-latest` default in `docker-compose.yml` and adding `start_period: 30s` to the postgres healthcheck (hardening, follow-up).
- Pinning SSH host key (currently TOFU on first run, gated by Tailscale).

## Test plan

- [ ] PR check (`pr-build.yml`) — both `Source Build` and `Docker Image Build` jobs green on this PR.
- [ ] After merge into `main`: `Release` workflow `build-and-push` job pushes `:latest` and `:<sha>` tags to GHCR.
- [ ] After merge: `Release` workflow `deploy` job ends with passing `curl` smoke check against `https://prive.salon/`.
- [ ] After merge: `gh workflow run "Daily Postgres Backup"` produces a dump on the VPS and uploads to R2.
- [ ] Manual rollback by re-running `docker compose up -d web` with `IMAGE_TAG=<previous-sha>` succeeds.

## Reference

- Design spec: `docs/superpowers/specs/2026-04-26-deploy-pipeline-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-26-deploy-pipeline.md`
- Operator guide: `docs/deploy/vps-setup.md`