### PR TITLE
fix: display currency amounts in euros

### DIFF
--- a/apps/web/src/components/dashboard-kpis.tsx
+++ b/apps/web/src/components/dashboard-kpis.tsx
@@ -161,5 +161,5 @@ function HairCard({ title, data }: { title: string; data: HairMonthlyBreakdown |
 }
 
 function fmtCents(cents: number) {
-  return `$${(cents / 100).toFixed(2)}`
+  return `€${(cents / 100).toFixed(2)}`
 }

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -19,7 +19,7 @@ type HairAssignedTableProps = {
   onDelete: (item: HairAssignedRow) => void
 }
 
-const formatCents = (cents: number) => `$${(cents / 100).toFixed(2)}`
+const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 
 export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, onDelete }: HairAssignedTableProps) {
   if (items.length === 0) {
@@ -39,7 +39,7 @@ export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, 
           <Table.Th>Weight</Table.Th>
           <Table.Th>Sold For</Table.Th>
           <Table.Th>Profit</Table.Th>
-          <Table.Th>$/g</Table.Th>
+          <Table.Th>€/g</Table.Th>
           <Table.Th />
         </Table.Tr>
       </Table.Thead>

--- a/apps/web/src/components/transactions/edit-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/edit-transaction-dialog.tsx
@@ -43,7 +43,7 @@ export function EditTransactionDialog({ open, onOpenChange, transaction, invalid
   const initialStatus: "PENDING" | "COMPLETED" = transaction.status === "COMPLETED" ? "COMPLETED" : "PENDING"
   const initialCurrency: Currency = (CURRENCIES as readonly string[]).includes(transaction.currency)
     ? (transaction.currency as Currency)
-    : "GBP"
+    : "EUR"
 
   return (
     <Modal opened={open} onClose={() => onOpenChange(false)} title="Edit Transaction">

--- a/apps/web/src/functions/user-settings.ts
+++ b/apps/web/src/functions/user-settings.ts
@@ -17,7 +17,7 @@ export const getUserSettings = createServerFn({ method: "GET" })
     if (row) {
       return { userId: row.userId, preferredCurrency: row.preferredCurrency }
     }
-    return { userId, preferredCurrency: "GBP" as const }
+    return { userId, preferredCurrency: "EUR" as const }
   })
 
 export const updateUserSettings = createServerFn({ method: "POST" })

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -1,4 +1,4 @@
-import { z } from "zod"
+import {z} from "zod"
 
 export const CURRENCIES = ["GBP", "EUR"] as const
 export type Currency = (typeof CURRENCIES)[number]

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -1,4 +1,4 @@
-import {z} from "zod"
+import { z } from "zod"
 
 export const CURRENCIES = ["GBP", "EUR"] as const
 export type Currency = (typeof CURRENCIES)[number]

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -133,7 +133,7 @@ function AppointmentDetailPage() {
   const currenciesPresent = CURRENCIES.filter(
     (c) => totalsByCurrency[c].completed !== 0 || totalsByCurrency[c].pending !== 0,
   )
-  const chartCurrency: Currency = currenciesPresent[0] ?? "GBP"
+  const chartCurrency: Currency = currenciesPresent[0] ?? "EUR"
   const chartData = [
     { name: "Completed", value: Math.abs(totalsByCurrency[chartCurrency].completed), color: "green.4" },
     { name: "Pending", value: Math.abs(totalsByCurrency[chartCurrency].pending), color: "pink.6" },
@@ -168,7 +168,7 @@ function AppointmentDetailPage() {
   const txCustomerId = createTxCustomerId ?? appointment.client.id
   const txDefaultCurrency: Currency = (() => {
     const raw = userSettings?.preferredCurrency
-    return raw && (CURRENCIES as readonly string[]).includes(raw) ? (raw as Currency) : "GBP"
+    return raw && (CURRENCIES as readonly string[]).includes(raw) ? (raw as Currency) : "EUR"
   })()
 
   const openCreateTx = (customerId: string) => {
@@ -296,13 +296,13 @@ function AppointmentDetailPage() {
                 {currenciesPresent.length === 0 ? (
                   <Stack gap={2}>
                     <Text size="sm">
-                      Completed: <b>{formatMinor(0, "GBP")}</b>
+                      Completed: <b>{formatMinor(0, "EUR")}</b>
                     </Text>
                     <Text size="sm">
-                      Pending: <b>{formatMinor(0, "GBP")}</b>
+                      Pending: <b>{formatMinor(0, "EUR")}</b>
                     </Text>
                     <Text size="sm">
-                      Total: <b>{formatMinor(0, "GBP")}</b>
+                      Total: <b>{formatMinor(0, "EUR")}</b>
                     </Text>
                   </Stack>
                 ) : (
@@ -353,7 +353,7 @@ function AppointmentDetailPage() {
           {(() => {
             const txRows: TransactionRow[] = txList.map((t) => ({
               ...t,
-              currency: (CURRENCIES as readonly string[]).includes(t.currency) ? (t.currency as Currency) : "GBP",
+              currency: (CURRENCIES as readonly string[]).includes(t.currency) ? (t.currency as Currency) : "EUR",
               legalEntityId: t.legalEntityId,
               legalEntity: t.legalEntity ?? null,
             }))

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -282,12 +282,12 @@ function CustomerDetailPage() {
                   const parts = CURRENCIES.flatMap((c) =>
                     summary.transactionSumsMinor[c] !== 0 ? [formatMinor(summary.transactionSumsMinor[c], c)] : [],
                   )
-                  return parts.length > 0 ? parts.join(" · ") : formatMinor(0, "GBP")
+                  return parts.length > 0 ? parts.join(" · ") : formatMinor(0, "EUR")
                 })()}
               </Title>
             </Card>
-            <StatCard label="Hair profit" value={`£${summary.hairAssignedProfitSum.toFixed(2)}`} />
-            <StatCard label="Hair sold for" value={`£${summary.hairAssignedSoldForSum.toFixed(2)}`} />
+            <StatCard label="Hair profit" value={`€${summary.hairAssignedProfitSum.toFixed(2)}`} />
+            <StatCard label="Hair sold for" value={`€${summary.hairAssignedSoldForSum.toFixed(2)}`} />
             <StatCard label="Hair weight" value={`${summary.hairAssignedWeightInGramsSum}g`} />
             <StatCard label="Notes" value={String(summary.noteCount)} />
             <Card padding="md">

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -47,7 +47,7 @@ export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")
   },
 })
 
-const formatCents = (cents: number) => `$${(cents / 100).toFixed(2)}`
+const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 
 function HairOrderDetailPage() {
   const { hairOrderId } = Route.useParams()

--- a/apps/web/src/routes/_authenticated/profile.tsx
+++ b/apps/web/src/routes/_authenticated/profile.tsx
@@ -116,7 +116,7 @@ function ProfilePage() {
                 {user.email}
               </Text>
               <Text fz="xs" c="dimmed">
-                Preferred currency: {settings?.preferredCurrency ?? "GBP"}
+                Preferred currency: {settings?.preferredCurrency ?? "EUR"}
               </Text>
             </Stack>
           </Group>
@@ -205,7 +205,7 @@ function ProfilePage() {
         open={editOpen}
         onOpenChange={setEditOpen}
         initialName={user.name}
-        initialCurrency={settings?.preferredCurrency ?? "GBP"}
+        initialCurrency={settings?.preferredCurrency ?? "EUR"}
       />
       <ChangePasswordModal open={pwOpen} onOpenChange={setPwOpen} />
     </Container>
@@ -222,7 +222,7 @@ type EditUserModalProps = {
 function EditUserModal({ open, onOpenChange, initialName, initialCurrency }: EditUserModalProps) {
   const queryClient = useQueryClient()
   const [submitting, setSubmitting] = useState(false)
-  const safeInitialCurrency: Currency = initialCurrency === "GBP" || initialCurrency === "EUR" ? initialCurrency : "GBP"
+  const safeInitialCurrency: Currency = initialCurrency === "GBP" || initialCurrency === "EUR" ? initialCurrency : "EUR"
   const form = useForm({ initialValues: { name: initialName, preferredCurrency: safeInitialCurrency } })
 
   const settingsMutation = useMutation({


### PR DESCRIPTION
## Summary
- display all formatted currency amounts with the euro symbol
- update currency fallbacks/defaults to EUR
- replace hard-coded pound/dollar amount labels in UI surfaces

## Verification
- bun run check-types
- rg -n '£' apps/web/src packages --glob '!**/migrations/**' --glob '!**/*.gen.ts'