### PR TITLE
feat(auth): block new user registrations

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -11,7 +11,6 @@ export function createAuth() {
   return betterAuth({
     database: drizzleAdapter(db, {
       provider: "pg",
-
       schema: schema,
     }),
     trustedOrigins: [env.CORS_ORIGIN],


### PR DESCRIPTION
## Summary
- Follow-up to #169 which used a `chore:` type and did not trigger a release.
- Re-cut as `feat:` so release-please publishes the sign-up disable change for deployment.
- Drops a stray blank line in `drizzleAdapter` config (no functional change).

## Test plan
- [ ] release-please opens / updates a release PR after merge.