### PR TITLE
chore: validate auto-pushed v* tag

### DIFF
--- a/.changeset/test-auto-tag-push.md
+++ b/.changeset/test-auto-tag-push.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+chore: validate auto-pushed v* tag fires release pipeline


### PR DESCRIPTION
## Summary
Real `web: patch` changeset to drive a Version PR + auto-pushed `v0.0.3` tag.

Sequence: merge #118 first (the auto-push fix), then merge this PR, then merge the Version PR it produces.

## Expected
1. Merge → `Changeset Release` opens Version PR bumping all packages + root `0.0.2 → 0.0.3`.
2. Merge Version PR → `scripts/release-tag.sh` creates `v0.0.3` and pushes to origin (no manual step).
3. `v0.0.3` tag triggers `release.yml`.

## Test plan
- [ ] `Changeset Check` passes.
- [ ] Version PR appears with everything at `0.0.3`.
- [ ] `v0.0.3` tag visible on remote without manual push.
- [ ] `Release` workflow run starts from the tag push.