### PR TITLE
ci(deploy): add web healthcheck, use compose --wait

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - tanstack-rewrite
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,13 +136,13 @@ jobs:
             "cd ~/prive-admin && \
              docker login ghcr.io -u '${GH_ACTOR}' --password-stdin && \
              docker compose pull && \
-             docker compose up -d --remove-orphans && \
+             docker compose up -d --remove-orphans --wait --wait-timeout 120 && \
              docker image prune -f"
 
       - name: Smoke check
         run: |
           for i in $(seq 1 10); do
-            if curl -fsS --max-time 10 https://prive.salon/ > /dev/null; then
+            if curl -fsS --max-time 10 "https://${DOMAIN_NAME}/" > /dev/null; then
               echo "smoke check ok"
               exit 0
             fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,22 @@ services:
       DOMAIN_NAME: ${DOMAIN_NAME}
       ACME_EMAIL: ${ACME_EMAIL}
     depends_on:
-      - web
+      web:
+        condition: service_healthy
 
   web:
     image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
     restart: unless-stopped
     env_file: .env
-    expose:
-      - "8081"
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:8081/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   postgres:
     image: postgres:18-alpine
@@ -34,6 +39,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    expose:
+      - "5432"
     volumes:
       - /var/lib/prive-admin/pg:/var/lib/postgresql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,13 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "bun", "-e", "fetch('http://localhost:8081/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      test:
+        [
+          "CMD",
+          "bun",
+          "-e",
+          "fetch('http://localhost:8081/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Add container healthcheck on `web` service (bun fetch on port 8081). Caddy waits on `service_healthy`.
- Drop cosmetic `expose: 8081` on web; add `expose: 5432` on postgres for symmetry.
- Use `docker compose up --wait --wait-timeout 120` so the deploy step fails fast if web doesn't become healthy.
- Re-add external smoke check, but driven by `DOMAIN_NAME` env (already loaded from 1Password) instead of a hardcoded URL.

## Test plan
- [ ] CI release workflow runs on merge
- [ ] Web container reports `healthy` in `docker ps`
- [ ] Smoke check passes against `https://${DOMAIN_NAME}/`
- [ ] Caddy starts only after web is healthy