### PR TITLE
ci(deps): add nightly taze major workflow

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -1,0 +1,51 @@
+name: Nightly Dependency Updates
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  taze:
+    name: Run taze major
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Load PAT from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DEPS_PAT: op://prive-admin/github-pat/token
+
+      - name: Run taze major
+        run: bunx taze major -r -w
+
+      - name: Update Lockfile
+        run: bun install
+
+      - name: Create or Update Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ env.DEPS_PAT }}
+          branch: chore/auto-dep-updates
+          base: main
+          commit-message: "chore(deps): bump dependencies via taze major"
+          title: "chore(deps): nightly dependency updates"
+          body: |
+            Automated nightly run of `bunx taze major -r -w` followed by `bun install`.
+
+            This PR is updated each night with any newly outdated packages until merged or closed.
+          labels: dependencies
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deps-update.yml`: nightly cron at 03:00 UTC (also `workflow_dispatch`).
- Runs `bunx taze major -r -w` then `bun install`, opens or updates a PR on fixed branch `chore/auto-dep-updates`.
- Auth via PAT loaded from 1Password (`op://prive-admin/github-pat/token`) so the auto-PR triggers `pr-build.yml` (a `GITHUB_TOKEN`-authored PR would not).

## Prereqs before first run
- [x] Create item `github-pat` in 1Password vault `prive-admin`, field `token` set to a fine-grained PAT scoped to this repo (Contents r/w, Pull requests r/w, Workflows r/w).
- [x] Confirm the existing `OP_SERVICE_ACCOUNT_TOKEN` service account has read access to that vault item.
- [x] Settings → Actions → General → Workflow permissions → enable "Allow GitHub Actions to create and approve pull requests".

## Test plan
- [ ] After merge + prereqs, trigger manually: `gh workflow run "Nightly Dependency Updates"`.
- [ ] Verify auto-PR opens on branch `chore/auto-dep-updates` and CI runs against it.
- [ ] Re-run workflow with no new updates → no churn (action is a no-op when diff is empty).
- [ ] Re-run after a new outdated package appears → existing PR is updated, not duplicated.