### PR TITLE
fix(ci): drop release-please package-name to fix tag creation

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,6 @@
   "bootstrap-sha": "1a32c3050da0b0c6b970268d5554759a6d1e8125",
   "packages": {
     ".": {
-      "package-name": "prive-admin-tanstack",
-      "component": "",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

Remove `package-name` and the empty `component` field from `release-please-config.json`. With both fields absent, the action's configured-component derivation produces an empty value that matches the parsed component (undefined) from the default `chore: release main` PR title.

## Why

Both v0.1.2 (#145) and v0.1.3 (#152) merged with the `autorelease: pending` label and never received a tag. The `Release Please` workflow log on each merge shows:

```
⚠ PR component: undefined does not match configured component: prive-admin-tanstack
⚠ There are untagged, merged release PRs outstanding - aborting
```

#146 attempted to fix this with `component: ""`, but release-please-action treats the empty string as falsy and falls back to `package-name` (`prive-admin-tanstack`) when comparing against the parsed component, so the mismatch persisted.

Both releases had to be tagged manually and the PR labels flipped to `autorelease: tagged`.

## Test plan

- [ ] After the next merged `chore: release main` PR, a `v*` tag and matching GitHub release are created automatically.
- [ ] `release.yml` triggers on that tag and deploys.
- [ ] No manual tagging or label flipping required.