### PR TITLE
ci: auto-create GitHub Release with changelog notes

### DIFF
--- a/.changeset/auto-github-release.md
+++ b/.changeset/auto-github-release.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: create GitHub Release with changelog notes on each version tag

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -11,4 +11,21 @@ fi
 
 git tag "${tag}"
 git push origin "${tag}"
+
+if [[ -f apps/web/CHANGELOG.md ]]; then
+  notes=$(awk -v ver="${version}" '
+    $0 ~ "^## "ver"$" {flag=1; next}
+    /^## / {flag=0}
+    flag
+  ' apps/web/CHANGELOG.md)
+else
+  notes=""
+fi
+
+if [[ -z "${notes}" ]]; then
+  notes="Release ${tag}"
+fi
+
+gh release create "${tag}" --title "${tag}" --notes "${notes}"
+
 echo "🦋  New tag: ${tag}"


### PR DESCRIPTION
## Summary
Extends `scripts/release-tag.sh` to call `gh release create` after pushing the `v<version>` tag. Notes are extracted from the matching `## <version>` section of `apps/web/CHANGELOG.md` (which mirrors the fixed-group changes).

`v0.0.4` was backfilled manually before this PR.

`gh` auths via `GITHUB_TOKEN` already provided to the changesets/action step (set to `DEPS_PAT`), so no extra token wiring needed.

## Test plan
- [ ] Next merged real-changeset PR → Version PR → merge cycle creates a GitHub Release at `https://github.com/moreorover/prive-admin/releases/tag/v<version>` containing the changelog body for that version.