### PR TITLE
chore: validate fixed-group release chain

### DIFF
--- a/.changeset/test-monorepo-release.md
+++ b/.changeset/test-monorepo-release.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+chore: validate fixed-group bump + v* tag + release chain


### PR DESCRIPTION
## Summary
End-to-end test of the new single-version monorepo release pipeline.

Adds a real `patch` changeset against `web`. Because all internal packages are in a `fixed` group, the bump should cascade to every package and to root `package.json`.

## Expected after merge
1. `Changeset Release` opens a `Version Packages` PR setting all packages + root from `0.0.1` → `0.0.2`.
2. Merging the Version PR runs `scripts/release-tag.sh`, creating and pushing `v0.0.2`.
3. `v0.0.2` tag fires `release.yml` → Docker build + deploy.

## Test plan
- [ ] `Changeset Check` passes.
- [ ] After merge, Version PR appears with every package and root at `0.0.2`.
- [ ] CHANGELOG.md updated for each fixed-group package.
- [ ] After Version PR merge, `v0.0.2` tag exists under Tags.
- [ ] `Release` workflow run starts from the tag push.