### PR TITLE
ci(release): pre-deploy postgres backup to R2

### DIFF
--- a/.changeset/pre-deploy-backup.md
+++ b/.changeset/pre-deploy-backup.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(release): take a postgres snapshot to R2 before deploying and gate the rollout on it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,7 @@ jobs:
         run: |
           # Sanitize ref names like "feature/foo" → "feature-foo" so the
           # label matches BACKUP_LABEL's allowed charset.
-          REF_SAFE=$(printf '%s' "${GITHUB_REF_NAME}" | tr '/' '-')
-          BACKUP_LABEL="${REF_SAFE}_${GITHUB_SHA}"
+          BACKUP_LABEL=$(printf '%s' "${GITHUB_REF_NAME}" | tr '/' '-')
           ssh root@prive "
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \
             PG_DATABASE='${POSTGRES_DB}' \
+            BACKUP_LABEL='pre-deploy_${GITHUB_SHA}' \
             ~/backup_postgres.sh"
 
       - name: Install s3cmd
@@ -140,7 +141,7 @@ jobs:
           bucket_location = auto
           use_https = True
           EOF
-          R2_KEY="pre-deploy/${GITHUB_SHA}_${FILE_NAME}"
+          R2_KEY="pre-deploy/${FILE_NAME}"
           s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${R2_KEY}"
           echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/${R2_KEY}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,88 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy
 
+  pre-deploy-backup:
+    name: Pre-deploy Postgres Backup
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://prive.salon
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          POSTGRES_DB: op://prive-admin/prive-admin-prod/postgres/POSTGRES_DB
+          POSTGRES_USER: op://prive-admin/prive-admin-prod/postgres/POSTGRES_USER
+          R2_ACCOUNT_ID: op://prive-admin/Cloudflare R2/account-id
+          R2_ACCESS_KEY_ID: op://prive-admin/Cloudflare R2/access-key-id
+          R2_SECRET_ACCESS_KEY: op://prive-admin/Cloudflare R2/secret-access-key
+          R2_BUCKET_NAME: op://prive-admin/Cloudflare R2/bucket-name
+          TS_OAUTH_CLIENT_ID: op://prive-admin/tailscale-oauth/client-id
+          TS_OAUTH_CLIENT_SECRET: op://prive-admin/tailscale-oauth/client-secret
+
+      - name: Tailscale up
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_CLIENT_SECRET }}
+          tags: tag:prod-server
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 0700 ~/.ssh
+          ssh-keyscan -H prive >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Copy backup script to VPS
+        run: scp scripts/backup_postgres.sh root@prive:~/backup_postgres.sh
+
+      - name: Run backup script on VPS
+        run: |
+          ssh root@prive "
+            chmod +x ~/backup_postgres.sh && \
+            PG_USER='${POSTGRES_USER}' \
+            PG_DATABASE='${POSTGRES_DB}' \
+            ~/backup_postgres.sh"
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y s3cmd
+
+      - name: Upload backup to Cloudflare R2
+        run: |
+          set -e
+          umask 077
+          FILE_NAME=$(ssh root@prive 'ls -t ~/db_backups/ | head -n1')
+          [ -n "${FILE_NAME}" ] || { echo "no backup file produced on VPS"; exit 1; }
+          ssh root@prive "cat ~/db_backups/${FILE_NAME}" > "${FILE_NAME}"
+          cat > ~/.s3cfg <<EOF
+          [default]
+          access_key = ${R2_ACCESS_KEY_ID}
+          secret_key = ${R2_SECRET_ACCESS_KEY}
+          host_base = ${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+          host_bucket = %(bucket)s.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+          bucket_location = auto
+          use_https = True
+          EOF
+          R2_KEY="pre-deploy/${GITHUB_SHA}_${FILE_NAME}"
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${R2_KEY}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/${R2_KEY}"
+
   deploy:
     name: Deploy to prive
-    needs: build-and-push
+    needs: [build-and-push, pre-deploy-backup]
     runs-on: ubuntu-latest
     environment:
       name: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,15 @@ jobs:
 
       - name: Run backup script on VPS
         run: |
+          # Sanitize ref names like "feature/foo" → "feature-foo" so the
+          # label matches BACKUP_LABEL's allowed charset.
+          REF_SAFE=$(printf '%s' "${GITHUB_REF_NAME}" | tr '/' '-')
+          BACKUP_LABEL="${REF_SAFE}_${GITHUB_SHA}"
           ssh root@prive "
             chmod +x ~/backup_postgres.sh && \
             PG_USER='${POSTGRES_USER}' \
             PG_DATABASE='${POSTGRES_DB}' \
-            BACKUP_LABEL='pre-deploy_${GITHUB_SHA}' \
+            BACKUP_LABEL='${BACKUP_LABEL}' \
             ~/backup_postgres.sh"
 
       - name: Install s3cmd
@@ -141,9 +145,8 @@ jobs:
           bucket_location = auto
           use_https = True
           EOF
-          R2_KEY="pre-deploy/${FILE_NAME}"
-          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${R2_KEY}"
-          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/${R2_KEY}"
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/${FILE_NAME}"
 
   deploy:
     name: Deploy to prive

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -21,7 +21,9 @@ mkdir -p "${BACKUP_DIR}"
 find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
 
 if [[ -n "${BACKUP_LABEL}" ]]; then
-  OUT="${BACKUP_DIR}/postgres_backup_${BACKUP_LABEL}_${TIMESTAMP}.sql"
+  # Timestamp first so directory/object listings sort chronologically
+  # regardless of label.
+  OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}_${BACKUP_LABEL}.sql"
 else
   OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
 fi

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -6,12 +6,25 @@ TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 BACKUP_DIR="${HOME}/db_backups"
 COMPOSE_DIR="${COMPOSE_DIR:-${HOME}/prive-admin}"
 
+# Optional label embedded in the filename (e.g. "pre-deploy_<sha>") so the
+# operator can distinguish scheduled backups from one-off ones at a glance,
+# both on the VPS and in object storage. Restricted to a safe charset.
+BACKUP_LABEL="${BACKUP_LABEL:-}"
+if [[ -n "${BACKUP_LABEL}" ]] && [[ ! "${BACKUP_LABEL}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "BACKUP_LABEL '${BACKUP_LABEL}' contains unsupported characters" >&2
+  exit 1
+fi
+
 mkdir -p "${BACKUP_DIR}"
 
 # Prune backups older than 14 days
 find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
 
-OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
+if [[ -n "${BACKUP_LABEL}" ]]; then
+  OUT="${BACKUP_DIR}/postgres_backup_${BACKUP_LABEL}_${TIMESTAMP}.sql"
+else
+  OUT="${BACKUP_DIR}/postgres_backup_${TIMESTAMP}.sql"
+fi
 TMP="${OUT}.partial"
 trap 'rm -f "${TMP}"' ERR
 


### PR DESCRIPTION
## Summary
- Add a `pre-deploy-backup` job between `build-and-push` and `deploy` in `.github/workflows/release.yml`.
- Reuses `scripts/backup_postgres.sh` on the VPS (same path the daily cron uses) and uploads the dump to R2 under `pre-deploy/${SHA}_*.sql` so it does not collide with daily backups.
- `deploy` now `needs: [build-and-push, pre-deploy-backup]`, so a failed snapshot aborts the rollout before any new image is pulled.
- The web container is **not** stopped for the snapshot — `pg_dump` is transactional and consistent under live writes; stopping web would only add downtime.

## Test plan
- [ ] Trigger a tag push (or `workflow_dispatch`) and confirm the new job runs and uploads `pre-deploy/<sha>_postgres_backup_*.sql` to R2.
- [ ] Confirm `deploy` only starts after the backup job succeeds.
- [ ] Force-fail the backup job (e.g. by temporarily breaking the SSH step) and confirm `deploy` is skipped.
- [ ] Restore one of the produced `pre-deploy/...` dumps locally with `scripts/restore_postgres.sh` (other PR) to verify it is usable.