### PR TITLE
ci(deploy): bind postgres to tailnet IP only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
         run: |
           ssh root@prive 'mkdir -p ~/prive-admin'
           scp docker-compose.yml Caddyfile .env root@prive:~/prive-admin/
+          ssh root@prive 'set -e; ts_ip=$(tailscale ip -4 | head -n1); [ -n "$ts_ip" ] || { echo "tailscale ip unavailable"; exit 1; }; printf "TAILSCALE_IP=%s\n" "$ts_ip" >> ~/prive-admin/.env'
 
       - name: Deploy stack
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    expose:
-      - "5432"
+    ports:
+      - "${TAILSCALE_IP}:5432:5432"
     volumes:
       - /var/lib/prive-admin/pg:/var/lib/postgresql
     healthcheck:


### PR DESCRIPTION
## Summary
- Replace `expose: 5432` on postgres with `ports: ${TAILSCALE_IP}:5432:5432` so the port is only reachable over the tailnet, never on `0.0.0.0`.
- Resolve `TAILSCALE_IP` on the VPS during the Stage step (`tailscale ip -4`) and append it to `.env`.
- Fail the deploy if the VPS reports no tailscale IP.

## Test plan
- [ ] Release workflow runs on merge
- [ ] `.env` on VPS contains a non-empty `TAILSCALE_IP`
- [ ] `docker compose ps` shows postgres bound to the tailnet IP, not `0.0.0.0`
- [ ] `psql 'host=<tailnet-ip> port=5432 ...'` works from a tailnet client
- [ ] Same connection from a non-tailnet host fails (connection refused)