### PR TITLE
ci(deps-update): fail step on taze timeouts so retry triggers

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -34,7 +34,15 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: bunx taze major -r -w
+          shell: bash
+          command: |
+            set -o pipefail
+            log=$(mktemp)
+            bunx taze major -r -w --concurrency 3 2>&1 | tee "$log"
+            if grep -q 'Timeout requesting' "$log"; then
+              echo "::warning::taze hit registry timeouts; failing step to trigger retry"
+              exit 1
+            fi
 
       - name: Update Lockfile
         run: bun install


### PR DESCRIPTION
## Summary
- Tee taze output, grep for `Timeout requesting`, exit 1 on hit so `nick-fields/retry@v3` re-runs the step.
- Drop `--concurrency` from default 10 to 3 to reduce flakes at the source.

## Why
PR #183 added retry but it never fired — taze prints `ERROR Timeout requesting "<pkg>"` and still exits 0, so retry saw success on attempt 1. Confirmed in run [25813486676](https://github.com/moreorover/prive-admin/actions/runs/25813486676):

```
ERROR
> @aws-sdk/client-s3 unknown error
Error: Timeout requesting "@aws-sdk/client-s3"
> drizzle-orm unknown error
Error: Timeout requesting "drizzle-orm"
...
Command completed after 1 attempt(s).
```

Detecting the string in stderr and forcing a non-zero exit is the only way to make the retry wrapper useful, since taze has no `--fail-on-error` flag.

## Test plan
- [ ] Trigger workflow via `workflow_dispatch`.
- [ ] If a timeout occurs, confirm a second/third attempt runs.
- [ ] Confirm the nightly PR picks up all currently-outdated `@mantine/*` packages (incl. `core`, `form` that PR #173 missed).
- [ ] If all 3 attempts fail, the step fails loud rather than silently opening a partial PR.