### PR TITLE
chore: end-to-end release chain validation

### DIFF
--- a/.changeset/test-full-chain.md
+++ b/.changeset/test-full-chain.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+chore: end-to-end validation of changeset → version PR → auto-pushed v* tag → release with version-tagged Docker image


### PR DESCRIPTION
## Summary
Real `web: patch` changeset to validate the full chain after #121 (auto-trigger) and #122 (versioned Docker tag) landed.

## Expected
1. Merge → `Changeset Release` opens Version PR bumping all packages + root from `0.0.3` → `0.0.4`.
2. Merge Version PR → `scripts/release-tag.sh` creates **and pushes** `v0.0.4` (no manual step).
3. Tag push fires `release.yml` automatically (PAT-authored push triggers workflows).
4. `release.yml` builds and pushes Docker image with three tags: `:latest`, `:<sha>`, `:v0.0.4`.

## Test plan
- [ ] Version PR appears with all packages + root at `0.0.4`.
- [ ] `v0.0.4` tag visible on remote without manual push.
- [ ] `Release` workflow auto-fires from the tag (not via `workflow_dispatch`).
- [ ] GHCR shows `ghcr.io/moreorover/prive-admin:v0.0.4` alongside `:latest` and `:<sha>`.