### PR TITLE
fix(deps): override fast-xml-builder to ^1.1.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1041.0",
         "@aws-sdk/s3-request-presigner": "^3.1041.0",
@@ -70,7 +70,7 @@
     },
     "packages/auth": {
       "name": "@prive-admin-tanstack/auth",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@prive-admin-tanstack/db": "workspace:*",
         "@prive-admin-tanstack/env": "workspace:*",
@@ -85,11 +85,11 @@
     },
     "packages/config": {
       "name": "@prive-admin-tanstack/config",
-      "version": "0.1.0",
+      "version": "0.1.2",
     },
     "packages/db": {
       "name": "@prive-admin-tanstack/db",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@prive-admin-tanstack/env": "workspace:*",
@@ -108,7 +108,7 @@
     },
     "packages/env": {
       "name": "@prive-admin-tanstack/env",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@t3-oss/env-core": "^0.13.11",
         "dotenv": "catalog:",
@@ -122,7 +122,7 @@
     },
     "packages/ui": {
       "name": "@prive-admin-tanstack/ui",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@mantine/core": "^9.1.1",
         "@mantine/hooks": "^9.1.1",
@@ -141,6 +141,9 @@
         "typescript": "^6.0.3",
       },
     },
+  },
+  "overrides": {
+    "fast-xml-builder": "^1.1.7",
   },
   "catalog": {
     "@types/node": "^25.6.0",
@@ -931,7 +934,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
@@ -1276,6 +1279,8 @@
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "xmlbuilder2": ["xmlbuilder2@4.0.3", "", { "dependencies": { "@oozcitak/dom": "^2.0.2", "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0", "js-yaml": "^4.1.1" } }, "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   "overrides": {
     "fast-xml-builder": "^1.1.7"
   },
+  "_overridesNotes": {
+    "fast-xml-builder": "GHSA-5wm8-gmm8-39j9, GHSA-45c6-75p6-83cc. Drop when @aws-sdk/xml-builder ships a fast-xml-parser release that requires fast-xml-builder >=1.1.7. Tracking: #151."
+  },
   "packageManager": "bun@1.3.13"
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "typescript": "^6.0.3",
     "zod": "catalog:"
   },
+  "overrides": {
+    "fast-xml-builder": "^1.1.7"
+  },
   "packageManager": "bun@1.3.13"
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "overrides": {
     "fast-xml-builder": "^1.1.7"
   },
+  "packageManager": "bun@1.3.13",
   "_overridesNotes": {
     "fast-xml-builder": "GHSA-5wm8-gmm8-39j9, GHSA-45c6-75p6-83cc. Drop when @aws-sdk/xml-builder ships a fast-xml-parser release that requires fast-xml-builder >=1.1.7. Tracking: #151."
-  },
-  "packageManager": "bun@1.3.13"
+  }
 }


### PR DESCRIPTION
## Summary
- `bun audit --prod` flags `fast-xml-builder@1.1.5` for two advisories (GHSA-5wm8-gmm8-39j9 high, GHSA-45c6-75p6-83cc moderate). The package is pulled in transitively via `@aws-sdk/client-s3` → `@aws-sdk/xml-builder` → `fast-xml-parser@5.7.2` → `fast-xml-builder@^1.1.5`.
- Upstream `@aws-sdk/xml-builder` and `fast-xml-parser` have not yet released a chain bump that pulls a fixed version, so a top-level `bun update` does not refresh the nested entry.
- Add a root `overrides` block pinning `fast-xml-builder` to `^1.1.7`. Lockfile re-resolves to `1.2.0` and `bun audit` exits clean.
- Record the rationale and removal condition in a sibling `_overridesNotes` field so the marker travels with the code.
- Tracking issue for eventual removal: #151.

## Test plan
- [x] Local: `bun audit --prod --ignore GHSA-67mh-4wv8-2f99` exits 0.
- [x] Local: `bun install` reports no changes after override applied.
- [ ] CI `Source Build → Audit Dependencies` passes on this PR.
- [ ] Drop the override (and the `_overridesNotes` entry) once #151 conditions are met.