### PR TITLE
ci: auto-tag web releases; trim CodeQL triggers

### DIFF
--- a/.changeset/auto-tag-and-trim-codeql.md
+++ b/.changeset/auto-tag-and-trim-codeql.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: replace bunx changeset tag with custom tag script; trim CodeQL triggers

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -38,7 +38,8 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bunx changeset version
-          publish: bunx changeset tag
+          publish: bash scripts/release-tag.sh
+          createGithubReleases: false
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,12 @@
 name: CodeQL
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
   schedule:
     - cron: "0 5 * * 1"
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=$(node -p "require('./apps/web/package.json').version")
+tag="web@${version}"
+
+if git rev-parse "${tag}" >/dev/null 2>&1; then
+  echo "Tag ${tag} already exists, skipping"
+  exit 0
+fi
+
+git tag "${tag}"
+echo "🦋  New tag: ${tag}"


### PR DESCRIPTION
## Summary

### Auto-tag fix
`bunx changeset tag` silently skips packages with `"private": true`, so the previous Version PR (#113) merged but produced no `web@0.0.1` tag — the release pipeline never fired automatically. Tag was pushed manually for that release.

Replaces `publish: bunx changeset tag` with `publish: bash scripts/release-tag.sh`. The script:
- reads the current version from `apps/web/package.json`,
- creates a `web@<version>` tag if missing,
- echoes `🦋  New tag: web@<version>` so `changesets/action@v1` recognizes a "publish" happened and pushes tags to origin.

`createGithubReleases: false` added because we are not publishing to npm; default `true` would otherwise try to create empty Releases.

### CodeQL load reduction
`codeql.yml` previously ran on every push to `main`, every PR, and weekly. Trimmed to just PR + weekly cron + `workflow_dispatch`. Findings on main come from the weekly run; PR diffs are still scanned before merge.

## Test plan
- [ ] Confirm `web@0.0.1` tag triggered `release.yml` run from the manual push (validates tag-trigger chain).
- [ ] On the next merged feature PR + Version PR, confirm the auto-tag script creates and pushes `web@<new-version>` and that `release.yml` fires from the tag push.
- [ ] CodeQL no longer runs on push to `main`.