### PR TITLE
fix(web): declare archiver module to unblock typecheck

### DIFF
--- a/apps/web/src/types/archiver.d.ts
+++ b/apps/web/src/types/archiver.d.ts
@@ -1,0 +1,5 @@
+// archiver@8 is ESM and ships no type declarations; @types/archiver is still on v6/v7
+// and describes a different (callable) API. We import the package as a namespace and
+// cast it to the ZipArchive shape we use; this shim only exists to satisfy module
+// resolution.
+declare module "archiver"


### PR DESCRIPTION
## Summary
- PR #148 / #159 squash exposed a tsc failure on CI: `Could not find a declaration file for module 'archiver'`. archiver@8 ships no types and `@types/archiver` is still v6/v7 (different API), so we removed the dep and cast inline.
- Adds a minimal `apps/web/src/types/archiver.d.ts` shim (`declare module "archiver"`) so module resolution succeeds. Runtime types continue to come from the inline cast in the export route.

## Test plan
- [x] `bun run check-types` passes locally with no `@types/archiver` in node_modules.
- [ ] PR Build "Check Types" step turns green.