### PR TITLE
ci(backup): change Tailscale OAuth tag to tag:prod-server

### DIFF
--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ env.TS_OAUTH_CLIENT_SECRET }}
-          tags: tag:prod-ci
+          tags: tag:prod-server
 
       - name: Prepare SSH
         run: |


### PR DESCRIPTION
## Summary
- Daily Postgres backup workflow has been failing every run since the Tailscale ACL change. The OAuth client only permits `tag:prod-server`, so requesting `tag:prod-ci` returns `Status: 400, Message: "requested tags [tag:prod-ci] are invalid or not permitted"` and the runner never joins the tailnet — `ssh-keyscan prive` then fails with `Temporary failure in name resolution` and no backup is produced.
- Mirrors the fix already applied to `release.yml` in 857d7e8.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm the Tailscale up step succeeds.
- [ ] Confirm the backup file lands in the R2 bucket and the workflow exits 0.