### PR TITLE
fix(ci): use fix(deps) for nightly dependency PRs

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -41,8 +41,8 @@ jobs:
           token: ${{ env.DEPS_PAT }}
           branch: chore/auto-dep-updates
           base: main
-          commit-message: "chore(deps): bump dependencies via taze major"
-          title: "chore(deps): nightly dependency updates"
+          commit-message: "fix(deps): bump dependencies via taze major"
+          title: "fix(deps): nightly dependency updates"
           body: |
             Automated nightly run of `bunx taze major -r -w` followed by `bun install`.
 


### PR DESCRIPTION
## Summary
- Change auto-dep nightly PR title and commit message from `chore(deps):` to `fix(deps):`.
- Lets release-please bump the patch version when these PRs merge instead of skipping with "No user facing commits".

## Context
After merging #140 (`chore(deps): nightly dependency updates`), release-please correctly skipped opening a release PR — `chore` is not a release-triggering type. Switching to `fix(deps):` keeps the conventional commit semantics honest (a dep bump is a fix at the consumer level) and ensures dep updates ship as patch releases.

## Test plan
- [ ] Next nightly run opens a PR titled `fix(deps): nightly dependency updates`.
- [ ] On merge, release-please opens a release PR bumping the patch version.