### PR TITLE
feat(calendar): configure schedule view-specific props

### DIFF
--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -77,6 +77,20 @@ function CalendarPage() {
           onDateChange={setDate}
           layout="responsive"
           onEventClick={(event) => goToAppointment(String(event.id))}
+          dayViewProps={{
+            startTime: "09:00:00",
+            endTime: "19:00:00",
+            intervalMinutes: 30,
+          }}
+          weekViewProps={{
+            startTime: "09:00:00",
+            endTime: "19:00:00",
+            intervalMinutes: 30,
+            withWeekendDays: true,
+          }}
+          monthViewProps={{
+            firstDayOfWeek: 1,
+          }}
         />
       </Stack>
     </Container>


### PR DESCRIPTION
## Summary
- Add `dayViewProps`, `weekViewProps`, `monthViewProps` to `Schedule` in `apps/web/src/routes/_authenticated/calendar.tsx`
- Day/week views: business hours 09:00-19:00, 30min slot granularity, weekends visible
- Month view: Monday as first day of week

## Test plan
- [x] Open `/calendar`, switch through day/week/month views
- [x] Confirm day & week views show 09:00-19:00 with 30min slots
- [x] Confirm weekends visible in week view
- [x] Confirm month view starts on Monday