### PR TITLE
fix(web): convert money inputs to cents on frontend submit

### DIFF
--- a/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
@@ -33,11 +33,15 @@ export function EditHairAssignedDialog({
   })
 
   const form = useForm({
-    initialValues: { weightInGrams: hairAssigned.weightInGrams, soldFor: hairAssigned.soldFor },
+    initialValues: { weightInGrams: hairAssigned.weightInGrams, soldFor: hairAssigned.soldFor / 100 },
   })
 
   const handleSubmit = async (values: { weightInGrams: number; soldFor: number }) => {
-    await mutation.mutateAsync({ id: hairAssigned.id, ...values })
+    await mutation.mutateAsync({
+      id: hairAssigned.id,
+      weightInGrams: values.weightInGrams,
+      soldFor: Math.round(values.soldFor * 100),
+    })
   }
 
   return (
@@ -45,7 +49,7 @@ export function EditHairAssignedDialog({
       <form onSubmit={form.onSubmit(handleSubmit)}>
         <Stack>
           <NumberInput label="Weight (grams)" min={0} {...form.getInputProps("weightInGrams")} />
-          <NumberInput label="Sold For (cents)" min={0} {...form.getInputProps("soldFor")} />
+          <NumberInput label="Sold For" min={0} decimalScale={2} step={0.01} {...form.getInputProps("soldFor")} />
           <Group justify="flex-end">
             <Button type="submit" loading={mutation.isPending}>
               Save Changes

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -269,7 +269,7 @@ function EditHairOrderModal({ open, onOpenChange, hairOrder }: EditHairOrderModa
           customerId: hairOrder.customerId,
           weightReceived: values.weightReceived,
           weightUsed: hairOrder.weightUsed,
-          total: values.total,
+          total: Math.round(values.total * 100),
         },
       }),
     onSuccess: () => {
@@ -286,7 +286,7 @@ function EditHairOrderModal({ open, onOpenChange, hairOrder }: EditHairOrderModa
       arrivedAt: hairOrder.arrivedAt ?? "",
       status: (hairOrder.status === "COMPLETED" ? "COMPLETED" : "PENDING") as "PENDING" | "COMPLETED",
       weightReceived: hairOrder.weightReceived,
-      total: hairOrder.total,
+      total: hairOrder.total / 100,
     },
   })
 
@@ -306,7 +306,7 @@ function EditHairOrderModal({ open, onOpenChange, hairOrder }: EditHairOrderModa
           />
           <Group grow>
             <NumberInput label="Weight Received (g)" min={0} {...form.getInputProps("weightReceived")} />
-            <NumberInput label="Total (cents)" min={0} {...form.getInputProps("total")} />
+            <NumberInput label="Total" min={0} decimalScale={2} step={0.01} {...form.getInputProps("total")} />
           </Group>
           <Button type="submit" loading={mutation.isPending}>
             Save Changes

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -80,7 +80,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
       status: "PENDING",
       weightReceived: values.weightReceived,
       weightUsed: 0,
-      total: values.total,
+      total: Math.round(values.total * 100),
     })
   }
 
@@ -99,7 +99,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
           <TextInput label="Placed At" type="date" {...form.getInputProps("placedAt")} />
           <Group grow>
             <NumberInput label="Weight (g)" min={0} {...form.getInputProps("weightReceived")} />
-            <NumberInput label="Total (cents)" min={0} {...form.getInputProps("total")} />
+            <NumberInput label="Total" min={0} decimalScale={2} step={0.01} {...form.getInputProps("total")} />
           </Group>
           <Button type="submit" loading={mutation.isPending}>
             Create Hair Order


### PR DESCRIPTION
## Summary
- Hair-assigned `soldFor` and hair-orders `total` inputs sent the raw user-typed value to the backend, which stored it directly as cents (typing 100 EUR persisted as £1.00 instead of £100.00).
- Multiply by 100 on submit and divide by 100 on edit prefill so all conversion lives on the frontend, matching the existing transaction form pattern.
- Drop the misleading `(cents)` labels and add `decimalScale={2}` / `step={0.01}` to the money inputs.

## Test plan
- [ ] Create new hair order with Total `100` → DB stores `10000`, detail page shows `\$100.00`.
- [ ] Edit existing hair order, prefill shows major value (e.g. `100`), save preserves correct cents.
- [ ] Edit hair-assigned `Sold For` with `50.5` → DB stores `5050`, table shows `\$50.50`.
- [ ] Transaction form unchanged (regression check): create + edit round-trip values correctly.
- [ ] Existing rows with corrupted values may need backfill (`UPDATE hair_order SET total = total * 100 WHERE …`) — out of scope for this PR.