### PR TITLE
chore(dev): align dev compose container names + restore script defaults

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -15,5 +15,5 @@ CORS_ORIGIN=http://localhost:3001
 R2_ENDPOINT=http://localhost:9000
 R2_ACCESS_KEY_ID=minioadmin
 R2_SECRET_ACCESS_KEY=minioadmin
-R2_BUCKET_NAME=prive-admin-backup
+R2_BUCKET_NAME=prive-admin
 R2_FORCE_PATH_STYLE=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ name: prive-admin-dev
 services:
   postgres:
     image: postgres
-    container_name: prive-admin-postgres
+    container_name: postgres
     environment:
       POSTGRES_DB: prive_admin
       POSTGRES_USER: postgres
@@ -21,7 +21,7 @@ services:
 
   minio:
     image: minio/minio
-    container_name: prive-admin-minio
+    container_name: minio
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -40,14 +40,14 @@ services:
 
   minio-bucket:
     image: minio/mc
-    container_name: prive-admin-minio-bucket
+    container_name: minio-bucket
     depends_on:
       minio:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       mc alias set local http://minio:9000 minioadmin minioadmin;
-      mc mb --ignore-existing local/prive-admin-backup;
+      mc mb --ignore-existing local/prive-admin;
       exit 0;
       "
 

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Interactive restore of a Postgres dump from Cloudflare R2 into the local
-# database container defined in packages/db/docker-compose.yml.
+# database container defined in docker-compose.dev.yml.
 #
 # Usage:
 #   scripts/restore_postgres.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 umask 077
 
-PG_CONTAINER="${PG_CONTAINER:-prive-admin}"
+PG_CONTAINER="${PG_CONTAINER:-postgres}"
 PG_SUPERUSER="${PG_SUPERUSER:-postgres}"
 PG_PASSWORD="${PG_PASSWORD:-password}"
 
@@ -124,7 +124,7 @@ printf '\ndownloading %s\n' "${S3_KEY}"
 s3cmd -c "${S3CFG}" get "${S3_KEY}" "${LOCAL_PATH}"
 
 if ! docker ps --format '{{.Names}}' | grep -Fxq "${PG_CONTAINER}"; then
-  err "postgres container '${PG_CONTAINER}' is not running. Start it with: (cd packages/db && docker compose up -d)"
+  err "postgres container '${PG_CONTAINER}' is not running. Start it with: bun compose:up"
 fi
 
 # Validate the production role name we'll create locally — guards against


### PR DESCRIPTION
## Summary
- `docker-compose.dev.yml`: rename containers to plain `postgres`, `minio`, `minio-bucket`; init the bucket as `prive-admin` (matches the renamed prod bucket).
- `scripts/restore_postgres.sh`: `PG_CONTAINER` default → `postgres`, error hint points at `bun compose:up`, header doc references `docker-compose.dev.yml` (was `packages/db/docker-compose.yml`).
- `apps/web/.env.example`: `R2_BUCKET_NAME` default → `prive-admin`.

## Test plan
- [ ] `bun compose:up` starts containers, MinIO bucket `prive-admin` is created.
- [ ] `scripts/restore_postgres.sh` finds the local `postgres` container and lists `postgres_backup/` keys from R2.