### PR TITLE
ci(release-please): revert custom pull-request-title-pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "bootstrap-sha": "1a32c3050da0b0c6b970268d5554759a6d1e8125",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
- Revert `pull-request-title-pattern` override added in #138.
- Restores manifest-mode default so release-please can reconcile PR #142 and tag `v0.1.1`.

## Context
PR #142 (`chore: release main`) merged but no `v0.1.1` tag/release was created. Workflow log:

```
⚠ pullRequestTitlePattern miss the part of '${scope}' / '${component}' / '${version}'
⚠ PR component: undefined does not match configured component: prive-admin-tanstack
⚠ There are untagged, merged release PRs outstanding - aborting
```

PR #142 was opened with the default manifest title before #138 changed the pattern. After #138 merged, the new strict pattern could no longer parse the existing PR title, so release-please aborted instead of tagging.

Removing the override falls back to the manifest-mode default (`chore${branch}: release${component}`), which matches `chore: release main`. Next push to `main` should let release-please pick up #142 and create the `v0.1.1` tag + GitHub release.

## Test plan
- [ ] Merge this PR.
- [ ] Verify Release Please workflow run on `main` no longer aborts.
- [ ] Confirm `v0.1.1` tag and GitHub release created.
- [ ] Confirm PR #142 label flips from `autorelease: pending` to `autorelease: tagged`.