### PR TITLE
chore: test release pipeline end-to-end

### DIFF
--- a/.changeset/test-release-chain.md
+++ b/.changeset/test-release-chain.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+chore: verify changeset → version PR → tag → release pipeline end-to-end

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "web",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
End-to-end test of the changeset → version PR → tag → release chain.

- Adds `version: "0.0.0"` to `apps/web/package.json` so changesets can bump it. Without a `version` field, changesets silently skips the package.
- Adds a real (non-empty) changeset bumping `web` at patch.

## Expected flow after merge
1. `Changeset Release` workflow opens a `Version Packages` PR setting `web` to `0.0.1`.
2. Merging that PR pushes commit to main and creates `web@0.0.1` tag.
3. `Release` workflow fires from the tag → Docker build + deploy.

## Follow-up (separate PR)
- Add `version: "0.0.0"` + `private: true` to the other packages without versions (`@prive-admin-tanstack/auth`, `@prive-admin-tanstack/db`) so they can also be tracked by changesets.
- `packages/api` has no `package.json` — investigate.

## Test plan
- [ ] `Changeset Check` passes on this PR.
- [ ] After merge, `Changeset Release` opens a Version PR with `web 0.0.0 → 0.0.1`.
- [ ] Merging the Version PR creates tag `web@0.0.1`.
- [ ] Tag triggers `Release` workflow.