### PR TITLE
ci(release-please): set pull-request-title-pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "bootstrap-sha": "1a32c3050da0b0c6b970268d5554759a6d1e8125",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
- Add `pull-request-title-pattern` to `release-please-config.json` so release-please can re-parse its own release PR titles correctly.
- Without `${component}` and `${version}` in the title, release-please warned `PR component: undefined does not match configured component: prive-admin-tanstack` and aborted with `There are untagged, merged release PRs outstanding`. That blocked the v0.1.0 tag (and therefore the deploy) after #135 merged.

## Notes
- The merged PR #135 still needs to be unblocked manually (create `v0.1.0` release at the merge SHA and relabel to `autorelease: tagged`). This config change only prevents a recurrence on future release PRs.

## Test plan
- [ ] After merge, next release PR opened by release-please has title like `chore: release 0.2.0` (component empty for single-package, version present).
- [ ] On merge of that PR, release-please tags the commit and the `Release` workflow fires.