### PR TITLE
chore: add production Caddy logging and hardening

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,13 @@
 {$DOMAIN_NAME} {
   encode zstd gzip
+  log {
+    output stdout
+    format console
+  }
+
+  @percent_encoded_path expression `{http.request.uri}.matches("^[^?]*%.*")`
+  respond @percent_encoded_path "Bad Request" 400
+
   reverse_proxy web:8081
   tls {$ACME_EMAIL}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,32 @@
+{
+  admin 0.0.0.0:2019
+}
+
 {$DOMAIN_NAME} {
   encode zstd gzip
   log {
     output stdout
-    format console
+    format json
   }
 
   @percent_encoded_path expression `{http.request.uri}.matches("^[^?]*%.*")`
   respond @percent_encoded_path "Bad Request" 400
 
-  reverse_proxy web:8081
+  header {
+    X-Content-Type-Options nosniff
+    Referrer-Policy strict-origin-when-cross-origin
+    X-Frame-Options DENY
+    -Server
+  }
+
+  request_body {
+    max_size 25MB
+  }
+
+  reverse_proxy web:8081 {
+    header_up X-Real-IP {remote_host}
+    header_up X-Forwarded-Proto {scheme}
+  }
+
   tls {$ACME_EMAIL}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "${TAILSCALE_IP}:2019:2019"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - /var/lib/prive-admin/caddy/data:/data

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -20,6 +20,9 @@ export function createAuth() {
     },
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
+    logger: {
+      level: "debug",
+    },
     plugins: [tanstackStartCookies()],
   })
 }


### PR DESCRIPTION
## Summary
- enable Caddy access logs in JSON format
- reject percent-encoded request paths before they hit the app runtime
- expose Caddy admin API on the Tailscale-bound compose port
- add basic response security headers, request body limit, and forwarded proxy headers
- enable Better Auth debug logging

## Validation
- bun run --cwd apps/web check-types
- docker compose config could not complete locally because .env is not present
- caddy validate was not run locally because caddy is not installed