### PR TITLE
ci(release-please): set empty component to match PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
   "packages": {
     ".": {
       "package-name": "prive-admin-tanstack",
+      "component": "",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

- Set `component: \"\"` in `release-please-config.json` so the configured component matches what release-please parses from the PR title.

## Why

Default `pull-request-title-pattern` (without `\${component}`) produces titles like `chore: release main`. Release-please derives the configured component from `package-name` (\"prive-admin-tanstack\"), then rejects the merged release PR because the parsed component is undefined. Result: no tag, no release, subsequent runs abort with `There are untagged, merged release PRs outstanding`.

This is what just happened with #145 — v0.1.2 had to be tagged manually and the label flipped from `autorelease: pending` to `autorelease: tagged`.

## Test plan

- [ ] Next merged `chore: release main` PR creates a v* tag and GitHub release without manual intervention.
- [ ] `release.yml` triggers on the new tag and deploys.