### PR TITLE
chore(backups): write predeploy postgres dump under postgres_backup/ prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,8 @@ jobs:
           bucket_location = auto
           use_https = True
           EOF
-          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/${FILE_NAME}"
-          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/${FILE_NAME}"
+          s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"
+          echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"
 
   deploy:
     name: Deploy to prive


### PR DESCRIPTION
## Summary
- The scheduled backup workflow (`backup-postgres.yml`) was moved under the `postgres_backup/` prefix in #166, but the predeploy backup step in `release.yml` was missed.
- Without this fix, every release tag uploads its pre-deploy dump to the bucket root, defeating the prefix grouping and causing `restore_postgres.sh` (which now defaults `R2_PREFIX=postgres_backup/`) to skip those dumps in its picker.

## Test plan
- [ ] Trigger `Release` workflow (tag push or `workflow_dispatch`) and confirm the upload step logs `r2://<bucket>/postgres_backup/<file>`.
- [ ] Verify the new object lands under `postgres_backup/` in R2 and is listed by `restore_postgres.sh`.