### PR TITLE
chore(backups): write postgres dumps under postgres_backup/ prefix in R2

### DIFF
--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -79,6 +79,6 @@ jobs:
           bucket_location = auto
           use_https = True
           EOF
-          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"
           s3cmd info "s3://${R2_BUCKET_NAME}" || true
-          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -14,7 +14,7 @@
 #   PG_CONTAINER      Local postgres container name. Default: prive-admin
 #   PG_SUPERUSER      Postgres superuser inside the container. Default: postgres
 #   PG_PASSWORD       Postgres password. Default: password
-#   R2_PREFIX         Limit listing to this key prefix (e.g. "pre-deploy/").
+#   R2_PREFIX         Limit listing to this key prefix. Default: postgres_backup/
 #   KEEP_DOWNLOAD     If set, keep the downloaded dump file after restore.
 #
 # The script depends on: op, s3cmd, docker, gzip (only when restoring .gz dumps).
@@ -75,7 +75,7 @@ bucket_location = auto
 use_https = True
 EOF
 
-LIST_PREFIX="s3://${R2_BUCKET_NAME}/${R2_PREFIX:-}"
+LIST_PREFIX="s3://${R2_BUCKET_NAME}/${R2_PREFIX:-postgres_backup/}"
 printf 'listing %s\n' "${LIST_PREFIX}"
 
 # s3cmd ls output: "YYYY-MM-DD HH:MM   SIZE   s3://bucket/key"


### PR DESCRIPTION
## Summary
- `backup-postgres.yml`: upload destination is now `s3://${R2_BUCKET_NAME}/postgres_backup/<file>` instead of bucket root.
- `restore_postgres.sh`: default `R2_PREFIX` is now `postgres_backup/`, so the interactive picker only lists postgres dumps. Override via env when restoring something else.
- The 20 existing objects in the `prive-admin` bucket were already relocated under `postgres_backup/` out-of-band, so the next scheduled run keeps using the same flat namespace within the prefix.

## Test plan
- [ ] Manually trigger `Daily Postgres Backup` workflow and confirm new file appears at `r2://prive-admin/postgres_backup/postgres_backup_<ts>.sql`.
- [ ] Run `scripts/restore_postgres.sh` locally — listing shows only objects under `postgres_backup/` and restore works.