### PR TITLE
ci(release): tag Docker image with version

### DIFF
--- a/.changeset/docker-tag-version.md
+++ b/.changeset/docker-tag-version.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(release): tag Docker image with the git tag name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
Adds `${{ github.ref_name }}` to the Docker tag list in `release.yml` so each release pushes an image tagged with the version (e.g. `ghcr.io/moreorover/prive-admin:v0.0.3`) alongside the existing `:latest` and `:${{ github.sha }}`.

`github.ref_name` resolves to:
- the tag name on `push: tags` events (e.g. `v0.0.3`)
- the tag name on `workflow_dispatch` runs invoked with `--ref v0.0.3`

Docker tag rules accept `v0.0.3` (alphanumeric + `.`).

## Test plan
- [ ] Trigger a release via the changeset → version PR → tag chain.
- [ ] Verify three image tags appear on GHCR: `:latest`, `:<sha>`, `:v<version>`.