### PR TITLE
ci(deps-update): retry taze on npm registry timeouts

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -30,7 +30,11 @@ jobs:
           DEPS_PAT: op://prive-admin/PAT prive-admin deps bot/token
 
       - name: Run taze major
-        run: bunx taze major -r -w
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: bunx taze major -r -w
 
       - name: Update Lockfile
         run: bun install


### PR DESCRIPTION
## Summary
- Wrap the `taze major -r -w` step in `nick-fields/retry@v3` (max 3 attempts, 5 min each).
- Fixes silent package skips caused by transient `Timeout requesting "<pkg>"` errors from npm.

## Why
Taze fetches each dependency from the npm registry serially with concurrency 10. On flaky CI networks some requests time out and taze logs `ERROR Timeout requesting "<pkg>"` but still exits 0, so the nightly PR opens missing newly published versions.

Example from run [25781919611](https://github.com/moreorover/prive-admin/actions/runs/25781919611):

\`\`\`
> @mantine/core unknown error
Error: Timeout requesting "@mantine/core"
> @mantine/form unknown error
Error: Timeout requesting "@mantine/form"
\`\`\`

Result: PR #173 bumped 6 of 8 `@mantine/*` packages in `apps/web` and skipped `core` + `form`.

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and confirm step succeeds.
- [ ] Verify `chore/auto-dep-updates` PR picks up all currently-outdated `@mantine/*` packages.
- [ ] Confirm retry kicks in on simulated/real timeout (transient — observable in next flaky run).