### PR TITLE
ci(codeql): gate PR analysis by JS/TS path filter

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "apps/**/*.ts"
+      - "apps/**/*.tsx"
+      - "apps/**/*.js"
+      - "apps/**/*.jsx"
+      - "apps/**/*.mjs"
+      - "apps/**/*.cjs"
+      - "packages/**/*.ts"
+      - "packages/**/*.tsx"
+      - "packages/**/*.js"
+      - "packages/**/*.jsx"
+      - "packages/**/*.mjs"
+      - "packages/**/*.cjs"
+      - ".github/workflows/codeql.yml"
   schedule:
     - cron: "0 5 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- CodeQL only analyzes `javascript-typescript`, so PRs that touch only docs, workflows, or non-source files cannot change the analysis result.
- Add a `paths` filter to the `pull_request` trigger so CodeQL is skipped on those PRs (saves ~1–2 min per run building the CodeQL DB).
- `schedule` (weekly) and `workflow_dispatch` keep their existing behaviour, so the full repo is still scanned regularly even if a stretch of PRs is non-source.
- The workflow file itself is included in the path list so changes to the analysis config still trigger a run.

## Caveat
If `Analyze (javascript-typescript)` is set as a **required** branch protection check, skipped runs leave it pending and block merges. Either:
- drop the required-status, or
- split into a stub workflow that always reports success on the same check name.

Please confirm the protection setting before merging.

## Test plan
- [ ] Open a docs-only PR and verify CodeQL does not run.
- [ ] Open a `*.ts` PR and verify CodeQL runs.
- [ ] Edit `.github/workflows/codeql.yml` itself and verify CodeQL runs.