### PR TITLE
fix(ci): set release-please package-name to empty string

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "bootstrap-sha": "1a32c3050da0b0c6b970268d5554759a6d1e8125",
   "packages": {
     ".": {
+      "package-name": "",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

Set `package-name: ""` in `release-please-config.json` so the post-merge release detection no longer aborts on a component mismatch.

## Why

#146 set `component: ""` and #154 removed `package-name` entirely; both left the `release-type: node` default in place, which falls back to reading `package.json` `name` (`prive-admin-tanstack`). v0.1.2 (#145), v0.1.3 (#152), and v0.1.4 (#155) all merged with `autorelease: pending` and required manual tagging.

The `Run release-please` step on each merge logged:

```
⚠ PR component: undefined does not match configured component: prive-admin-tanstack
⚠ There are untagged, merged release PRs outstanding - aborting
```

Tracing this in `googleapis/release-please/src/strategies/base.ts`:

- `getComponent()` returns `''` because `include-component-in-tag: false`.
- `getBranchComponent()` does NOT honour that flag: it returns `this.component || (await this.getDefaultComponent())`, and for `release-type: node` with no `package-name` the default reads `pkg.name` → `prive-admin-tanstack`.
- The `Merge` plugin produces a single PR on the default branch `release-please--branches--main` (no `--components--…` suffix), so `BranchName.parse(...)` yields `component: undefined`.
- Comparison `normalizeComponent(undefined) !== normalizeComponent("prive-admin-tanstack")` → mismatch → release skipped.

Setting `package-name: ""` makes `getDefaultPackageName()` (via `this.packageName ?? …`) return the empty string instead of falling through to `pkg.name`. `getDefaultComponent()` then normalises to `""`, which matches the parsed `undefined`.

## Test plan

- [ ] After the next merged `chore: release main` PR, a `v*` tag and matching GitHub release are created automatically.
- [ ] `release.yml` triggers on that tag and the deploy succeeds.
- [ ] No manual `git tag` / `gh release create` / label flip required.