### PR TITLE
ci(release): pin deploy image to tag, fallback to SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,8 +186,13 @@ jobs:
       - name: Render .env
         run: |
           umask 077
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            IMAGE_TAG="${GITHUB_REF_NAME}"
+          else
+            IMAGE_TAG="${GITHUB_SHA}"
+          fi
           cat > .env <<EOF
-          IMAGE_TAG=${GITHUB_SHA}
+          IMAGE_TAG=${IMAGE_TAG}
           GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
           NODE_ENV=production
           POSTGRES_DB=${POSTGRES_DB}


### PR DESCRIPTION
## Summary
- Deploy job now renders `IMAGE_TAG=${GITHUB_REF_NAME}` when the workflow is triggered by a tag push, so the live stack matches the released version (e.g. `vX.Y.Z`) instead of an opaque commit SHA.
- Falls back to `IMAGE_TAG=${GITHUB_SHA}` on `workflow_dispatch` from a branch, where `GITHUB_REF_NAME` would be a branch name. The build job always publishes a SHA-tagged image (`release.yml:46`), so the fallback is guaranteed to resolve.

## Test plan
- [ ] Cut a tag (`v*`) and confirm the deployed container uses `:vX.Y.Z`.
- [ ] Trigger `workflow_dispatch` from a non-tag ref and confirm `IMAGE_TAG` resolves to the commit SHA, not the branch name.