### PR TITLE
ci(deps): nightly PR generates a changeset

### DIFF
--- a/.changeset/deps-update-changeset.md
+++ b/.changeset/deps-update-changeset.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: nightly deps PR adds a changeset so changeset-check passes

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Update Lockfile
         run: bun install
 
+      - name: Add changeset
+        run: |
+          mkdir -p .changeset
+          cat > .changeset/auto-deps-update.md <<'EOF'
+          ---
+          "web": patch
+          ---
+
+          chore(deps): nightly dependency updates
+          EOF
+
       - name: Create or Update Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
## Summary
PR #126 (nightly taze) failed `Changeset Check` because dep bumps modify `package.json` files but no changeset is added. Adds a step to `deps-update.yml` that writes `.changeset/auto-deps-update.md` (a real `web: patch` changeset) before opening / updating the PR. Fixed filename means each subsequent nightly run on the same branch overwrites the file rather than stacking duplicates.

`peter-evans/create-pull-request` will pick up the changeset file alongside the bumped lockfile/package.json files when it commits to `chore/auto-dep-updates`.

## Notes
- Picks `web: patch` so the bump cascades through the fixed group when the PR is merged. Switch to `--empty` style if you'd rather have dep updates not bump app version.
- Existing PR #126 needs the changeset added manually (rebase from this branch, or just trigger another `workflow_dispatch` after this lands).

## Test plan
- [ ] Merge this PR.
- [ ] Trigger `Nightly Dependency Updates` via `gh workflow run`.
- [ ] Verify the resulting PR contains `.changeset/auto-deps-update.md` and `Changeset Check` passes.