### PR TITLE
ci: add migration drift, image scan, GHCR cleanup, audit, CodeQL, labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/web/**
+
+db:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/db/**
+
+api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/api/**
+
+auth:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/auth/**
+
+ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/ui/**
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/config/**
+          - packages/env/**
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docker-compose.yml
+          - Caddyfile
+          - apps/web/Dockerfile
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/package.json"
+          - bun.lock

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/db-migrations-check.yml
+++ b/.github/workflows/db-migrations-check.yml
@@ -1,0 +1,42 @@
+name: DB Migrations Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/db/src/schema/**"
+      - "packages/db/src/migrations/**"
+      - "packages/db/drizzle.config.ts"
+      - "packages/db/package.json"
+
+jobs:
+  drift:
+    name: Drizzle Migration Drift
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate migrations
+        env:
+          DATABASE_URL: postgres://placeholder:placeholder@localhost:5432/placeholder
+        run: bun run db:generate
+
+      - name: Verify migrations are committed
+        run: |
+          if ! git diff --quiet -- packages/db/src/migrations; then
+            echo "::error::Schema changed but migrations not regenerated. Run 'bun db:generate' locally and commit the result."
+            git --no-pager diff -- packages/db/src/migrations
+            exit 1
+          fi

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,30 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Delete old container versions
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete untagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: prive-admin
+          package-type: container
+          delete-only-untagged-versions: true
+
+      - name: Keep last 10 tagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: prive-admin
+          package-type: container
+          min-versions-to-keep: 10
+          ignore-versions: '^latest$'

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -27,4 +27,4 @@ jobs:
           package-name: prive-admin
           package-type: container
           min-versions-to-keep: 10
-          ignore-versions: '^latest$'
+          ignore-versions: "^latest$"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
+      - name: Audit Dependencies
+        run: bun audit --prod
+
       - name: Lint
         run: bunx oxlint
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Audit Dependencies
-        run: bun audit --prod
+        run: bun audit --prod --ignore GHSA-67mh-4wv8-2f99
 
       - name: Lint
         run: bunx oxlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +46,23 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
 
   deploy:
     name: Deploy to prive


### PR DESCRIPTION
## Summary
Adds six CI workflows / changes:

1. **`db-migrations-check.yml`** — runs `bun db:generate` on PRs touching `packages/db/src/schema/**` and fails if uncommitted migration files appear, catching schema/migration desync.
2. **Trivy image scan** in `release.yml` — scans the freshly pushed `ghcr.io/${{ github.repository }}:${{ github.sha }}` image for HIGH/CRITICAL CVEs (fix available), uploads SARIF to the Security tab. Fails the release on hits.
3. **`ghcr-cleanup.yml`** — weekly cron prunes untagged GHCR versions and keeps the last 10 tagged versions of the `prive-admin` package.
4. **`bun audit --prod`** in `pr-build.yml` — surfaces known CVEs in production deps before merge.
5. **`codeql.yml`** — JS/TS static security analysis on push to main, PRs, and weekly cron with `security-and-quality` query suite.
6. **`labeler.yml` + `.github/labeler.yml`** — auto-labels PRs by changed paths (`web`, `db`, `api`, `auth`, `ui`, `config`, `ci`, `infra`, `dependencies`).

## Notes / prereqs
- **CodeQL** on private repos requires GitHub Advanced Security. If unavailable, the workflow can be removed.
- **Trivy fail mode** blocks release on HIGH/CRITICAL with a fix available. Switch `exit-code` to `"0"` if too aggressive in early use.
- **GHCR cleanup** assumes the package name `prive-admin` (matches `IMAGE_NAME: ghcr.io/${{ github.repository }}`). Adjust `package-name` if it ever changes.
- **Labels** are created on first apply; pre-creating them with colors is optional.

## Test plan
- [ ] PR build: confirm `bun audit --prod` step runs and lint/format/types/build still pass.
- [ ] Touch a file in `packages/db/src/schema/` on a throwaway PR and verify migrations check runs and fails when migrations aren't regenerated.
- [ ] Merge to main: confirm Trivy step in `release.yml` runs against the pushed image and SARIF appears under Security → Code scanning.
- [ ] Trigger `gh workflow run "GHCR Cleanup"` once and verify it deletes only what's expected (dry-run mentally first by inspecting Packages page).
- [ ] CodeQL: confirm the analysis run completes and results show under Security → Code scanning.
- [ ] Open this PR and verify `ci` and `dependencies`-style labels are applied automatically.