### PR TITLE
chore(infra): add beszel hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,17 @@ services:
       retries: 5
       start_period: 30s
 
+  beszel:
+    image: henrygd/beszel:latest
+    restart: unless-stopped
+    environment:
+      APP_URL: http://${TAILSCALE_IP}:8090
+    ports:
+      - "${TAILSCALE_IP}:8090:8090"
+    volumes:
+      - /var/lib/prive-admin/beszel/data:/beszel_data
+      - /var/lib/prive-admin/beszel/socket:/beszel_socket
+
   postgres:
     image: postgres:18-alpine
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add Beszel hub container on `${TAILSCALE_IP}:8090` (Tailnet-only).
- Persistent data at `/var/lib/prive-admin/beszel/data`.
- Shared `beszel_socket` dir mounted in advance — agent (next PR) attaches to it for unix-socket comms (recommended over localhost when hub + agent run in separate containers on same host).
- `APP_URL` set to the Tailscale URL so generated links resolve correctly inside the Tailnet.

## Bootstrap (after deploy)
1. Visit `http://${TAILSCALE_IP}:8090` from a Tailnet device.
2. Create admin user.
3. Click **Add System** → copy the generated `KEY` (hub pubkey) and `TOKEN`.
4. Store in 1Password under `prive-admin/beszel`. Follow-up PR adds the agent service + `release.yml` secret loading.

## Test plan
- [ ] `docker compose up -d beszel` brings up the container.
- [ ] Hub UI reachable at `http://${TAILSCALE_IP}:8090` from Tailnet.
- [ ] Not reachable from public internet.