### PR TITLE
ci: push release tag from script

### DIFF
--- a/.changeset/fix-tag-push.md
+++ b/.changeset/fix-tag-push.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: push release tag from script directly

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -10,4 +10,5 @@ if git rev-parse "${tag}" >/dev/null 2>&1; then
 fi
 
 git tag "${tag}"
+git push origin "${tag}"
 echo "🦋  New tag: ${tag}"


### PR DESCRIPTION
## Summary
`changesets/action@v1` only pushes tags when its publish-step stdout matches `🦋  New tag: <name>@<version>` (with literal `@`). Our tag format is `v<version>` so the regex never matches and the tag stayed local — the previous release was salvaged by manually pushing `v0.0.2`.

Updates `scripts/release-tag.sh` to call `git push origin <tag>` itself instead of relying on the action's tag push.

## Test plan
- [ ] On the next merged feature PR + Version PR cycle, confirm `v<version>` tag appears on remote without manual push and triggers `release.yml`.