### PR TITLE
chore(uploads): write statement attachments under statement_uploads/ prefix

### DIFF
--- a/apps/web/src/routes/api/statement-attachments.upload.ts
+++ b/apps/web/src/routes/api/statement-attachments.upload.ts
@@ -42,7 +42,7 @@ export const Route = createFileRoute("/api/statement-attachments/upload")({
         }
 
         const safeName = file.name.replace(/[^\w.-]+/g, "_")
-        const key = `statement-uploads/${entryId}/${Date.now()}-${safeName}`
+        const key = `statement_uploads/${entryId}/${Date.now()}-${safeName}`
         const arrayBuffer = await file.arrayBuffer()
 
         try {


### PR DESCRIPTION
## Summary
Match the `postgres_backup/` prefix convention introduced for daily DB backups. R2 keys for user-uploaded statement attachments are now `statement_uploads/{entryId}/{ts}-{safeName}` (was `statement-uploads/...`).

No data migration: the upload route has not yet shipped to main, so no R2 objects exist under the old prefix.

## Test plan
- [ ] Upload a file via the bank-statements paperclip; confirm key in R2 starts with `statement_uploads/`.