### PR TITLE
chore(infra): add dozzle log viewer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,22 @@ services:
       retries: 5
       start_period: 15s
 
+  dozzle:
+    image: amir20/dozzle:latest
+    restart: unless-stopped
+    environment:
+      DOZZLE_NO_ANALYTICS: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - "${TAILSCALE_IP}:8080:8080"
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 3s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+
   postgres:
     image: postgres:18-alpine
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add Dozzle service to docker-compose for container log viewing
- Bound to `${TAILSCALE_IP}:8080` only (no public expose, matches postgres pattern)
- Docker socket mounted read-only, analytics disabled
- Built-in healthcheck via `/dozzle healthcheck`

## Test plan
- [ ] `docker compose up -d dozzle` brings up healthy container
- [ ] Logs UI reachable at `http://${TAILSCALE_IP}:8080` from Tailnet
- [ ] Not reachable from public internet