### PR TITLE
feat(web): add appointment transactions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1019.0",
     "@aws-sdk/s3-request-presigner": "^3.1019.0",
+    "@mantine/charts": "^9.0.0",
     "@mantine/core": "^9.0.0",
     "@mantine/dates": "^9.1.0",
     "@mantine/form": "^9.0.0",

--- a/apps/web/src/components/transactions/create-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/create-transaction-dialog.tsx
@@ -1,0 +1,63 @@
+import { Modal } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { TransactionForm, type TransactionFormSubmit } from "@/components/transactions/transaction-form"
+import { createTransaction } from "@/functions/transactions"
+
+type CreateTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  appointmentId: string
+  customerId: string
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+const todayIso = () => {
+  const d = new Date()
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+export function CreateTransactionDialog({
+  open,
+  onOpenChange,
+  appointmentId,
+  customerId,
+  invalidateKeys,
+}: CreateTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (values: TransactionFormSubmit) =>
+      createTransaction({ data: { ...values, appointmentId, customerId } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction created" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="New Transaction">
+      <TransactionForm
+        initialValues={{
+          name: "",
+          notes: "",
+          amountPounds: 0,
+          type: "BANK",
+          status: "PENDING",
+          completedDateBy: todayIso(),
+        }}
+        submitLabel="Create"
+        loading={mutation.isPending}
+        onSubmit={async (values) => {
+          await mutation.mutateAsync(values)
+        }}
+      />
+    </Modal>
+  )
+}

--- a/apps/web/src/components/transactions/delete-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/delete-transaction-dialog.tsx
@@ -1,0 +1,58 @@
+import { Button, Group, Modal, Stack, Text } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { deleteTransaction } from "@/functions/transactions"
+
+type DeleteTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  transaction: {
+    id: string
+    name: string | null
+    amount: number
+    customer?: { name: string } | null
+  }
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+
+export function DeleteTransactionDialog({
+  open,
+  onOpenChange,
+  transaction,
+  invalidateKeys,
+}: DeleteTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: () => deleteTransaction({ data: { id: transaction.id } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction deleted" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="Delete Transaction">
+      <Stack>
+        <Text size="sm">
+          This will permanently remove the transaction
+          {transaction.name ? ` "${transaction.name}"` : ""} of {formatCents(transaction.amount)}
+          {transaction.customer ? ` for ${transaction.customer.name}` : ""}. This action cannot be undone.
+        </Text>
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button color="red" loading={mutation.isPending} onClick={() => mutation.mutate()}>
+            Delete
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/apps/web/src/components/transactions/edit-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/edit-transaction-dialog.tsx
@@ -1,0 +1,61 @@
+import { Modal } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { TransactionForm, type TransactionFormSubmit } from "@/components/transactions/transaction-form"
+import { updateTransaction } from "@/functions/transactions"
+
+type EditTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  transaction: {
+    id: string
+    name: string | null
+    notes: string | null
+    amount: number
+    type: "BANK" | "CASH" | "PAYPAL" | string
+    status: "PENDING" | "COMPLETED" | string
+    completedDateBy: string
+  }
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+export function EditTransactionDialog({ open, onOpenChange, transaction, invalidateKeys }: EditTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (values: TransactionFormSubmit) => updateTransaction({ data: { ...values, id: transaction.id } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction updated" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  const initialType: "BANK" | "CASH" | "PAYPAL" =
+    transaction.type === "BANK" || transaction.type === "CASH" || transaction.type === "PAYPAL"
+      ? transaction.type
+      : "BANK"
+  const initialStatus: "PENDING" | "COMPLETED" = transaction.status === "COMPLETED" ? "COMPLETED" : "PENDING"
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="Edit Transaction">
+      <TransactionForm
+        initialValues={{
+          name: transaction.name ?? "",
+          notes: transaction.notes ?? "",
+          amountPounds: transaction.amount / 100,
+          type: initialType,
+          status: initialStatus,
+          completedDateBy: transaction.completedDateBy,
+        }}
+        submitLabel="Save Changes"
+        loading={mutation.isPending}
+        onSubmit={async (values) => {
+          await mutation.mutateAsync(values)
+        }}
+      />
+    </Modal>
+  )
+}

--- a/apps/web/src/components/transactions/transaction-form.tsx
+++ b/apps/web/src/components/transactions/transaction-form.tsx
@@ -1,0 +1,100 @@
+import { Button, Group, NativeSelect, NumberInput, Stack, Textarea, TextInput } from "@mantine/core"
+import { DateInput } from "@mantine/dates"
+import { useForm } from "@mantine/form"
+import { useMemo } from "react"
+
+export type TransactionFormValues = {
+  name: string
+  notes: string
+  amountPounds: number
+  type: "BANK" | "CASH" | "PAYPAL"
+  status: "PENDING" | "COMPLETED"
+  completedDateBy: string | null
+}
+
+export type TransactionFormSubmit = {
+  name: string | null
+  notes: string | null
+  amount: number
+  type: "BANK" | "CASH" | "PAYPAL"
+  status: "PENDING" | "COMPLETED"
+  completedDateBy: string
+}
+
+type TransactionFormProps = {
+  initialValues: TransactionFormValues
+  submitLabel: string
+  onSubmit: (values: TransactionFormSubmit) => void | Promise<void>
+  loading?: boolean
+}
+
+export function TransactionForm({ initialValues, submitLabel, onSubmit, loading }: TransactionFormProps) {
+  const form = useForm<TransactionFormValues>({
+    mode: "uncontrolled",
+    initialValues,
+    validate: {
+      completedDateBy: (value) => (value ? null : "Date is required"),
+      amountPounds: (value) => (Number.isFinite(value) ? null : "Amount is required"),
+    },
+  })
+
+  const dateLabel = useMemo(
+    () => (form.getValues().status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [form.getValues().status],
+  )
+
+  return (
+    <form
+      onSubmit={form.onSubmit(async (values) => {
+        if (!values.completedDateBy) return
+        await onSubmit({
+          name: values.name.trim() || null,
+          notes: values.notes.trim() || null,
+          amount: Math.round(values.amountPounds * 100),
+          type: values.type,
+          status: values.status,
+          completedDateBy: values.completedDateBy,
+        })
+      })}
+    >
+      <Stack>
+        <TextInput label="Name" placeholder="Transaction name" {...form.getInputProps("name")} />
+        <Textarea label="Notes" placeholder="Notes (optional)" autosize minRows={2} {...form.getInputProps("notes")} />
+        <Group grow>
+          <NativeSelect
+            label="Type"
+            data={[
+              { value: "BANK", label: "Bank" },
+              { value: "CASH", label: "Cash" },
+              { value: "PAYPAL", label: "PayPal" },
+            ]}
+            {...form.getInputProps("type")}
+          />
+          <NativeSelect
+            label="Status"
+            data={[
+              { value: "PENDING", label: "Pending" },
+              { value: "COMPLETED", label: "Completed" },
+            ]}
+            {...form.getInputProps("status")}
+          />
+        </Group>
+        <DateInput label={dateLabel} valueFormat="DD MMM YYYY" required {...form.getInputProps("completedDateBy")} />
+        <NumberInput
+          label="Amount"
+          prefix="£"
+          decimalScale={2}
+          fixedDecimalScale
+          step={0.01}
+          {...form.getInputProps("amountPounds")}
+        />
+        <Group justify="flex-end">
+          <Button type="submit" loading={loading}>
+            {submitLabel}
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  )
+}

--- a/apps/web/src/components/transactions/transaction-form.tsx
+++ b/apps/web/src/components/transactions/transaction-form.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, NativeSelect, NumberInput, Stack, Textarea, TextInput } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
-import { useMemo } from "react"
+import { useState } from "react"
 
 export type TransactionFormValues = {
   name: string
@@ -38,11 +38,8 @@ export function TransactionForm({ initialValues, submitLabel, onSubmit, loading 
     },
   })
 
-  const dateLabel = useMemo(
-    () => (form.getValues().status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [form.getValues().status],
-  )
+  const [status, setStatus] = useState<TransactionFormValues["status"]>(initialValues.status)
+  const dateLabel = status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"
 
   return (
     <form
@@ -78,6 +75,11 @@ export function TransactionForm({ initialValues, submitLabel, onSubmit, loading 
               { value: "COMPLETED", label: "Completed" },
             ]}
             {...form.getInputProps("status")}
+            onChange={(event) => {
+              const next = event.currentTarget.value as TransactionFormValues["status"]
+              form.setFieldValue("status", next)
+              setStatus(next)
+            }}
           />
         </Group>
         <DateInput label={dateLabel} valueFormat="DD MMM YYYY" required {...form.getInputProps("completedDateBy")} />

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -91,7 +91,9 @@ export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTable
                   </Text>
                   {isOverdue && (
                     <Tooltip label="Pending transaction is overdue" withArrow>
-                      <IconAlertTriangle size={14} color="red" />
+                      <span style={{ display: "inline-flex" }} tabIndex={0} aria-label="Overdue">
+                        <IconAlertTriangle size={14} color="red" />
+                      </span>
                     </Tooltip>
                   )}
                 </Group>

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -1,0 +1,122 @@
+import { ActionIcon, Badge, Group, Menu, Table, Text, Tooltip } from "@mantine/core"
+import { IconAlertTriangle, IconCheck, IconClock, IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
+import { Link } from "@tanstack/react-router"
+import dayjs from "dayjs"
+
+export type TransactionRow = {
+  id: string
+  name: string | null
+  notes: string | null
+  amount: number
+  type: "BANK" | "CASH" | "PAYPAL" | string
+  status: "PENDING" | "COMPLETED" | string
+  completedDateBy: string
+  customerId: string
+  appointmentId: string | null
+  customer?: { id: string; name: string } | null
+}
+
+type TransactionsTableProps = {
+  items: TransactionRow[]
+  onEdit: (item: TransactionRow) => void
+  onDelete: (item: TransactionRow) => void
+}
+
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+
+const typeColor: Record<string, string> = {
+  BANK: "teal",
+  CASH: "blue",
+  PAYPAL: "grape",
+}
+
+export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTableProps) {
+  if (items.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No transactions.
+      </Text>
+    )
+  }
+
+  return (
+    <Table>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Customer</Table.Th>
+          <Table.Th>Name</Table.Th>
+          <Table.Th>Type</Table.Th>
+          <Table.Th>Amount</Table.Th>
+          <Table.Th>Completed</Table.Th>
+          <Table.Th />
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {items.map((tx) => {
+          const isCompleted = tx.status === "COMPLETED"
+          const completedDate = dayjs(tx.completedDateBy)
+          const isOverdue = !isCompleted && completedDate.isBefore(dayjs(), "day")
+          const statusBadgeColor = isCompleted ? "green" : "pink"
+          const statusIcon = isCompleted ? <IconCheck size={12} /> : <IconClock size={12} />
+          return (
+            <Table.Tr key={tx.id}>
+              <Table.Td>
+                {tx.customer ? (
+                  <Text
+                    renderRoot={(props) => (
+                      <Link to="/customers/$customerId" params={{ customerId: tx.customer!.id }} {...props} />
+                    )}
+                    c="blue"
+                  >
+                    {tx.customer.name}
+                  </Text>
+                ) : (
+                  "—"
+                )}
+              </Table.Td>
+              <Table.Td>{tx.name ?? <Text c="dimmed">—</Text>}</Table.Td>
+              <Table.Td>
+                <Badge color={typeColor[tx.type] ?? "gray"} variant="light">
+                  {tx.type}
+                </Badge>
+              </Table.Td>
+              <Table.Td>{formatCents(tx.amount)}</Table.Td>
+              <Table.Td>
+                <Group gap="xs" align="center">
+                  <Badge color={statusBadgeColor} leftSection={statusIcon} radius="sm" size="sm" variant="light">
+                    {tx.status}
+                  </Badge>
+                  <Text size="xs" c={isOverdue ? "red" : "dimmed"} fw={500}>
+                    {completedDate.format("DD MMM YYYY")}
+                  </Text>
+                  {isOverdue && (
+                    <Tooltip label="Pending transaction is overdue" withArrow>
+                      <IconAlertTriangle size={14} color="red" />
+                    </Tooltip>
+                  )}
+                </Group>
+              </Table.Td>
+              <Table.Td>
+                <Menu shadow="md" width={140} position="bottom-end">
+                  <Menu.Target>
+                    <ActionIcon variant="subtle" size="sm" aria-label="Actions">
+                      <IconDots size={14} />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item leftSection={<IconPencil size={14} />} onClick={() => onEdit(tx)}>
+                      Update
+                    </Menu.Item>
+                    <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => onDelete(tx)}>
+                      Delete
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+              </Table.Td>
+            </Table.Tr>
+          )
+        })}
+      </Table.Tbody>
+    </Table>
+  )
+}

--- a/apps/web/src/functions/transactions.ts
+++ b/apps/web/src/functions/transactions.ts
@@ -1,0 +1,117 @@
+import { db } from "@prive-admin-tanstack/db"
+import { personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
+import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
+import { createServerFn } from "@tanstack/react-start"
+import { asc, eq } from "drizzle-orm"
+import { z } from "zod"
+
+import { requireAuthMiddleware } from "@/middleware/auth"
+
+const transactionTypeSchema = z.enum(["BANK", "CASH", "PAYPAL"])
+const transactionStatusSchema = z.enum(["PENDING", "COMPLETED"])
+const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD")
+
+const transactionFieldsSchema = z.object({
+  name: z.string().nullish(),
+  notes: z.string().nullish(),
+  amount: z.number().int(),
+  type: transactionTypeSchema,
+  status: transactionStatusSchema,
+  completedDateBy: dateStringSchema,
+})
+
+export const getTransactionsByAppointmentId = createServerFn({ method: "GET" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(z.object({ appointmentId: z.string() }))
+  .handler(async ({ data }) => {
+    return db.query.transaction.findMany({
+      where: eq(transaction.appointmentId, data.appointmentId),
+      with: { customer: { columns: { id: true, name: true } } },
+      orderBy: [asc(transaction.completedDateBy)],
+    })
+  })
+
+export const createTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(
+    transactionFieldsSchema.extend({
+      appointmentId: z.string().min(1),
+      customerId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const allowedCustomerIds = new Set<string>()
+    const appointmentRow = await db.query.appointment.findFirst({
+      where: (a, { eq }) => eq(a.id, data.appointmentId),
+      columns: { clientId: true },
+    })
+    if (!appointmentRow) {
+      throw new Error("Appointment not found")
+    }
+    allowedCustomerIds.add(appointmentRow.clientId)
+    const personnelRows = await db
+      .select({ personnelId: personnelOnAppointments.personnelId })
+      .from(personnelOnAppointments)
+      .where(eq(personnelOnAppointments.appointmentId, data.appointmentId))
+    for (const row of personnelRows) {
+      allowedCustomerIds.add(row.personnelId)
+    }
+    if (!allowedCustomerIds.has(data.customerId)) {
+      throw new Error("Customer is not the appointment client or assigned personnel")
+    }
+
+    const [result] = await db
+      .insert(transaction)
+      .values({
+        appointmentId: data.appointmentId,
+        customerId: data.customerId,
+        name: data.name ?? null,
+        notes: data.notes ?? null,
+        amount: data.amount,
+        type: data.type,
+        status: data.status,
+        completedDateBy: data.completedDateBy,
+      })
+      .returning()
+    return result
+  })
+
+export const updateTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(transactionFieldsSchema.extend({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const existing = await db.query.transaction.findFirst({
+      where: eq(transaction.id, data.id),
+      columns: { id: true },
+    })
+    if (!existing) {
+      throw new Error("Transaction not found")
+    }
+    const [result] = await db
+      .update(transaction)
+      .set({
+        name: data.name ?? null,
+        notes: data.notes ?? null,
+        amount: data.amount,
+        type: data.type,
+        status: data.status,
+        completedDateBy: data.completedDateBy,
+      })
+      .where(eq(transaction.id, data.id))
+      .returning()
+    return result
+  })
+
+export const deleteTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const existing = await db.query.transaction.findFirst({
+      where: eq(transaction.id, data.id),
+      columns: { id: true },
+    })
+    if (!existing) {
+      throw new Error("Transaction not found")
+    }
+    await db.delete(transaction).where(eq(transaction.id, data.id))
+  })

--- a/apps/web/src/functions/transactions.ts
+++ b/apps/web/src/functions/transactions.ts
@@ -2,7 +2,7 @@ import { db } from "@prive-admin-tanstack/db"
 import { personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
 import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
 import { createServerFn } from "@tanstack/react-start"
-import { asc, eq } from "drizzle-orm"
+import { eq } from "drizzle-orm"
 import { z } from "zod"
 
 import { requireAuthMiddleware } from "@/middleware/auth"
@@ -27,7 +27,7 @@ export const getTransactionsByAppointmentId = createServerFn({ method: "GET" })
     return db.query.transaction.findMany({
       where: eq(transaction.appointmentId, data.appointmentId),
       with: { customer: { columns: { id: true, name: true } } },
-      orderBy: [asc(transaction.completedDateBy)],
+      orderBy: (tx, { asc }) => [asc(tx.completedDateBy)],
     })
   })
 
@@ -40,40 +40,42 @@ export const createTransaction = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }) => {
-    const allowedCustomerIds = new Set<string>()
-    const appointmentRow = await db.query.appointment.findFirst({
-      where: (a, { eq }) => eq(a.id, data.appointmentId),
-      columns: { clientId: true },
-    })
-    if (!appointmentRow) {
-      throw new Error("Appointment not found")
-    }
-    allowedCustomerIds.add(appointmentRow.clientId)
-    const personnelRows = await db
-      .select({ personnelId: personnelOnAppointments.personnelId })
-      .from(personnelOnAppointments)
-      .where(eq(personnelOnAppointments.appointmentId, data.appointmentId))
-    for (const row of personnelRows) {
-      allowedCustomerIds.add(row.personnelId)
-    }
-    if (!allowedCustomerIds.has(data.customerId)) {
-      throw new Error("Customer is not the appointment client or assigned personnel")
-    }
-
-    const [result] = await db
-      .insert(transaction)
-      .values({
-        appointmentId: data.appointmentId,
-        customerId: data.customerId,
-        name: data.name ?? null,
-        notes: data.notes ?? null,
-        amount: data.amount,
-        type: data.type,
-        status: data.status,
-        completedDateBy: data.completedDateBy,
+    return await db.transaction(async (tx) => {
+      const allowedCustomerIds = new Set<string>()
+      const appointmentRow = await tx.query.appointment.findFirst({
+        where: (a, { eq }) => eq(a.id, data.appointmentId),
+        columns: { clientId: true },
       })
-      .returning()
-    return result
+      if (!appointmentRow) {
+        throw new Error("Appointment not found")
+      }
+      allowedCustomerIds.add(appointmentRow.clientId)
+      const personnelRows = await tx
+        .select({ personnelId: personnelOnAppointments.personnelId })
+        .from(personnelOnAppointments)
+        .where(eq(personnelOnAppointments.appointmentId, data.appointmentId))
+      for (const row of personnelRows) {
+        allowedCustomerIds.add(row.personnelId)
+      }
+      if (!allowedCustomerIds.has(data.customerId)) {
+        throw new Error("Customer is not the appointment client or assigned personnel")
+      }
+
+      const [result] = await tx
+        .insert(transaction)
+        .values({
+          appointmentId: data.appointmentId,
+          customerId: data.customerId,
+          name: data.name ?? null,
+          notes: data.notes ?? null,
+          amount: data.amount,
+          type: data.type,
+          status: data.status,
+          completedDateBy: data.completedDateBy,
+        })
+        .returning()
+      return result
+    })
   })
 
 export const updateTransaction = createServerFn({ method: "POST" })

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,4 @@
 @import "@prive-admin-tanstack/ui/globals.css";
+@import "@mantine/charts/styles.css";
 @import "@mantine/dates/styles.css";
 @import "@mantine/schedule/styles.css";

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -43,3 +43,8 @@ export const hairAssignedKeys = {
   byAppointment: (id: string) => [...hairAssignedKeys.all, "by-appointment", id] as const,
   byCustomer: (id: string) => [...hairAssignedKeys.all, "by-customer", id] as const,
 }
+
+export const transactionKeys = {
+  all: ["transactions"] as const,
+  byAppointment: (appointmentId: string) => [...transactionKeys.all, "by-appointment", appointmentId] as const,
+}

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -37,6 +37,8 @@ import { getHairAssignedByAppointment } from "@/functions/hair-assigned"
 import { getTransactionsByAppointmentId } from "@/functions/transactions"
 import { appointmentKeys, customerKeys, hairAssignedKeys, transactionKeys } from "@/lib/query-keys"
 
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
   loader: async ({ context, params }) => {
@@ -97,7 +99,6 @@ function AppointmentDetailPage() {
     { name: "Completed", value: Math.abs(completedSum), color: "green.4" },
     { name: "Pending", value: Math.abs(pendingSum), color: "pink.6" },
   ]
-  const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
 
   if (isLoading) {
     return (
@@ -226,7 +227,7 @@ function AppointmentDetailPage() {
               </Group>
             </Title>
           </Group>
-          {totalSum === 0 ? (
+          {txList.length === 0 ? (
             <Text size="sm" c="dimmed">
               No transactions yet.
             </Text>

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -1,3 +1,4 @@
+import { DonutChart } from "@mantine/charts"
 import {
   Anchor,
   Button,
@@ -16,7 +17,7 @@ import {
   Title,
 } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import { IconArrowLeft, IconClock, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
+import { IconArrowLeft, IconCash, IconClock, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
@@ -87,6 +88,16 @@ function AppointmentDetailPage() {
     queryKey: transactionKeys.byAppointment(appointmentId),
     queryFn: () => getTransactionsByAppointmentId({ data: { appointmentId } }),
   })
+
+  const txList = transactions ?? []
+  const completedSum = txList.filter((t) => t.status === "COMPLETED").reduce((acc, t) => acc + t.amount, 0)
+  const pendingSum = txList.filter((t) => t.status === "PENDING").reduce((acc, t) => acc + t.amount, 0)
+  const totalSum = txList.reduce((acc, t) => acc + t.amount, 0)
+  const chartData = [
+    { name: "Completed", value: Math.abs(completedSum), color: "green.4" },
+    { name: "Pending", value: Math.abs(pendingSum), color: "pink.6" },
+  ]
+  const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
 
   if (isLoading) {
     return (
@@ -205,6 +216,37 @@ function AppointmentDetailPage() {
             />
           </Card>
         </Group>
+
+        <Card withBorder>
+          <Group justify="space-between" mb="sm">
+            <Title order={5}>
+              <Group gap={6}>
+                <IconCash size={14} />
+                Transactions Summary
+              </Group>
+            </Title>
+          </Group>
+          {totalSum === 0 ? (
+            <Text size="sm" c="dimmed">
+              No transactions yet.
+            </Text>
+          ) : (
+            <Group align="center" gap="xl">
+              <DonutChart size={124} thickness={15} data={chartData} withLabels={false} />
+              <Stack gap={2}>
+                <Text size="sm">
+                  Completed: <b>{formatCents(completedSum)}</b>
+                </Text>
+                <Text size="sm">
+                  Pending: <b>{formatCents(pendingSum)}</b>
+                </Text>
+                <Text size="sm">
+                  Total: <b>{formatCents(totalSum)}</b>
+                </Text>
+              </Stack>
+            </Group>
+          )}
+        </Card>
 
         <Card withBorder>
           <Group justify="space-between" mb="sm">

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -26,10 +26,15 @@ import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair
 import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair-assigned-dialog"
 import { EditHairAssignedDialog } from "@/components/hair-assigned/edit-hair-assigned-dialog"
 import { HairAssignedTable, type HairAssignedRow } from "@/components/hair-assigned/hair-assigned-table"
+import { CreateTransactionDialog } from "@/components/transactions/create-transaction-dialog"
+import { DeleteTransactionDialog } from "@/components/transactions/delete-transaction-dialog"
+import { EditTransactionDialog } from "@/components/transactions/edit-transaction-dialog"
+import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
 import { getAppointment, linkPersonnel } from "@/functions/appointments"
 import { getCustomers } from "@/functions/customers"
 import { getHairAssignedByAppointment } from "@/functions/hair-assigned"
-import { appointmentKeys, customerKeys, hairAssignedKeys } from "@/lib/query-keys"
+import { getTransactionsByAppointmentId } from "@/functions/transactions"
+import { appointmentKeys, customerKeys, hairAssignedKeys, transactionKeys } from "@/lib/query-keys"
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
@@ -47,6 +52,12 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
           queryFn: () => getHairAssignedByAppointment({ data: { appointmentId: params.appointmentId } }),
         }),
       ),
+      context.queryClient.prefetchQuery(
+        queryOptions({
+          queryKey: transactionKeys.byAppointment(params.appointmentId),
+          queryFn: () => getTransactionsByAppointmentId({ data: { appointmentId: params.appointmentId } }),
+        }),
+      ),
     ])
   },
 })
@@ -57,6 +68,10 @@ function AppointmentDetailPage() {
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
   const [pickPersonnelOpen, setPickPersonnelOpen] = useState(false)
+  const [createTxOpen, setCreateTxOpen] = useState(false)
+  const [createTxCustomerId, setCreateTxCustomerId] = useState<string | null>(null)
+  const [editTx, setEditTx] = useState<TransactionRow | null>(null)
+  const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
 
   const { data: appointment, isLoading } = useQuery({
     queryKey: appointmentKeys.detail(appointmentId),
@@ -66,6 +81,11 @@ function AppointmentDetailPage() {
   const { data: hairAssigned } = useQuery({
     queryKey: hairAssignedKeys.byAppointment(appointmentId),
     queryFn: () => getHairAssignedByAppointment({ data: { appointmentId } }),
+  })
+
+  const { data: transactions } = useQuery({
+    queryKey: transactionKeys.byAppointment(appointmentId),
+    queryFn: () => getTransactionsByAppointmentId({ data: { appointmentId } }),
   })
 
   if (isLoading) {
@@ -91,6 +111,13 @@ function AppointmentDetailPage() {
     { queryKey: appointmentKeys.detail(appointmentId) },
     { queryKey: hairAssignedKeys.byAppointment(appointmentId) },
   ]
+
+  const txInvalidateKeys = [{ queryKey: transactionKeys.byAppointment(appointmentId) }]
+
+  const openCreateTx = (customerId: string) => {
+    setCreateTxCustomerId(customerId)
+    setCreateTxOpen(true)
+  }
 
   return (
     <Container size="lg">
@@ -180,6 +207,21 @@ function AppointmentDetailPage() {
         </Group>
 
         <Card withBorder>
+          <Group justify="space-between" mb="sm">
+            <Title order={5}>Transactions</Title>
+            <Button
+              variant="subtle"
+              size="xs"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => openCreateTx(appointment.client.id)}
+            >
+              New
+            </Button>
+          </Group>
+          <TransactionsTable items={transactions ?? []} onEdit={setEditTx} onDelete={setDeleteTx} />
+        </Card>
+
+        <Card withBorder>
           <Title order={5} mb="sm">
             Notes
           </Title>
@@ -230,6 +272,32 @@ function AppointmentDetailPage() {
           appointmentId={appointmentId}
           assignedPersonnelIds={appointment.personnel?.map((p) => p.personnelId) ?? []}
         />
+        <CreateTransactionDialog
+          open={createTxOpen}
+          onOpenChange={(open) => {
+            setCreateTxOpen(open)
+            if (!open) setCreateTxCustomerId(null)
+          }}
+          appointmentId={appointmentId}
+          customerId={createTxCustomerId ?? appointment.client.id}
+          invalidateKeys={txInvalidateKeys}
+        />
+        {editTx && (
+          <EditTransactionDialog
+            open={!!editTx}
+            onOpenChange={(open) => !open && setEditTx(null)}
+            transaction={editTx}
+            invalidateKeys={txInvalidateKeys}
+          />
+        )}
+        {deleteTx && (
+          <DeleteTransactionDialog
+            open={!!deleteTx}
+            onOpenChange={(open) => !open && setDeleteTx(null)}
+            transaction={deleteTx}
+            invalidateKeys={txInvalidateKeys}
+          />
+        )}
       </Stack>
     </Container>
   )

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -1,5 +1,6 @@
 import { DonutChart } from "@mantine/charts"
 import {
+  ActionIcon,
   Anchor,
   Button,
   Card,
@@ -7,6 +8,7 @@ import {
   Container,
   Divider,
   Group,
+  Menu,
   Modal,
   ScrollArea,
   Skeleton,
@@ -17,7 +19,7 @@ import {
   Title,
 } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import { IconArrowLeft, IconCash, IconClock, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
+import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
@@ -183,9 +185,23 @@ function AppointmentDetailPage() {
               <Stack gap="xs">
                 {appointment.personnel.map((p) => (
                   <Card key={p.personnelId} withBorder padding="xs">
-                    <Group gap="xs">
-                      <IconUser size={12} />
-                      <Text size="sm">{p.personnel.name}</Text>
+                    <Group justify="space-between" gap="xs">
+                      <Group gap="xs">
+                        <IconUser size={12} />
+                        <Text size="sm">{p.personnel.name}</Text>
+                      </Group>
+                      <Menu shadow="md" width={180} position="bottom-end">
+                        <Menu.Target>
+                          <ActionIcon variant="subtle" size="sm" aria-label="Personnel actions">
+                            <IconDots size={14} />
+                          </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                          <Menu.Item leftSection={<IconCash size={14} />} onClick={() => openCreateTx(p.personnelId)}>
+                            New transaction
+                          </Menu.Item>
+                        </Menu.Dropdown>
+                      </Menu>
                     </Group>
                   </Card>
                 ))}

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -84,7 +84,7 @@ function StatCard({ label, value }: { label: string; value: string }) {
   )
 }
 
-const formatCurrency = (n: number) => `$${n.toFixed(2)}`
+const formatCurrency = (n: number) => `£${n.toFixed(2)}`
 
 function EditCustomerDialog({
   customer,

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1019.0",
         "@aws-sdk/s3-request-presigner": "^3.1019.0",
+        "@mantine/charts": "^9.0.0",
         "@mantine/core": "^9.0.0",
         "@mantine/dates": "^9.1.0",
         "@mantine/form": "^9.0.0",
@@ -396,6 +397,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mantine/charts": ["@mantine/charts@9.1.0", "", { "peerDependencies": { "@mantine/core": "9.1.0", "@mantine/hooks": "9.1.0", "react": "^19.2.0", "react-dom": "^19.2.0", "recharts": ">=3.2.1" } }, "sha512-EaZDfob8iAcPj/Oz8HabcPM5w52rGrP01TWEijZV8xliBF/AYH/r4dVcvmepQSZXf2vVpUshLlS215TebFqCxQ=="],
+
     "@mantine/core": ["@mantine/core@9.1.0", "", { "dependencies": { "@floating-ui/react": "^0.27.19", "clsx": "^2.1.1", "react-number-format": "^5.4.5", "react-remove-scroll": "^2.7.2", "type-fest": "^5.6.0" }, "peerDependencies": { "@mantine/hooks": "9.1.0", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-gT14pELclqrxhWZsFoY6MxN3dtVKxwUQFM9Y5SNzNyHgm6Mjh374pFdMg7P6FOECXYy1nlTP8y5S1vIR9CiNTA=="],
 
     "@mantine/dates": ["@mantine/dates@9.1.0", "", { "dependencies": { "clsx": "^2.1.1" }, "peerDependencies": { "@mantine/core": "9.1.0", "@mantine/hooks": "9.1.0", "dayjs": ">=1.0.0", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-g6BbiqUjn7RI1/n8M/9n5Gof3YvCJDjs9TcfdFUJLBc6DPPqLTCi9EPnOon9ilSJl+ceW+LGYhYOJGPkmdI76A=="],
@@ -517,6 +520,8 @@
     "@prive-admin-tanstack/env": ["@prive-admin-tanstack/env@workspace:packages/env"],
 
     "@prive-admin-tanstack/ui": ["@prive-admin-tanstack/ui@workspace:packages/ui"],
+
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 
@@ -654,6 +659,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@t3-oss/env-core": ["@t3-oss/env-core@0.13.11", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ=="],
 
     "@tabler/icons": ["@tabler/icons@3.41.1", "", {}, "sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q=="],
@@ -728,6 +735,24 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
@@ -735,6 +760,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
@@ -814,6 +841,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
@@ -823,6 +872,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
@@ -862,11 +913,15 @@
 
     "error-causes": ["error-causes@3.0.2", "", {}, "sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw=="],
 
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -905,6 +960,10 @@
     "httpxy": ["httpxy@0.5.1", "", {}, "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -1072,6 +1131,8 @@
 
     "react-number-format": ["react-number-format@5.4.5", "", { "peerDependencies": { "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1084,7 +1145,15 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1178,6 +1247,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
@@ -1223,6 +1294,8 @@
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/docs/superpowers/plans/2026-04-27-appointment-transactions.md
+++ b/docs/superpowers/plans/2026-04-27-appointment-transactions.md
@@ -1,0 +1,1425 @@
+# Appointment Transactions UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the transactions surface on `/appointments/$appointmentId` (table, donut summary, create/edit/delete dialogs, per-personnel "New transaction") matching `main_backup` behaviour, using current TanStack Start + Drizzle conventions.
+
+**Architecture:** Server functions in `apps/web/src/functions/transactions.ts` query the existing `transaction` table (Drizzle, cents, FK to appointment + customer). UI lives in `apps/web/src/components/transactions/` (Mantine `Modal` dialogs, shared form). Route file `routes/_authenticated/appointments/$appointmentId.tsx` prefetches in loader, renders summary + table + dialogs, and adds a per-personnel row menu. Mantine `DonutChart` (`@mantine/charts`) used for the Completed/Pending split.
+
+**Tech Stack:** TanStack Start (`createServerFn`), TanStack Router file-based routes, TanStack Query, Drizzle ORM, Mantine v9 (`core`, `dates`, `form`, `notifications`, `charts`), Zod, `@tabler/icons-react`, `dayjs`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-appointment-transactions-design.md`
+
+**Branch:** `feature/appointment-transactions` (already created and contains the spec commit).
+
+**Verification model:** Repository has no automated tests (no vitest, no spec files). After each task that produces code, verification is `bun run check-types`, `bun run check` (oxlint + oxfmt), and where applicable a manual browser check on the dev server (`bun run dev:web`). Each task ends with a commit.
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/web/src/functions/transactions.ts` — four server functions: `getTransactionsByAppointmentId`, `createTransaction`, `updateTransaction`, `deleteTransaction`.
+- `apps/web/src/components/transactions/transactions-table.tsx` — pure table render.
+- `apps/web/src/components/transactions/transaction-form.tsx` — shared form for create + edit.
+- `apps/web/src/components/transactions/create-transaction-dialog.tsx` — Modal wrapper around the form, calls `createTransaction`.
+- `apps/web/src/components/transactions/edit-transaction-dialog.tsx` — Modal wrapper around the form, calls `updateTransaction`.
+- `apps/web/src/components/transactions/delete-transaction-dialog.tsx` — confirm Modal, calls `deleteTransaction`.
+
+**Modified files:**
+- `apps/web/package.json` — add `@mantine/charts` dependency.
+- `apps/web/src/lib/query-keys.ts` — add `transactionKeys`.
+- `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx` — prefetch, summary card, transactions card, dialogs, per-personnel "New transaction" menu.
+- `apps/web/src/routes/_authenticated/customers/$customerId.tsx` — flip `formatCurrency` from `$` to `£`.
+
+---
+
+## Task 1: Add `@mantine/charts` dependency
+
+**Files:**
+- Modify: `apps/web/package.json`
+
+- [ ] **Step 1: Add `@mantine/charts` to dependencies**
+
+In `apps/web/package.json`, add the dependency in the existing alphabetical block (next to other `@mantine/*` entries):
+
+```json
+"@mantine/charts": "^9.0.0",
+```
+
+Final dependencies block must contain:
+
+```json
+"@mantine/charts": "^9.0.0",
+"@mantine/core": "^9.0.0",
+"@mantine/dates": "^9.1.0",
+"@mantine/form": "^9.0.0",
+"@mantine/hooks": "^9.0.0",
+"@mantine/modals": "^9.0.0",
+"@mantine/notifications": "^9.0.0",
+"@mantine/schedule": "^9.1.0",
+```
+
+- [ ] **Step 2: Install**
+
+Run from repo root:
+
+```bash
+bun install
+```
+
+Expected: lockfile updates, no errors. `node_modules/@mantine/charts` exists.
+
+Verify:
+
+```bash
+ls node_modules/@mantine/charts/package.json
+```
+
+Expected: file exists.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/package.json bun.lock
+git commit -m "build(web): add @mantine/charts dependency"
+```
+
+---
+
+## Task 2: Add `transactionKeys` to query-keys
+
+**Files:**
+- Modify: `apps/web/src/lib/query-keys.ts`
+
+- [ ] **Step 1: Append `transactionKeys` factory**
+
+Add this to the bottom of `apps/web/src/lib/query-keys.ts`:
+
+```ts
+export const transactionKeys = {
+  all: ["transactions"] as const,
+  byAppointment: (appointmentId: string) =>
+    [...transactionKeys.all, "by-appointment", appointmentId] as const,
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/query-keys.ts
+git commit -m "feat(web): add transactionKeys query-key factory"
+```
+
+---
+
+## Task 3: Implement server functions in `transactions.ts`
+
+**Files:**
+- Create: `apps/web/src/functions/transactions.ts`
+
+- [ ] **Step 1: Create the file with all four server functions**
+
+Create `apps/web/src/functions/transactions.ts` with this exact contents:
+
+```ts
+import { db } from "@prive-admin-tanstack/db"
+import { personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
+import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
+import { createServerFn } from "@tanstack/react-start"
+import { and, asc, eq } from "drizzle-orm"
+import { z } from "zod"
+
+import { requireAuthMiddleware } from "@/middleware/auth"
+
+const transactionTypeSchema = z.enum(["BANK", "CASH", "PAYPAL"])
+const transactionStatusSchema = z.enum(["PENDING", "COMPLETED"])
+const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD")
+
+const transactionFieldsSchema = z.object({
+  name: z.string().nullish(),
+  notes: z.string().nullish(),
+  amount: z.number().int(),
+  type: transactionTypeSchema,
+  status: transactionStatusSchema,
+  completedDateBy: dateStringSchema,
+})
+
+export const getTransactionsByAppointmentId = createServerFn({ method: "GET" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(z.object({ appointmentId: z.string() }))
+  .handler(async ({ data }) => {
+    return db.query.transaction.findMany({
+      where: eq(transaction.appointmentId, data.appointmentId),
+      with: { customer: { columns: { id: true, name: true } } },
+      orderBy: [asc(transaction.completedDateBy)],
+    })
+  })
+
+export const createTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(
+    transactionFieldsSchema.extend({
+      appointmentId: z.string().min(1),
+      customerId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const allowedCustomerIds = new Set<string>()
+    const appointmentRow = await db.query.appointment.findFirst({
+      where: (a, { eq }) => eq(a.id, data.appointmentId),
+      columns: { clientId: true },
+    })
+    if (!appointmentRow) {
+      throw new Error("Appointment not found")
+    }
+    allowedCustomerIds.add(appointmentRow.clientId)
+    const personnelRows = await db
+      .select({ personnelId: personnelOnAppointments.personnelId })
+      .from(personnelOnAppointments)
+      .where(eq(personnelOnAppointments.appointmentId, data.appointmentId))
+    for (const row of personnelRows) {
+      allowedCustomerIds.add(row.personnelId)
+    }
+    if (!allowedCustomerIds.has(data.customerId)) {
+      throw new Error("Customer is not the appointment client or assigned personnel")
+    }
+
+    const [result] = await db
+      .insert(transaction)
+      .values({
+        appointmentId: data.appointmentId,
+        customerId: data.customerId,
+        name: data.name ?? null,
+        notes: data.notes ?? null,
+        amount: data.amount,
+        type: data.type,
+        status: data.status,
+        completedDateBy: data.completedDateBy,
+      })
+      .returning()
+    return result
+  })
+
+export const updateTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(transactionFieldsSchema.extend({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const existing = await db.query.transaction.findFirst({
+      where: eq(transaction.id, data.id),
+      columns: { id: true },
+    })
+    if (!existing) {
+      throw new Error("Transaction not found")
+    }
+    const [result] = await db
+      .update(transaction)
+      .set({
+        name: data.name ?? null,
+        notes: data.notes ?? null,
+        amount: data.amount,
+        type: data.type,
+        status: data.status,
+        completedDateBy: data.completedDateBy,
+      })
+      .where(eq(transaction.id, data.id))
+      .returning()
+    return result
+  })
+
+export const deleteTransaction = createServerFn({ method: "POST" })
+  .middleware([requireAuthMiddleware])
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const existing = await db.query.transaction.findFirst({
+      where: eq(transaction.id, data.id),
+      columns: { id: true },
+    })
+    if (!existing) {
+      throw new Error("Transaction not found")
+    }
+    await db.delete(transaction).where(eq(transaction.id, data.id))
+  })
+```
+
+Note: the unused `and` import is intentional reservation removed — replace the `import { and, asc, eq }` line with `import { asc, eq } from "drizzle-orm"` if oxlint flags `and` as unused. Run lint to find out.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0. If oxlint flags `and` as unused, remove it from the import:
+
+```ts
+import { asc, eq } from "drizzle-orm"
+```
+
+Re-run `bun run check`. Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/functions/transactions.ts
+git commit -m "feat(web): add transactions server functions"
+```
+
+---
+
+## Task 4: Build `TransactionsTable` component
+
+**Files:**
+- Create: `apps/web/src/components/transactions/transactions-table.tsx`
+
+- [ ] **Step 1: Create the table component**
+
+Create `apps/web/src/components/transactions/transactions-table.tsx` with this exact contents:
+
+```tsx
+import { ActionIcon, Badge, Group, Menu, Table, Text, Tooltip } from "@mantine/core"
+import { IconAlertTriangle, IconCheck, IconClock, IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
+import { Link } from "@tanstack/react-router"
+import dayjs from "dayjs"
+
+export type TransactionRow = {
+  id: string
+  name: string | null
+  notes: string | null
+  amount: number
+  type: "BANK" | "CASH" | "PAYPAL" | string
+  status: "PENDING" | "COMPLETED" | string
+  completedDateBy: string
+  customerId: string
+  appointmentId: string | null
+  customer?: { id: string; name: string } | null
+}
+
+type TransactionsTableProps = {
+  items: TransactionRow[]
+  onEdit: (item: TransactionRow) => void
+  onDelete: (item: TransactionRow) => void
+}
+
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+
+const typeColor: Record<string, string> = {
+  BANK: "teal",
+  CASH: "blue",
+  PAYPAL: "grape",
+}
+
+export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTableProps) {
+  if (items.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No transactions.
+      </Text>
+    )
+  }
+
+  return (
+    <Table>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Customer</Table.Th>
+          <Table.Th>Name</Table.Th>
+          <Table.Th>Type</Table.Th>
+          <Table.Th>Amount</Table.Th>
+          <Table.Th>Completed</Table.Th>
+          <Table.Th />
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {items.map((tx) => {
+          const isCompleted = tx.status === "COMPLETED"
+          const completedDate = dayjs(tx.completedDateBy)
+          const isOverdue = !isCompleted && completedDate.isBefore(dayjs(), "day")
+          const statusBadgeColor = isCompleted ? "green" : "pink"
+          const statusIcon = isCompleted ? <IconCheck size={12} /> : <IconClock size={12} />
+          return (
+            <Table.Tr key={tx.id}>
+              <Table.Td>
+                {tx.customer ? (
+                  <Text
+                    renderRoot={(props) => (
+                      <Link to="/customers/$customerId" params={{ customerId: tx.customer!.id }} {...props} />
+                    )}
+                    c="blue"
+                  >
+                    {tx.customer.name}
+                  </Text>
+                ) : (
+                  "—"
+                )}
+              </Table.Td>
+              <Table.Td>{tx.name ?? <Text c="dimmed">—</Text>}</Table.Td>
+              <Table.Td>
+                <Badge color={typeColor[tx.type] ?? "gray"} variant="light">
+                  {tx.type}
+                </Badge>
+              </Table.Td>
+              <Table.Td>{formatCents(tx.amount)}</Table.Td>
+              <Table.Td>
+                <Group gap="xs" align="center">
+                  <Badge color={statusBadgeColor} leftSection={statusIcon} radius="sm" size="sm" variant="light">
+                    {tx.status}
+                  </Badge>
+                  <Text size="xs" c={isOverdue ? "red" : "dimmed"} fw={500}>
+                    {completedDate.format("DD MMM YYYY")}
+                  </Text>
+                  {isOverdue && (
+                    <Tooltip label="Pending transaction is overdue" withArrow>
+                      <IconAlertTriangle size={14} color="red" />
+                    </Tooltip>
+                  )}
+                </Group>
+              </Table.Td>
+              <Table.Td>
+                <Menu shadow="md" width={140} position="bottom-end">
+                  <Menu.Target>
+                    <ActionIcon variant="subtle" size="sm" aria-label="Actions">
+                      <IconDots size={14} />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item leftSection={<IconPencil size={14} />} onClick={() => onEdit(tx)}>
+                      Update
+                    </Menu.Item>
+                    <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => onDelete(tx)}>
+                      Delete
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+              </Table.Td>
+            </Table.Tr>
+          )
+        })}
+      </Table.Tbody>
+    </Table>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/transactions/transactions-table.tsx
+git commit -m "feat(web): add transactions table component"
+```
+
+---
+
+## Task 5: Build `TransactionForm` component
+
+**Files:**
+- Create: `apps/web/src/components/transactions/transaction-form.tsx`
+
+- [ ] **Step 1: Create the form**
+
+Create `apps/web/src/components/transactions/transaction-form.tsx` with this exact contents:
+
+```tsx
+import { Button, Group, NativeSelect, NumberInput, Stack, Textarea, TextInput } from "@mantine/core"
+import { DateInput } from "@mantine/dates"
+import { useForm } from "@mantine/form"
+import { useMemo } from "react"
+
+export type TransactionFormValues = {
+  name: string
+  notes: string
+  amountPounds: number
+  type: "BANK" | "CASH" | "PAYPAL"
+  status: "PENDING" | "COMPLETED"
+  completedDateBy: Date | null
+}
+
+export type TransactionFormSubmit = {
+  name: string | null
+  notes: string | null
+  amount: number
+  type: "BANK" | "CASH" | "PAYPAL"
+  status: "PENDING" | "COMPLETED"
+  completedDateBy: string
+}
+
+type TransactionFormProps = {
+  initialValues: TransactionFormValues
+  submitLabel: string
+  onSubmit: (values: TransactionFormSubmit) => void | Promise<void>
+  loading?: boolean
+}
+
+const toIsoDate = (d: Date) => {
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+export function TransactionForm({ initialValues, submitLabel, onSubmit, loading }: TransactionFormProps) {
+  const form = useForm<TransactionFormValues>({
+    mode: "uncontrolled",
+    initialValues,
+    validate: {
+      completedDateBy: (value) => (value ? null : "Date is required"),
+      amountPounds: (value) => (Number.isFinite(value) ? null : "Amount is required"),
+    },
+  })
+
+  const dateLabel = useMemo(
+    () => (form.getValues().status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [form.getValues().status],
+  )
+
+  return (
+    <form
+      onSubmit={form.onSubmit(async (values) => {
+        if (!values.completedDateBy) return
+        await onSubmit({
+          name: values.name.trim() || null,
+          notes: values.notes.trim() || null,
+          amount: Math.round(values.amountPounds * 100),
+          type: values.type,
+          status: values.status,
+          completedDateBy: toIsoDate(values.completedDateBy),
+        })
+      })}
+    >
+      <Stack>
+        <TextInput label="Name" placeholder="Transaction name" {...form.getInputProps("name")} />
+        <Textarea label="Notes" placeholder="Notes (optional)" autosize minRows={2} {...form.getInputProps("notes")} />
+        <Group grow>
+          <NativeSelect
+            label="Type"
+            data={[
+              { value: "BANK", label: "Bank" },
+              { value: "CASH", label: "Cash" },
+              { value: "PAYPAL", label: "PayPal" },
+            ]}
+            {...form.getInputProps("type")}
+          />
+          <NativeSelect
+            label="Status"
+            data={[
+              { value: "PENDING", label: "Pending" },
+              { value: "COMPLETED", label: "Completed" },
+            ]}
+            {...form.getInputProps("status")}
+          />
+        </Group>
+        <DateInput label={dateLabel} valueFormat="DD MMM YYYY" required {...form.getInputProps("completedDateBy")} />
+        <NumberInput
+          label="Amount"
+          prefix="£"
+          decimalScale={2}
+          fixedDecimalScale
+          step={0.01}
+          {...form.getInputProps("amountPounds")}
+        />
+        <Group justify="flex-end">
+          <Button type="submit" loading={loading}>
+            {submitLabel}
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  )
+}
+```
+
+If oxlint flags the `eslint-disable-next-line` comment as unrecognized, remove that comment line and replace `[form.getValues().status]` with the literal `[]` and accept the static label, OR move the label computation inline (re-evaluated on every render — fine). Simpler safer alternative if lint complains: drop `useMemo` entirely and compute inline:
+
+```tsx
+const dateLabel =
+  form.getValues().status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0. If `DateInput` value type is `string | null` instead of `Date | null` in this Mantine version, change the type alias `completedDateBy: Date | null` to `completedDateBy: string | null` and update `toIsoDate` to accept `string` (re-parse via `dayjs(value).format("YYYY-MM-DD")`). Re-run.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/transactions/transaction-form.tsx
+git commit -m "feat(web): add shared transaction form"
+```
+
+---
+
+## Task 6: Build `CreateTransactionDialog`
+
+**Files:**
+- Create: `apps/web/src/components/transactions/create-transaction-dialog.tsx`
+
+- [ ] **Step 1: Create the dialog**
+
+Create `apps/web/src/components/transactions/create-transaction-dialog.tsx` with this exact contents:
+
+```tsx
+import { Modal } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { TransactionForm, type TransactionFormSubmit } from "@/components/transactions/transaction-form"
+import { createTransaction } from "@/functions/transactions"
+
+type CreateTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  appointmentId: string
+  customerId: string
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+export function CreateTransactionDialog({
+  open,
+  onOpenChange,
+  appointmentId,
+  customerId,
+  invalidateKeys,
+}: CreateTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (values: TransactionFormSubmit) =>
+      createTransaction({ data: { ...values, appointmentId, customerId } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction created" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="New Transaction">
+      <TransactionForm
+        initialValues={{
+          name: "",
+          notes: "",
+          amountPounds: 0,
+          type: "BANK",
+          status: "PENDING",
+          completedDateBy: new Date(),
+        }}
+        submitLabel="Create"
+        loading={mutation.isPending}
+        onSubmit={(values) => mutation.mutateAsync(values)}
+      />
+    </Modal>
+  )
+}
+```
+
+If Task 5's type adjustment switched `completedDateBy` to `string | null`, change `completedDateBy: new Date()` here to a YYYY-MM-DD string built the same way as `toIsoDate(new Date())`.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/transactions/create-transaction-dialog.tsx
+git commit -m "feat(web): add create transaction dialog"
+```
+
+---
+
+## Task 7: Build `EditTransactionDialog`
+
+**Files:**
+- Create: `apps/web/src/components/transactions/edit-transaction-dialog.tsx`
+
+- [ ] **Step 1: Create the dialog**
+
+Create `apps/web/src/components/transactions/edit-transaction-dialog.tsx` with this exact contents:
+
+```tsx
+import { Modal } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { TransactionForm, type TransactionFormSubmit } from "@/components/transactions/transaction-form"
+import { updateTransaction } from "@/functions/transactions"
+
+type EditTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  transaction: {
+    id: string
+    name: string | null
+    notes: string | null
+    amount: number
+    type: "BANK" | "CASH" | "PAYPAL" | string
+    status: "PENDING" | "COMPLETED" | string
+    completedDateBy: string
+  }
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+export function EditTransactionDialog({
+  open,
+  onOpenChange,
+  transaction,
+  invalidateKeys,
+}: EditTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (values: TransactionFormSubmit) => updateTransaction({ data: { ...values, id: transaction.id } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction updated" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  const initialType: "BANK" | "CASH" | "PAYPAL" =
+    transaction.type === "BANK" || transaction.type === "CASH" || transaction.type === "PAYPAL"
+      ? transaction.type
+      : "BANK"
+  const initialStatus: "PENDING" | "COMPLETED" = transaction.status === "COMPLETED" ? "COMPLETED" : "PENDING"
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="Edit Transaction">
+      <TransactionForm
+        initialValues={{
+          name: transaction.name ?? "",
+          notes: transaction.notes ?? "",
+          amountPounds: transaction.amount / 100,
+          type: initialType,
+          status: initialStatus,
+          completedDateBy: new Date(transaction.completedDateBy),
+        }}
+        submitLabel="Save Changes"
+        loading={mutation.isPending}
+        onSubmit={(values) => mutation.mutateAsync(values)}
+      />
+    </Modal>
+  )
+}
+```
+
+Same `completedDateBy` type note from Task 6 applies: if Task 5 switched the form field to `string | null`, replace `new Date(transaction.completedDateBy)` here with `transaction.completedDateBy`.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/transactions/edit-transaction-dialog.tsx
+git commit -m "feat(web): add edit transaction dialog"
+```
+
+---
+
+## Task 8: Build `DeleteTransactionDialog`
+
+**Files:**
+- Create: `apps/web/src/components/transactions/delete-transaction-dialog.tsx`
+
+- [ ] **Step 1: Create the dialog**
+
+Create `apps/web/src/components/transactions/delete-transaction-dialog.tsx` with this exact contents:
+
+```tsx
+import { Button, Group, Modal, Stack, Text } from "@mantine/core"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { deleteTransaction } from "@/functions/transactions"
+
+type DeleteTransactionDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  transaction: {
+    id: string
+    name: string | null
+    amount: number
+    customer?: { name: string } | null
+  }
+  invalidateKeys: { queryKey: readonly unknown[] }[]
+}
+
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+
+export function DeleteTransactionDialog({
+  open,
+  onOpenChange,
+  transaction,
+  invalidateKeys,
+}: DeleteTransactionDialogProps) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: () => deleteTransaction({ data: { id: transaction.id } }),
+    onSuccess: () => {
+      for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onOpenChange(false)
+      notifications.show({ color: "green", message: "Transaction deleted" })
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="Delete Transaction">
+      <Stack>
+        <Text size="sm">
+          This will permanently remove the transaction
+          {transaction.name ? ` "${transaction.name}"` : ""} of {formatCents(transaction.amount)}
+          {transaction.customer ? ` for ${transaction.customer.name}` : ""}. This action cannot be undone.
+        </Text>
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button color="red" loading={mutation.isPending} onClick={() => mutation.mutate()}>
+            Delete
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/transactions/delete-transaction-dialog.tsx
+git commit -m "feat(web): add delete transaction dialog"
+```
+
+---
+
+## Task 9: Wire transactions into appointment route — loader prefetch + table card
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`
+
+- [ ] **Step 1: Add imports for transactions module**
+
+At the top of `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`, add the new imports alongside the existing ones (keep alphabetical groups). Do not touch the `@tabler/icons-react` import yet (Tasks 10/11 will add their own icons).
+
+Add new imports below the existing component imports:
+
+```tsx
+import { CreateTransactionDialog } from "@/components/transactions/create-transaction-dialog"
+import { DeleteTransactionDialog } from "@/components/transactions/delete-transaction-dialog"
+import { EditTransactionDialog } from "@/components/transactions/edit-transaction-dialog"
+import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
+import { getTransactionsByAppointmentId } from "@/functions/transactions"
+```
+
+In the existing `@/lib/query-keys` import line, add `transactionKeys`:
+
+```tsx
+import { appointmentKeys, customerKeys, hairAssignedKeys, transactionKeys } from "@/lib/query-keys"
+```
+
+- [ ] **Step 2: Add prefetch in route loader**
+
+Inside the `loader` array passed to `Promise.all`, add a third prefetch entry. The full loader becomes:
+
+```tsx
+loader: async ({ context, params }) => {
+  await Promise.all([
+    context.queryClient.prefetchQuery(
+      queryOptions({
+        queryKey: appointmentKeys.detail(params.appointmentId),
+        queryFn: () => getAppointment({ data: { id: params.appointmentId } }),
+      }),
+    ),
+    context.queryClient.prefetchQuery(
+      queryOptions({
+        queryKey: hairAssignedKeys.byAppointment(params.appointmentId),
+        queryFn: () => getHairAssignedByAppointment({ data: { appointmentId: params.appointmentId } }),
+      }),
+    ),
+    context.queryClient.prefetchQuery(
+      queryOptions({
+        queryKey: transactionKeys.byAppointment(params.appointmentId),
+        queryFn: () => getTransactionsByAppointmentId({ data: { appointmentId: params.appointmentId } }),
+      }),
+    ),
+  ])
+},
+```
+
+- [ ] **Step 3: Add transactions query, state hooks, and invalidate key inside `AppointmentDetailPage`**
+
+Locate the `useQuery` calls inside `AppointmentDetailPage`. Just below the existing `hairAssigned` query, add:
+
+```tsx
+const { data: transactions } = useQuery({
+  queryKey: transactionKeys.byAppointment(appointmentId),
+  queryFn: () => getTransactionsByAppointmentId({ data: { appointmentId } }),
+})
+```
+
+Add new state hooks alongside the existing `createOpen`, `editItem`, `deleteItem`, `pickPersonnelOpen`:
+
+```tsx
+const [createTxOpen, setCreateTxOpen] = useState(false)
+const [createTxCustomerId, setCreateTxCustomerId] = useState<string | null>(null)
+const [editTx, setEditTx] = useState<TransactionRow | null>(null)
+const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
+```
+
+After the existing `invalidateKeys` declaration, add:
+
+```tsx
+const txInvalidateKeys = [{ queryKey: transactionKeys.byAppointment(appointmentId) }]
+
+const openCreateTx = (customerId: string) => {
+  setCreateTxCustomerId(customerId)
+  setCreateTxOpen(true)
+}
+```
+
+- [ ] **Step 4: Add the Transactions card before the existing Notes card**
+
+Locate the existing `<Card withBorder>` whose title is `Notes` (the one wrapping `appointment.notes`). Immediately before it, insert this new card:
+
+```tsx
+<Card withBorder>
+  <Group justify="space-between" mb="sm">
+    <Title order={5}>Transactions</Title>
+    <Button
+      variant="subtle"
+      size="xs"
+      leftSection={<IconPlus size={12} />}
+      onClick={() => openCreateTx(appointment.client.id)}
+    >
+      New
+    </Button>
+  </Group>
+  <TransactionsTable items={transactions ?? []} onEdit={setEditTx} onDelete={setDeleteTx} />
+</Card>
+```
+
+- [ ] **Step 5: Render the three dialogs at the bottom of the returned JSX**
+
+Inside the outer `<Stack>`, after the `<PickPersonnelModal ... />` (the last existing JSX element), append:
+
+```tsx
+<CreateTransactionDialog
+  open={createTxOpen}
+  onOpenChange={(open) => {
+    setCreateTxOpen(open)
+    if (!open) setCreateTxCustomerId(null)
+  }}
+  appointmentId={appointmentId}
+  customerId={createTxCustomerId ?? appointment.client.id}
+  invalidateKeys={txInvalidateKeys}
+/>
+{editTx && (
+  <EditTransactionDialog
+    open={!!editTx}
+    onOpenChange={(open) => !open && setEditTx(null)}
+    transaction={editTx}
+    invalidateKeys={txInvalidateKeys}
+  />
+)}
+{deleteTx && (
+  <DeleteTransactionDialog
+    open={!!deleteTx}
+    onOpenChange={(open) => !open && setDeleteTx(null)}
+    transaction={deleteTx}
+    invalidateKeys={txInvalidateKeys}
+  />
+)}
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 7: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 8: Manual verification**
+
+Start dev server (in a separate terminal):
+
+```bash
+bun run dev:web
+```
+
+Open `http://localhost:3001` in a browser, sign in, navigate to `/appointments` → pick an appointment.
+
+Verify:
+- "Transactions" card renders below "Hair Assigned"/"Personnel" group, above "Notes".
+- Empty state shows "No transactions." (assuming none exist).
+- Click "New" → modal opens with form fields (Name, Notes, Type, Status, Date, Amount).
+- Submit a transaction → notification "Transaction created", row appears in table.
+- Row "Update" action opens edit dialog with prefilled values; saving updates the row.
+- Row "Delete" action opens confirm dialog; confirming removes the row.
+- Type Badge color: BANK=teal, CASH=blue, PAYPAL=grape.
+- Status Badge: COMPLETED=green check, PENDING=pink clock.
+- Pending transaction with past date shows red date text + warning triangle icon.
+- Customer name in row links to `/customers/$customerId`.
+
+Stop the dev server (Ctrl+C).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+git commit -m "feat(web): wire transactions table + CRUD into appointment page"
+```
+
+---
+
+## Task 10: Add Transactions Summary card with DonutChart
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`
+
+- [ ] **Step 1: Add chart import + IconCash**
+
+At the top of the route file, after the existing Mantine imports, add:
+
+```tsx
+import { DonutChart } from "@mantine/charts"
+```
+
+In the existing `@tabler/icons-react` import line, add `IconCash` (kept alphabetical):
+
+```tsx
+import { IconArrowLeft, IconCash, IconClock, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
+```
+
+If oxlint orders imports differently, run `bun run check` and let oxfmt rewrite.
+
+- [ ] **Step 2: Compute summary totals inside the component**
+
+Inside `AppointmentDetailPage`, after the `transactions` query, add:
+
+```tsx
+const txList = transactions ?? []
+const completedSum = txList
+  .filter((t) => t.status === "COMPLETED")
+  .reduce((acc, t) => acc + t.amount, 0)
+const pendingSum = txList
+  .filter((t) => t.status === "PENDING")
+  .reduce((acc, t) => acc + t.amount, 0)
+const totalSum = txList.reduce((acc, t) => acc + t.amount, 0)
+const chartData = [
+  { name: "Completed", value: Math.abs(completedSum), color: "green.4" },
+  { name: "Pending", value: Math.abs(pendingSum), color: "pink.6" },
+]
+const formatCents = (cents: number) => `£${(cents / 100).toFixed(2)}`
+```
+
+- [ ] **Step 3: Insert the summary card right before the Transactions card**
+
+Immediately before the `<Card withBorder>` for "Transactions" added in Task 9, insert:
+
+```tsx
+<Card withBorder>
+  <Group justify="space-between" mb="sm">
+    <Title order={5}>
+      <Group gap={6}>
+        <IconCash size={14} />
+        Transactions Summary
+      </Group>
+    </Title>
+  </Group>
+  {totalSum === 0 ? (
+    <Text size="sm" c="dimmed">
+      No transactions yet.
+    </Text>
+  ) : (
+    <Group align="center" gap="xl">
+      <DonutChart size={124} thickness={15} data={chartData} withLabels={false} />
+      <Stack gap={2}>
+        <Text size="sm">
+          Completed: <b>{formatCents(completedSum)}</b>
+        </Text>
+        <Text size="sm">
+          Pending: <b>{formatCents(pendingSum)}</b>
+        </Text>
+        <Text size="sm">
+          Total: <b>{formatCents(totalSum)}</b>
+        </Text>
+      </Stack>
+    </Group>
+  )}
+</Card>
+```
+
+- [ ] **Step 4: Add Mantine charts CSS to the root layout**
+
+Mantine charts requires its CSS imported once. Open `apps/web/src/routes/__root.tsx` and verify whether `@mantine/charts/styles.css` is already imported. If not, add it after the existing Mantine CSS imports:
+
+```tsx
+import "@mantine/charts/styles.css"
+```
+
+If `__root.tsx` does not exist or imports differ, search for the file that imports `@mantine/core/styles.css` (run `grep -rn "@mantine/core/styles" apps/web/src`) and add the charts CSS import there in the same group.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 7: Manual verification**
+
+Start dev server:
+
+```bash
+bun run dev:web
+```
+
+Navigate to an appointment with at least one COMPLETED and one PENDING transaction. Verify:
+- "Transactions Summary" card renders above the Transactions card.
+- Donut shows green slice = completed sum, pink slice = pending sum.
+- Right-side text lines display correctly formatted £ totals.
+- With zero transactions, summary card shows "No transactions yet." (no donut).
+
+Stop the dev server.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx apps/web/src/routes/__root.tsx
+git commit -m "feat(web): add appointment transactions donut summary"
+```
+
+If `__root.tsx` was untouched (CSS already imported elsewhere), drop it from the `git add`.
+
+---
+
+## Task 11: Per-personnel "New transaction" action
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`
+
+- [ ] **Step 1: Replace personnel row with menu-equipped layout**
+
+Locate the existing personnel rendering inside the Personnel `<Card>`:
+
+```tsx
+{appointment.personnel.map((p) => (
+  <Card key={p.personnelId} withBorder padding="xs">
+    <Group gap="xs">
+      <IconUser size={12} />
+      <Text size="sm">{p.personnel.name}</Text>
+    </Group>
+  </Card>
+))}
+```
+
+Replace with:
+
+```tsx
+{appointment.personnel.map((p) => (
+  <Card key={p.personnelId} withBorder padding="xs">
+    <Group justify="space-between" gap="xs">
+      <Group gap="xs">
+        <IconUser size={12} />
+        <Text size="sm">{p.personnel.name}</Text>
+      </Group>
+      <Menu shadow="md" width={180} position="bottom-end">
+        <Menu.Target>
+          <ActionIcon variant="subtle" size="sm" aria-label="Personnel actions">
+            <IconDots size={14} />
+          </ActionIcon>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item leftSection={<IconCash size={14} />} onClick={() => openCreateTx(p.personnelId)}>
+            New transaction
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </Group>
+  </Card>
+))}
+```
+
+- [ ] **Step 2: Add missing imports**
+
+Verify the imports at the top of the file include `ActionIcon` and `Menu` from `@mantine/core` (the existing top import block already imports `ActionIcon`; add `Menu` if missing). In the `@tabler/icons-react` import line add `IconDots` (kept alphabetical):
+
+```tsx
+import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
+```
+
+`IconCash` was already added in Task 10.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Manual verification**
+
+Start the dev server:
+
+```bash
+bun run dev:web
+```
+
+Navigate to an appointment that has at least one personnel assigned (use the existing "Pick" button to add one if needed). Verify:
+- Each personnel card shows a kebab/dots action button on the right.
+- Clicking it reveals a "New transaction" menu item.
+- Selecting it opens the Create Transaction modal with the personnel preselected as `customerId` (verify by submitting a row and checking that the new row's customer cell shows that personnel's name).
+- The "New" button in the Transactions card header still defaults to the appointment client.
+
+Stop the dev server.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+git commit -m "feat(web): add per-personnel new-transaction action"
+```
+
+---
+
+## Task 12: Flip customer-detail currency from `$` to `£`
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/customers/$customerId.tsx:87`
+
+- [ ] **Step 1: Replace the formatCurrency definition**
+
+In `apps/web/src/routes/_authenticated/customers/$customerId.tsx`, find:
+
+```tsx
+const formatCurrency = (n: number) => `$${n.toFixed(2)}`
+```
+
+Replace with:
+
+```tsx
+const formatCurrency = (n: number) => `£${n.toFixed(2)}`
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+bun run check-types
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+bun run check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Manual verification**
+
+Start the dev server:
+
+```bash
+bun run dev:web
+```
+
+Navigate to `/customers` → pick a customer with non-zero transaction sum. Verify:
+- Stat cards now show `£` prefix on Transactions, Hair Profit, Hair Sold For (previously `$`).
+
+Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/customers/$customerId.tsx
+git commit -m "fix(web): use £ symbol on customer summary stats"
+```
+
+---
+
+## Task 13: End-to-end manual verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full type-check + lint**
+
+```bash
+bun run check-types && bun run check
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 2: Start dev server**
+
+```bash
+bun run dev:web
+```
+
+- [ ] **Step 3: Walk the manual checklist from the spec**
+
+Open `http://localhost:3001`, sign in, then for an existing appointment with at least one personnel assigned:
+
+- [ ] Create transaction (default customer = appointment client) — appears in table with correct fields, Customer column links to that client.
+- [ ] Create transaction from a personnel row — `customerId` matches the personnel.
+- [ ] Edit transaction — change name/amount/status/date — updates persist after modal close, table refreshes.
+- [ ] Delete transaction — confirm dialog → row removed.
+- [ ] Pending transaction with completedDateBy in the past — shows red date text + warning triangle icon.
+- [ ] Donut chart Completed slice = sum of COMPLETED amounts; Pending slice = sum of PENDING amounts; Total caption matches.
+- [ ] Customer-name cell links to `/customers/$customerId`.
+- [ ] `formatCurrency` on customer detail now shows `£`.
+- [ ] Empty state: appointment with zero transactions shows "No transactions." in the table card and "No transactions yet." in the summary card.
+- [ ] Refunds: amount entered as `-12.34` saves and displays as `-£12.34`.
+
+Stop the dev server (Ctrl+C).
+
+- [ ] **Step 4: No commit (verification only)**
+
+If any check fails, return to the relevant task and fix. Otherwise the branch is ready for PR.
+
+---
+
+## Done
+
+After all tasks pass, the branch `feature/appointment-transactions` is ready to push and open a PR. Suggested PR title:
+
+```
+feat(web): restore transactions UI on appointment detail page
+```
+
+PR description should reference the spec at `docs/superpowers/specs/2026-04-27-appointment-transactions-design.md`.

--- a/docs/superpowers/specs/2026-04-27-appointment-transactions-design.md
+++ b/docs/superpowers/specs/2026-04-27-appointment-transactions-design.md
@@ -1,0 +1,152 @@
+# Appointment Transactions UI — Design
+
+**Date:** 2026-04-27
+**Status:** Approved (brainstorm)
+**Scope:** Restore transactions UI on `/appointments/$appointmentId` to match `main_backup` behaviour, using current TanStack Start + Drizzle conventions.
+
+## Background
+
+The `transaction` table already exists in `packages/db/src/schema/transaction.ts` with FKs:
+
+- `customerId` → `customer.id` (cascade)
+- `orderId` → `order.id` (set null, nullable)
+- `appointmentId` → `appointment.id` (set null, nullable)
+
+No FK to `hair_orders` (intentionally removed in `main_backup` migration `20250509124115_removed_transactions_from_hair_order`).
+
+The current TanStack Start app has zero transaction CRUD UI. The customer detail page shows a `transactionSum` stat card (already wired through `getCustomerSummary`). Appointment and hair-order pages have no transaction surfaces.
+
+In `main_backup`:
+
+- `/customers/[id]` — summary stat only (already migrated equivalent).
+- `/appointments/[id]` — full transactions table + donut chart + create/edit/delete drawers + per-personnel "New transaction" action + client-card "New transaction" action.
+- `/hair-orders/[id]` — no transactions UI.
+
+## Goals
+
+1. Add full transactions surface on `/appointments/$appointmentId` (table, summary chart, create/edit/delete).
+2. Add per-personnel "New transaction" action on the appointment Personnel card.
+3. Match existing TanStack Start app conventions (Drizzle, server functions, Modal-based dialogs, `formatCents` helper, Mantine UI).
+
+## Non-goals
+
+- `/transactions` standalone page.
+- Customer-detail transactions list / CRUD (stat stays as-is).
+- Hair-order transactions (no FK; would require schema change — explicitly out).
+- Order-linked transactions UI.
+- CSV import (main_backup feature).
+
+## Decisions
+
+| # | Decision |
+|---|----------|
+| Currency | `£` symbol everywhere transactions display. Also flip `formatCurrency` in `apps/web/src/routes/_authenticated/customers/$customerId.tsx` from `$` → `£` for consistency. |
+| Amount unit | Cents on the wire and in DB (matches existing app). Form input takes pounds (decimal); server multiplies by 100 on insert/update. Display divides by 100 via `formatCents`. |
+| Dialog style | Mantine `Modal` (matches current hair-assigned / customer dialogs). |
+| Summary chart | `@mantine/charts` `DonutChart` (Completed vs Pending). Add dep. |
+| Entry points | (a) "New" button in Transactions card header. (b) Per-personnel row action "New transaction" preselecting that personnel as customer. |
+| Row actions | Update + Delete (no "View Transaction" — no transactions detail page in scope). Customer name cell links to `/customers/$customerId`. |
+
+## Architecture
+
+### Data layer — `apps/web/src/functions/transactions.ts` (new)
+
+Server functions using `createServerFn` with the existing auth-guard pattern (matches `apps/web/src/functions/appointments.ts`, `hair-assigned.ts`). Drizzle queries against the existing `transaction` table.
+
+| Function | Input | Output / Behaviour |
+|----------|-------|-------------------|
+| `getTransactionsByAppointmentId` | `{ appointmentId: string }` | Returns transactions for the appointment, joined with `customer` (id, name). Ordered by `completedDateBy` ascending. |
+| `createTransaction` | `{ appointmentId, customerId, name?, notes?, amount: number (cents), type: "BANK"|"CASH"|"PAYPAL", status: "PENDING"|"COMPLETED", completedDateBy: string (YYYY-MM-DD) }` | Inserts row. Validates `customerId` is the appointment client OR a personnel attached to the appointment. |
+| `updateTransaction` | `{ id, name?, notes?, amount, type, status, completedDateBy: string (YYYY-MM-DD) }` | Updates fields. `customerId`, `appointmentId`, `orderId` immutable. |
+| `deleteTransaction` | `{ id }` | Hard delete. |
+
+Validation: `zod` schemas inline (matches existing functions).
+
+Errors: server fns throw `Error` with a user-readable message; React Query `onError` surfaces via `notifications.show({ color: "red", ... })`. No special 404 — the appointment route already 404s before transactions render.
+
+### Query keys — `apps/web/src/lib/query-keys.ts`
+
+Add:
+
+```ts
+export const transactionKeys = {
+  all: ["transactions"] as const,
+  byAppointment: (appointmentId: string) =>
+    [...transactionKeys.all, "by-appointment", appointmentId] as const,
+}
+```
+
+Mutations (create / update / delete) invalidate `transactionKeys.byAppointment(appointmentId)`.
+
+### UI components — `apps/web/src/components/transactions/` (new)
+
+| File | Purpose |
+|------|---------|
+| `transactions-table.tsx` | `<TransactionsTable items={...} onEdit onDelete />`. Mantine `Table`. Columns: Customer (Link), Name, Type (Badge: BANK=teal, CASH=blue, PAYPAL=grape), Amount (`formatCents`), Completed (Badge + date, red if overdue), Actions (`ActionIcon` menu → Update / Delete). Empty state: dimmed "No transactions." |
+| `transaction-form.tsx` | Shared form used by create + edit dialogs. Fields: Name (TextInput), Notes (Textarea), Type (NativeSelect), Status (NativeSelect), CompletedDateBy (`@mantine/dates` `DateInput`, label flips by status — value normalized to YYYY-MM-DD on submit), Amount (NumberInput, prefix `£`, decimal). Submit emits cents-normalized payload (`Math.round(pounds * 100)`). |
+| `create-transaction-dialog.tsx` | Mantine `Modal`. Calls `createTransaction`. Props: `open`, `onOpenChange`, `appointmentId`, `customerId`, `invalidateKeys`. |
+| `edit-transaction-dialog.tsx` | Mantine `Modal`. Calls `updateTransaction`. Initial amount = `cents / 100`. |
+| `delete-transaction-dialog.tsx` | Mantine `Modal` confirm. Calls `deleteTransaction`. |
+
+### Route integration — `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`
+
+**Loader:** add prefetch for `transactionKeys.byAppointment(appointmentId)`.
+
+**Component:**
+
+- `useQuery` for transactions.
+- Compute `completedSum`, `pendingSum`, `totalSum` (sum of all amounts).
+- DonutChart `chartData = [{ name: "Completed", value: |completedSum|, color: "green.4" }, { name: "Pending", value: |pendingSum|, color: "pink.6" }]`.
+- New cards (after the existing Personnel/Hair Assigned `Group grow`, before Notes):
+  - **Transactions Summary card** — `DonutChart size={124} thickness={15}` + caption `Total: £{(totalSum/100).toFixed(2)}`.
+  - **Transactions card** — header "Transactions" + "New" button → `<CreateTransactionDialog>` with `customerId = appointment.client.id`. Body = `<TransactionsTable>`.
+- Personnel card update: each personnel row gains a row-action "New transaction" → opens `<CreateTransactionDialog>` with `customerId = p.personnelId`.
+- State hooks: `editTx`, `deleteTx` mirroring hair-assigned pattern.
+- Invalidate keys passed to dialogs: `[{ queryKey: transactionKeys.byAppointment(appointmentId) }]`.
+
+**Side cleanup (in scope):** flip `formatCurrency` in `apps/web/src/routes/_authenticated/customers/$customerId.tsx` from `$` to `£`.
+
+### Dependencies
+
+- Add `@mantine/charts` to `apps/web/package.json` (matching `@mantine/core` major).
+- `@mantine/dates` already present.
+
+## Edge cases
+
+| Case | Behaviour |
+|------|-----------|
+| Empty transactions list | Table renders dimmed "No transactions." |
+| Personnel not yet picked | "New" still works for client. |
+| Customer deleted | Transaction cascade-deletes (existing FK behaviour, no action needed). |
+| Appointment deleted | Transaction `appointmentId` set null, row persists (existing FK; out of scope). |
+| Overdue | `status === "PENDING" && completedDateBy < today` → red date text + warning icon. |
+| Negative amounts | Allowed (refunds). `NumberInput` has no `min`. |
+
+## Testing
+
+No automated test infra in repo today. Manual verification checklist (to be expanded in implementation plan):
+
+- [ ] Create transaction (default customer = appointment client) — appears in table with correct fields.
+- [ ] Create transaction from personnel row — `customerId` matches personnel.
+- [ ] Edit transaction — updates persist, table refreshes.
+- [ ] Delete transaction — row removed.
+- [ ] Pending transaction with past date — shows red overdue indicator.
+- [ ] Donut chart matches Completed vs Pending sums.
+- [ ] Customer-name cell links to `/customers/$customerId`.
+- [ ] `formatCurrency` on customer detail now shows `£`.
+
+## Files touched
+
+**New:**
+- `apps/web/src/functions/transactions.ts`
+- `apps/web/src/components/transactions/transactions-table.tsx`
+- `apps/web/src/components/transactions/transaction-form.tsx`
+- `apps/web/src/components/transactions/create-transaction-dialog.tsx`
+- `apps/web/src/components/transactions/edit-transaction-dialog.tsx`
+- `apps/web/src/components/transactions/delete-transaction-dialog.tsx`
+
+**Modified:**
+- `apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx`
+- `apps/web/src/routes/_authenticated/customers/$customerId.tsx` (currency symbol only)
+- `apps/web/src/lib/query-keys.ts` (add `transactionKeys`)
+- `apps/web/package.json` (add `@mantine/charts`)


### PR DESCRIPTION
## Summary
- Adds full CRUD for transactions on the appointment page: shared form, create/edit/delete dialogs, and a transactions table with overdue + paid styling.
- Adds a donut summary for appointment transactions plus a per-personnel "new transaction" quick action; uses £ symbol on customer summary stats.
- Adds `transactions` server functions (wrapped in `db.transaction` where appropriate), `transactionKeys` query-key factory, `@mantine/charts` dependency, and supporting design/plan docs.

## Test plan
- [ ] Create, edit, delete a transaction on an appointment; confirm cache invalidation and overdue/paid styling.
- [ ] Open the per-personnel "new transaction" action and submit; verify dateLabel reacts to status changes.
- [ ] Verify donut summary numbers match the table totals; customer summary stats render with £.
- [ ] Confirm overdue tooltip is keyboard accessible.