### PR TITLE
chore(ci): bump github/codeql-action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy


### PR DESCRIPTION
## Summary
- v3 deprecated December 2026 per https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/.
- Bumps `init`, `analyze`, and `upload-sarif` to `@v4` across `codeql.yml` and `release.yml`.

## Test plan
- [ ] CodeQL workflow passes on this PR.
- [ ] Release workflow next run picks up v4 cleanly.