### PR TITLE
feat(appointments): add create appointment dialog

### DIFF
--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -1,0 +1,146 @@
+import { Button, Group, Modal, Select, Stack, TextInput } from "@mantine/core"
+import { DateTimePicker } from "@mantine/dates"
+import { useForm } from "@mantine/form"
+import { notifications } from "@mantine/notifications"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import dayjs from "dayjs"
+import { useEffect } from "react"
+
+import { createAppointment } from "@/functions/appointments"
+import { getCustomers } from "@/functions/customers"
+import { listSalons } from "@/functions/salons"
+import { appointmentKeys, customerKeys, salonKeys } from "@/lib/query-keys"
+
+type CreateAppointmentDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  defaultClientId?: string
+  defaultStartsAt?: string | null
+  invalidateKeys?: { queryKey: readonly unknown[] }[]
+  navigateOnSuccess?: boolean
+}
+
+type FormValues = {
+  name: string
+  startsAt: string | null
+  clientId: string
+  salonId: string
+}
+
+const defaultStartsAtString = () => dayjs().startOf("hour").add(1, "hour").format("YYYY-MM-DD HH:mm:ss")
+
+export function CreateAppointmentDialog({
+  open,
+  onOpenChange,
+  defaultClientId,
+  defaultStartsAt,
+  invalidateKeys,
+  navigateOnSuccess,
+}: CreateAppointmentDialogProps) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const form = useForm<FormValues>({
+    initialValues: {
+      name: "",
+      startsAt: defaultStartsAt ?? defaultStartsAtString(),
+      clientId: defaultClientId ?? "",
+      salonId: "",
+    },
+    validate: {
+      name: (v) => (v.trim() ? null : "Name is required"),
+      startsAt: (v) => (v ? null : "Start time is required"),
+      clientId: (v) => (v ? null : "Client is required"),
+      salonId: (v) => (v ? null : "Salon is required"),
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      form.setValues({
+        name: "",
+        startsAt: defaultStartsAt ?? defaultStartsAtString(),
+        clientId: defaultClientId ?? "",
+        salonId: "",
+      })
+      form.resetDirty()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, defaultClientId, defaultStartsAt])
+
+  const { data: customers } = useQuery({
+    queryKey: customerKeys.list(),
+    queryFn: () => getCustomers(),
+    enabled: open && !defaultClientId,
+  })
+
+  const { data: salons } = useQuery({
+    queryKey: salonKeys.list(),
+    queryFn: () => listSalons(),
+    enabled: open,
+  })
+
+  const mutation = useMutation({
+    mutationFn: (values: FormValues) =>
+      createAppointment({
+        data: {
+          name: values.name.trim(),
+          startsAt: dayjs(values.startsAt!).toISOString(),
+          clientId: values.clientId,
+          salonId: values.salonId,
+        },
+      }),
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: appointmentKeys.all })
+      for (const key of invalidateKeys ?? []) queryClient.invalidateQueries(key)
+      notifications.show({ color: "green", message: "Appointment created" })
+      onOpenChange(false)
+      if (navigateOnSuccess && created?.id) {
+        navigate({ to: "/appointments/$appointmentId", params: { appointmentId: created.id } })
+      }
+    },
+    onError: (error) => notifications.show({ color: "red", message: error.message }),
+  })
+
+  const handleSubmit = (values: FormValues) => mutation.mutate(values)
+
+  return (
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="New Appointment">
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Stack>
+          <TextInput label="Name" placeholder="Appointment name" required {...form.getInputProps("name")} />
+          <DateTimePicker
+            label="Starts at"
+            required
+            valueFormat="DD MMM YYYY HH:mm"
+            {...form.getInputProps("startsAt")}
+          />
+          {!defaultClientId && (
+            <Select
+              label="Client"
+              required
+              searchable
+              data={(customers ?? []).map((c) => ({ value: c.id, label: c.name }))}
+              {...form.getInputProps("clientId")}
+            />
+          )}
+          <Select
+            label="Salon"
+            required
+            data={(salons ?? []).map((s) => ({ value: s.id, label: s.name }))}
+            {...form.getInputProps("salonId")}
+          />
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={mutation.isPending}>
+              Create
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  )
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -26,6 +26,12 @@ export const appointmentKeys = {
   byCustomer: (customerId: string) => [...appointmentKeys.all, "by-customer", customerId] as const,
 }
 
+export const salonKeys = {
+  all: ["salons"] as const,
+  list: () => [...salonKeys.all, "list"] as const,
+  detail: (id: string) => [...salonKeys.all, "detail", id] as const,
+}
+
 export const hairOrderKeys = {
   all: ["hair-orders"] as const,
   list: () => [...hairOrderKeys.all, "list"] as const,

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -1,6 +1,5 @@
-import { Button, Container, Group, Stack, Title } from "@mantine/core"
+import { Container, Stack, Title } from "@mantine/core"
 import { Schedule, type ScheduleEventData, type ScheduleViewLevel } from "@mantine/schedule"
-import { IconPlus } from "@tabler/icons-react"
 import { queryOptions, useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
@@ -28,6 +27,12 @@ function CalendarPage() {
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(dayjs().format("YYYY-MM-DD"))
   const [createOpen, setCreateOpen] = useState(false)
+  const [defaultStartsAt, setDefaultStartsAt] = useState<string | null>(null)
+
+  const openCreate = useCallback((startsAt: string | null) => {
+    setDefaultStartsAt(startsAt)
+    setCreateOpen(true)
+  }, [])
 
   const events = useMemo<ScheduleEventData[]>(() => {
     return (appointments ?? []).map((a) => {
@@ -71,12 +76,7 @@ function CalendarPage() {
   return (
     <Container size="xl">
       <Stack>
-        <Group justify="space-between">
-          <Title order={2}>Calendar</Title>
-          <Button leftSection={<IconPlus size={14} />} onClick={() => setCreateOpen(true)}>
-            New appointment
-          </Button>
-        </Group>
+        <Title order={2}>Calendar</Title>
         <Schedule
           events={events}
           view={view}
@@ -85,6 +85,8 @@ function CalendarPage() {
           onDateChange={setDate}
           layout="responsive"
           onEventClick={(event) => goToAppointment(String(event.id))}
+          onTimeSlotClick={({ slotStart }) => openCreate(slotStart)}
+          onDayClick={(d) => openCreate(`${d} 09:00:00`)}
           dayViewProps={{
             startTime: "09:00:00",
             endTime: "19:00:00",
@@ -103,6 +105,7 @@ function CalendarPage() {
         <CreateAppointmentDialog
           open={createOpen}
           onOpenChange={setCreateOpen}
+          defaultStartsAt={defaultStartsAt}
           invalidateKeys={[{ queryKey: appointmentKeys.list() }]}
           navigateOnSuccess
         />

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -1,10 +1,12 @@
-import { Container, Stack, Title } from "@mantine/core"
+import { Button, Container, Group, Stack, Title } from "@mantine/core"
 import { Schedule, type ScheduleEventData, type ScheduleViewLevel } from "@mantine/schedule"
+import { IconPlus } from "@tabler/icons-react"
 import { queryOptions, useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
+import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
 import { getAppointments } from "@/functions/appointments"
 import { appointmentKeys } from "@/lib/query-keys"
 
@@ -25,6 +27,7 @@ function CalendarPage() {
   const navigate = useNavigate()
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(dayjs().format("YYYY-MM-DD"))
+  const [createOpen, setCreateOpen] = useState(false)
 
   const events = useMemo<ScheduleEventData[]>(() => {
     return (appointments ?? []).map((a) => {
@@ -68,7 +71,12 @@ function CalendarPage() {
   return (
     <Container size="xl">
       <Stack>
-        <Title order={2}>Calendar</Title>
+        <Group justify="space-between">
+          <Title order={2}>Calendar</Title>
+          <Button leftSection={<IconPlus size={14} />} onClick={() => setCreateOpen(true)}>
+            New appointment
+          </Button>
+        </Group>
         <Schedule
           events={events}
           view={view}
@@ -91,6 +99,12 @@ function CalendarPage() {
           monthViewProps={{
             firstDayOfWeek: 1,
           }}
+        />
+        <CreateAppointmentDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          invalidateKeys={[{ queryKey: appointmentKeys.list() }]}
+          navigateOnSuccess
         />
       </Stack>
     </Container>

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -24,6 +24,7 @@ import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/r
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
 import { ClientDate } from "@/components/client-date"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
 import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair-assigned-dialog"
@@ -182,6 +183,7 @@ function CustomerDetailPage() {
   const { customerId } = Route.useParams()
   const [editOpen, setEditOpen] = useState(false)
   const [noteOpen, setNoteOpen] = useState(false)
+  const [appointmentCreateOpen, setAppointmentCreateOpen] = useState(false)
   const [hairCreateOpen, setHairCreateOpen] = useState(false)
   const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
   const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
@@ -312,6 +314,17 @@ function CustomerDetailPage() {
 
           <Tabs.Panel value="appointments" pt="md">
             <Card withBorder>
+              <Group justify="space-between" mb="sm">
+                <Title order={5}>Appointments</Title>
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  leftSection={<IconPlus size={12} />}
+                  onClick={() => setAppointmentCreateOpen(true)}
+                >
+                  New
+                </Button>
+              </Group>
               {appointments && appointments.length > 0 ? (
                 <Table>
                   <Table.Thead>
@@ -400,6 +413,16 @@ function CustomerDetailPage() {
 
         <EditCustomerDialog customer={customer} open={editOpen} onOpenChange={setEditOpen} />
         <AddNoteDialog customerId={customerId} open={noteOpen} onOpenChange={setNoteOpen} />
+        <CreateAppointmentDialog
+          open={appointmentCreateOpen}
+          onOpenChange={setAppointmentCreateOpen}
+          defaultClientId={customerId}
+          invalidateKeys={[
+            { queryKey: appointmentKeys.byCustomer(customerId) },
+            { queryKey: customerKeys.summary(customerId) },
+          ]}
+          navigateOnSuccess
+        />
         <CreateHairAssignedDialog
           open={hairCreateOpen}
           onOpenChange={setHairCreateOpen}


### PR DESCRIPTION
## Summary
- New shared `CreateAppointmentDialog` (name + start time + client + salon)
- Customer detail page Appointments tab: new "New" button, client pre-filled and hidden
- Calendar page: new "New appointment" button in header
- Adds `salonKeys` to query-keys; invalidates `appointmentKeys.all` plus caller-provided keys; optional navigate to created appointment

## Test plan
- [ ] Open customer detail → Appointments tab → "New" → fill name/time/salon → submit → lands on new appointment
- [ ] Open `/calendar` → "New appointment" → fill all fields → submit → lands on new appointment, calendar list refreshes
- [ ] Cancel button + close icon close dialog without submit
- [ ] Validation errors shown for missing name/time/client/salon