### PR TITLE
ci: separate dependency audit from PR build

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,27 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Audit Production Dependencies
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Audit Dependencies
+        run: bun audit --prod

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@
 name: "Dependency review"
 on:
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
@@ -34,6 +34,6 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-        #   fail-on-severity: moderate
+          fail-on-severity: high
         #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
         #   retry-on-snapshot-warnings: true

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -38,7 +38,7 @@ jobs:
           command: |
             set -o pipefail
             log=$(mktemp)
-            bunx taze major -r -w --concurrency 3 2>&1 | tee "$log"
+            bunx taze major -r -w --maturity-period 7 --concurrency 3 2>&1 | tee "$log"
             if grep -q 'Timeout requesting' "$log"; then
               echo "::warning::taze hit registry timeouts; failing step to trigger retry"
               exit 1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Audit Dependencies
-        run: bun audit --prod --ignore GHSA-67mh-4wv8-2f99
-
       - name: Lint
         run: bunx oxlint
 


### PR DESCRIPTION
## Summary
- remove full dependency audit from the generic PR build job
- run dependency review against main PRs and fail on high-severity newly introduced vulnerable dependencies
- add a scheduled/manual production dependency audit workflow
- delay automated taze dependency updates by 7 days after package release

## Validation
- Parsed touched workflow YAML files successfully