### PR TITLE
ci(pr-build): skip workflow on .github/** and markdown-only PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - ".github/**"
+      - "**/*.md"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `pr-build.yml` so the source build and docker image build don't run on PRs that only touch `.github/**` or markdown.

## Why
PR #184 (workflow YAML change) triggers a full docker image build that takes minutes and validates nothing — no runtime code changed. Same logic for docs-only PRs.

Branch protection on `main` is currently off, so removing these checks for non-code PRs doesn't risk merging unverified code. Mixed PRs (code + yaml) still run all checks.

## Test plan
- [ ] After merge, push a `.github/**`-only PR (or re-run #184 with this branch merged) and confirm `PR Build Check` doesn't appear.
- [ ] Push a code-only PR and confirm both source build + docker build run as before.
- [ ] Push a mixed code + `.github/**` PR and confirm both jobs run.