### PR TITLE
ci: checkout with PAT so tag pushes trigger release

### DIFF
--- a/.changeset/checkout-with-pat.md
+++ b/.changeset/checkout-with-pat.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: checkout with DEPS_PAT so pushed tags trigger workflows

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -17,12 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Load PAT from 1Password
         uses: 1password/load-secrets-action@v2
         with:
@@ -30,6 +24,14 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DEPS_PAT: op://prive-admin/PAT prive-admin deps bot/token
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.DEPS_PAT }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
Tags pushed via the default `GITHUB_TOKEN` do not trigger downstream workflows (GitHub safeguard). `actions/checkout@v4` configures the persistent git auth header from its `token` input, so even though we pass `DEPS_PAT` to `changesets/action`, the tag push from `scripts/release-tag.sh` was using the checkout-step credentials — `GITHUB_TOKEN` — and `release.yml` did not fire.

Fix: load `DEPS_PAT` from 1Password before `actions/checkout`, and pass `token: ${{ env.DEPS_PAT }}` to checkout. Now the persistent git auth uses the PAT, so the tag push reaches GitHub as the PAT owner and `release.yml` triggers.

`v0.0.3` was salvaged via `gh workflow run release.yml --ref v0.0.3`.

## Test plan
- [ ] Merge this PR (no version bump expected — empty changeset).
- [ ] Open a follow-up real-changeset PR, merge, then merge the resulting Version PR.
- [ ] Confirm `v<version>` tag appears AND `Release` workflow auto-fires from the tag push (no manual `workflow_dispatch`).