### PR TITLE
feat(bank-accounts): support Swedbank CSV statement imports

### DIFF
--- a/apps/web/src/functions/bank-statement-entries.ts
+++ b/apps/web/src/functions/bank-statement-entries.ts
@@ -8,13 +8,13 @@ import { and, desc, eq } from "drizzle-orm"
 import { z } from "zod"
 
 import { requireAuthMiddleware } from "@/middleware/auth"
-import { parseSebCsv } from "@/server/seb-csv.server"
+import { parseBankCsv } from "@/server/bank-csv.server"
 
-export const importSebCsv = createServerFn({ method: "POST" })
+export const importBankCsv = createServerFn({ method: "POST" })
   .middleware([requireAuthMiddleware])
   .inputValidator(z.object({ csv: z.string().min(1) }))
   .handler(async ({ data }) => {
-    const parsed = parseSebCsv(data.csv)
+    const parsed = parseBankCsv(data.csv)
 
     const account = await db.query.bankAccount.findFirst({
       where: eq(bankAccount.iban, parsed.accountIban),

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -51,7 +51,7 @@ import {
 import {
   getBankStatementEntry,
   ignoreStatementEntry,
-  importSebCsv,
+  importBankCsv,
   listBankStatementEntries,
   promoteEntryToTransaction,
   undoStatementEntry,
@@ -114,7 +114,7 @@ function BankAccountShow({ id }: { id: string }) {
   })
 
   const importMutation = useMutation({
-    mutationFn: async (csv: string) => importSebCsv({ data: { csv } }),
+    mutationFn: async (csv: string) => importBankCsv({ data: { csv } }),
     onSuccess: async (result) => {
       setImportResult(result)
       setFile(null)
@@ -213,7 +213,7 @@ function BankAccountShow({ id }: { id: string }) {
 
           <Card withBorder>
             <Stack>
-              <Text fw={500}>Upload SEB statement (CSV)</Text>
+              <Text fw={500}>Upload bank statement (SEB or Swedbank CSV)</Text>
               <Group align="end">
                 <FileInput
                   placeholder="Pick a .csv file"

--- a/apps/web/src/server/bank-csv.server.ts
+++ b/apps/web/src/server/bank-csv.server.ts
@@ -1,0 +1,39 @@
+import { parseSebCsv } from "./seb-csv.server"
+import { parseSwedbankCsv } from "./swedbank-csv.server"
+
+export type BankCsvRow = {
+  docNumber: string
+  date: string // YYYY-MM-DD
+  currency: string
+  amount: number // minor units
+  counterpartyName: string | null
+  counterpartyIban: string | null
+  counterpartyBank: string | null
+  swift: string | null
+  purpose: string | null
+  externalRef: string
+  transactionType: string | null
+  direction: "D" | "C"
+  accountAmount: number // minor units
+  accountIban: string
+  accountCurrency: string
+}
+
+export type BankCsvParse = {
+  accountIban: string
+  rows: BankCsvRow[]
+}
+
+export type BankCsvFormat = "SEB" | "SWEDBANK"
+
+export function detectBankCsvFormat(content: string): BankCsvFormat {
+  const stripped = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content
+  const firstLine = stripped.split(/\r?\n/, 1)[0] ?? ""
+  if (firstLine.includes('"Account No"')) return "SWEDBANK"
+  return "SEB"
+}
+
+export function parseBankCsv(content: string): BankCsvParse {
+  const format = detectBankCsvFormat(content)
+  return format === "SWEDBANK" ? parseSwedbankCsv(content) : parseSebCsv(content)
+}

--- a/apps/web/src/server/swedbank-csv.server.ts
+++ b/apps/web/src/server/swedbank-csv.server.ts
@@ -1,0 +1,87 @@
+import { parse as parseCsv } from "csv-parse/sync"
+
+import type { BankCsvParse, BankCsvRow } from "./bank-csv.server"
+
+function decimalToMinor(value: string): number {
+  const trimmed = value.trim()
+  if (!trimmed) return 0
+  const normalized = trimmed.replace(/\s/g, "").replace(",", ".")
+  const num = Number(normalized)
+  if (!Number.isFinite(num)) {
+    throw new Error(`Cannot parse amount: ${value}`)
+  }
+  return Math.round(num * 100)
+}
+
+function emptyToNull(value: string | undefined | null): string | null {
+  if (value === undefined || value === null) return null
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? null : trimmed
+}
+
+// Swedbank LT CSV export. Comma delimited, quoted fields. Columns:
+// 0 Account No, 1 Code (10/20/82/86), 2 Date, 3 Beneficiary, 4 Details,
+// 5 Amount, 6 Currency, 7 D/K, 8 Record ID, 9 Code, 10 Reference No,
+// 11 Doc. No, 12 Code in payer IS, 13 Client code, 14 Originator, 15 Beneficiary party.
+// Only code "20" rows are real transactions; 10/82/86 are balance/turnover summaries.
+export function parseSwedbankCsv(content: string): BankCsvParse {
+  const stripped = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content
+
+  const records = parseCsv(stripped, {
+    delimiter: ",",
+    relax_column_count: true,
+    skip_empty_lines: true,
+  }) as string[][]
+
+  if (records.length < 2) {
+    throw new Error("CSV file is empty or missing header")
+  }
+
+  const dataRows = records.slice(1)
+
+  let accountIban = ""
+  const rows: BankCsvRow[] = []
+
+  for (const cols of dataRows) {
+    const rowCode = (cols[1] ?? "").trim()
+    if (rowCode !== "20") continue
+
+    const iban = (cols[0] ?? "").trim()
+    if (!accountIban) accountIban = iban
+
+    const directionRaw = (cols[7] ?? "").trim()
+    let direction: "D" | "C"
+    if (directionRaw === "K") direction = "C"
+    else if (directionRaw === "D") direction = "D"
+    else throw new Error(`Unexpected direction value: ${cols[7]}`)
+
+    const amount = decimalToMinor(cols[5] ?? "0")
+    const currency = (cols[6] ?? "").trim()
+    const externalRef = (cols[8] ?? "").trim()
+    if (!externalRef) continue
+
+    rows.push({
+      docNumber: (cols[11] ?? "").trim(),
+      date: (cols[2] ?? "").trim(),
+      currency,
+      amount,
+      counterpartyName: emptyToNull(cols[3]),
+      counterpartyIban: null,
+      counterpartyBank: null,
+      swift: null,
+      purpose: emptyToNull(cols[4]),
+      externalRef,
+      transactionType: emptyToNull(cols[9]),
+      direction,
+      accountAmount: amount,
+      accountIban: iban,
+      accountCurrency: currency,
+    })
+  }
+
+  if (!accountIban) {
+    throw new Error("Could not extract account IBAN from Swedbank CSV")
+  }
+
+  return { accountIban, rows }
+}


### PR DESCRIPTION
## Summary
- Add Swedbank LT CSV parser (comma-delimited, filters to code 20 transaction rows, maps K/D direction to C/D).
- Add `parseBankCsv` dispatcher that detects format from header (`\"Account No\"` → Swedbank, else SEB) and delegates.
- Rename server fn `importSebCsv` → `importBankCsv`; update UI label to mention both banks.

## Test plan
- [ ] Upload existing SEB CSV — still imports as before.
- [ ] Upload Swedbank CSV against a bank account whose IBAN matches the file — only code 20 rows imported, balance/turnover/closing rows skipped.
- [ ] Re-upload same Swedbank CSV — duplicates skipped via `(bank_account_id, external_ref)` unique constraint.
- [ ] Upload Swedbank CSV when no matching bank account exists — clear error surfaced.