### PR TITLE
ci(deps): correct 1Password reference for DEPS_PAT

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -27,7 +27,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          DEPS_PAT: op://prive-admin/github-pat/token
+          DEPS_PAT: op://prive-admin/PAT prive-admin deps bot/token
 
       - name: Run taze major
         run: bunx taze major -r -w


### PR DESCRIPTION
## Summary
- Fixes `DEPS_PAT` 1Password secret reference in `.github/workflows/deps-update.yml` to match the real item title (`PAT prive-admin deps bot`). The placeholder `github-pat` from #106 does not resolve.

## Test plan
- [ ] After merge, trigger manually: `gh workflow run "Nightly Dependency Updates"`.
- [ ] Confirm `Load PAT from 1Password` step succeeds and downstream `Create or Update Pull Request` step authenticates with the PAT.