### PR TITLE
fix(db): expand env vars in drizzle.config so DATABASE_URL works under turbo

### DIFF
--- a/.changeset/drizzle-env-expand.md
+++ b/.changeset/drizzle-env-expand.md
@@ -1,0 +1,7 @@
+---
+"@prive-admin-tanstack/db": patch
+---
+
+fix(db): expand env vars in drizzle.config so DATABASE_URL resolves under turbo
+
+`apps/web/.env`'s `DATABASE_URL` interpolates `${POSTGRES_USER}/${POSTGRES_PASSWORD}/${POSTGRES_DB}`. Plain `dotenv.config()` doesn't expand those references, so any `bun run db:*` command (turbo-wrapped) hung at "Pulling schema from database..." and exited 1. Wrapping the load with `dotenv-expand` resolves the references before drizzle-kit reads them.

--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
         "@paralleldrive/cuid2": "^3.3.0",
         "@prive-admin-tanstack/env": "workspace:*",
         "dotenv": "catalog:",
+        "dotenv-expand": "^13.0.0",
         "drizzle-orm": "^0.45.2",
         "pg": "^8.20.0",
         "zod": "catalog:",
@@ -962,6 +963,8 @@
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "dotenv-expand": ["dotenv-expand@13.0.0", "", { "dependencies": { "dotenv": "^17.4.2" } }, "sha512-aBfBS8eYIeXmpHI9ThIlA7/WLq+SLt18iXUZhb52rW89QLKQFoIpPG1bPeewoPZsTyjSSO3T7234FBVUM1V2rA=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,9 +1,8 @@
 import dotenv from "dotenv"
+import dotenvExpand from "dotenv-expand"
 import { defineConfig } from "drizzle-kit"
 
-dotenv.config({
-  path: "../../apps/web/.env",
-})
+dotenvExpand.expand(dotenv.config({ path: "../../apps/web/.env" }))
 
 export default defineConfig({
   schema: "./src/schema",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,6 +25,7 @@
     "@paralleldrive/cuid2": "^3.3.0",
     "@prive-admin-tanstack/env": "workspace:*",
     "dotenv": "catalog:",
+    "dotenv-expand": "^13.0.0",
     "drizzle-orm": "^0.45.2",
     "pg": "^8.20.0",
     "zod": "catalog:"


### PR DESCRIPTION
## Summary

- Add `dotenv-expand` to `packages/db` and wrap the `dotenv.config(...)` call so `${POSTGRES_USER}/${POSTGRES_PASSWORD}/${POSTGRES_DB}` references inside `apps/web/.env`'s `DATABASE_URL` resolve before drizzle-kit reads it.
- Without this, `bun run db:push` (and any other turbo-wrapped drizzle-kit command) hangs at "Pulling schema from database..." then exits 1, because turbo passes env vars literally and the unexpanded URL is malformed.

## Test plan

- [ ] `bun run db:push` from repo root completes (no hang at "Pulling schema...").
- [ ] `bun run db:generate` from repo root succeeds.
- [ ] `bun run db:studio` from repo root opens drizzle studio.