### PR TITLE
ci: single-version monorepo with root version and v* tags

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,16 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "web",
+      "@prive-admin-tanstack/auth",
+      "@prive-admin-tanstack/config",
+      "@prive-admin-tanstack/db",
+      "@prive-admin-tanstack/env",
+      "@prive-admin-tanstack/ui"
+    ]
+  ],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/single-version-monorepo.md
+++ b/.changeset/single-version-monorepo.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: switch to single-version monorepo with root version + v* tags

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Create Release Pull Request or Tag
         uses: changesets/action@v1
         with:
-          version: bunx changeset version
-          publish: bunx changeset tag
+          version: bash scripts/release-version.sh
+          publish: bash scripts/release-tag.sh
+          createGithubReleases: false
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,12 @@
 name: CodeQL
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
   schedule:
     - cron: "0 5 * * 1"
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "web@*"
+      - "v*"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "prive-admin-tanstack",
+  "version": "0.0.1",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@prive-admin-tanstack/auth",
+  "version": "0.0.1",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@prive-admin-tanstack/config",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@prive-admin-tanstack/db",
+  "version": "0.0.1",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prive-admin-tanstack/env",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prive-admin-tanstack/ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=$(node -p "require('./package.json').version")
+tag="v${version}"
+
+if git rev-parse "${tag}" >/dev/null 2>&1; then
+  echo "Tag ${tag} already exists, skipping"
+  exit 0
+fi
+
+git tag "${tag}"
+echo "🦋  New tag: ${tag}"

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bunx changeset version
+
+new_version=$(node -p "require('./apps/web/package.json').version")
+
+node -e "
+  const fs = require('fs');
+  const path = './package.json';
+  const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+  pkg.version = '${new_version}';
+  fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "Synced root package.json to ${new_version}"


### PR DESCRIPTION
## Summary
Replaces per-package versioning with a single shared version stored in root `package.json`. All internal packages bump together via changesets `fixed` group, root mirrors the result, release tag is `v<version>`.

Supersedes #114.

## Changes

### Package alignment
- Root `package.json` gains `"version": "0.0.1"` (canonical source).
- Adds `"version": "0.0.1"` + `"private": true` to `@prive-admin-tanstack/auth` and `@prive-admin-tanstack/db` (previously missing — changesets silently skipped them).
- Aligns `@prive-admin-tanstack/config`, `@prive-admin-tanstack/env`, `@prive-admin-tanstack/ui` from `0.0.0` to `0.0.1`.

### Changesets config
- `fixed: [["web", "@prive-admin-tanstack/auth", "@prive-admin-tanstack/config", "@prive-admin-tanstack/db", "@prive-admin-tanstack/env", "@prive-admin-tanstack/ui"]]` — any changeset bumps the entire group together.

### Custom version + tag scripts
- `scripts/release-version.sh` — runs `bunx changeset version` to bump the fixed group, then writes the new version to root `package.json`.
- `scripts/release-tag.sh` — reads root `version`, creates `v<version>` tag if missing, prints `🦋  New tag: v<version>` so `changesets/action@v1` picks up the publish and pushes the tag.
- `bunx changeset tag` was unusable: silently skipped private packages, so tags were never created.

### Workflows
- `changeset-release.yml`: `version: bash scripts/release-version.sh`, `publish: bash scripts/release-tag.sh`, `createGithubReleases: false`.
- `release.yml`: trigger changed from `tags: web@*` to `tags: v*`.
- `codeql.yml`: dropped `push: branches: [main]` trigger to cut noise; runs only on PR + weekly cron + `workflow_dispatch`.

## Flow
1. Feature PR adds a changeset (any internal package, any bump). Merge.
2. `Changeset Release` opens `Version Packages` PR — bumps every package in the fixed group + root + writes per-package CHANGELOGs.
3. Merge the Version PR. `release-tag.sh` creates and pushes `v<version>`.
4. Tag fires `release.yml` → Docker build + deploy.

## Test plan
- [ ] `Changeset Check` passes on this PR (empty changeset).
- [ ] After merging, `Version Packages` PR is opened by changesets only when a real (non-empty) changeset is added in a follow-up PR.
- [ ] Verify `release-version.sh` bumps every fixed-group package + root in lock-step.
- [ ] Merging the Version PR creates `v<version>` tag and triggers `release.yml`.
- [ ] CodeQL no longer fires on push to main.