### PR TITLE
ci(release): gate release on web@* tags

### DIFF
--- a/.changeset/release-on-tag.md
+++ b/.changeset/release-on-tag.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: gate release pipeline on web@* tag pushes

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -34,10 +34,11 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Tag
         uses: changesets/action@v1
         with:
           version: bunx changeset version
+          publish: bunx changeset tag
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "web@*"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -20,5 +20,5 @@
   "experimentalSortPackageJson": {
     "sortScripts": false
   },
-  "ignorePatterns": [".agents", "**/*.html", "docs", "routeTree.gen.ts", "packages/db/src/migrations"]
+  "ignorePatterns": [".agents", ".changeset", "**/*.html", "docs", "routeTree.gen.ts", "packages/db/src/migrations"]
 }


### PR DESCRIPTION
## Summary
Gates the deploy pipeline so it only runs when a Version PR is merged, not on every feature merge.

- `release.yml` trigger changed from `push: branches: [main]` to `push: tags: ["web@*"]`. `workflow_dispatch` retained for manual deploys.
- `changeset-release.yml` gains `publish: bunx changeset tag`. After a Version PR is merged, `changesets/action@v1` runs the publish step (since no changesets remain), creating `web@<version>` tags and pushing them. Pushed tags fire `release.yml` → Docker build → deploy.

## Flow
1. Feature PR → must include changeset → merge.
2. `changeset-release.yml` opens / updates `Version Packages` PR.
3. Merge `Version Packages` PR → versions bumped on `main`, `bunx changeset tag` pushes `web@x.y.z` tag.
4. Tag push triggers `release.yml` → Docker build + deploy.

## Notes
- Docker tags remain `:latest` and `:${{ github.sha }}`. Avoiding `:web@x.y.z` because `@` is invalid in OCI tags.
- Empty changeset included so the new `Changeset Check` workflow passes on this PR.

## Test plan
- [ ] Merge this PR. Confirm `release.yml` does NOT trigger from the merge commit.
- [ ] On a follow-up feature PR with a real changeset, merge it and confirm a `Version Packages` PR is opened.
- [ ] Merge the Version PR. Confirm `web@<version>` tag appears under Tags and `release.yml` runs against the tag ref.
- [ ] Verify deploy step still finds the right image tag (`${{ github.sha }}` is the tagged commit's SHA — matches the build).