### PR TITLE
ci(release): use tag:prod-server for Tailscale OAuth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ env.TS_OAUTH_CLIENT_SECRET }}
-          tags: tag:prod-ci
+          tags: tag:prod-server
 
       - name: Prepare SSH
         run: |


### PR DESCRIPTION
Tailscale OAuth client provisions auth keys for `tag:prod-server` (not `tag:prod-ci`). Without this swap the deploy job fails with 403 "calling actor does not have enough permissions" at the `Tailscale up` step.