### PR TITLE
refactor: remove bank transaction linking

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1068.0",
-    "@mantine/charts": "^9.3.1",
     "@mantine/core": "^9.3.1",
     "@mantine/dates": "^9.3.1",
     "@mantine/form": "^9.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1068.0",
+    "@mantine/charts": "^9.3.1",
     "@mantine/core": "^9.3.1",
     "@mantine/dates": "^9.3.1",
     "@mantine/form": "^9.3.1",

--- a/apps/web/src/components/dashboard-kpis.tsx
+++ b/apps/web/src/components/dashboard-kpis.tsx
@@ -15,8 +15,8 @@ const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Se
 
 export function DashboardKpis({ year, legalEntityId }: { year: number; legalEntityId: string }) {
   const txQuery = useQuery({
-    queryKey: [...dashboardKeys.transactionStats(year), legalEntityId],
-    queryFn: () => getTransactionStatsForDate({ data: { year, legalEntityId: legalEntityId || undefined } }),
+    queryKey: dashboardKeys.transactionStats(year),
+    queryFn: () => getTransactionStatsForDate({ data: { year } }),
   })
   const hairAptQuery = useQuery({
     queryKey: [...dashboardKeys.hairAssignedStats(year), legalEntityId],

--- a/apps/web/src/components/hair-orders-table.tsx
+++ b/apps/web/src/components/hair-orders-table.tsx
@@ -9,18 +9,20 @@ type HairOrderRow = {
   status: string
   weightReceived: number
   placedAt: string | null
+  legalEntityId: string
   customer: { name: string } | null
-  legalEntity: { name: string } | null
 }
 
 export function HairOrdersTable({
   hairOrders,
   isLoading,
   showLegalEntityColumn = true,
+  legalEntityNames,
 }: {
   hairOrders: HairOrderRow[] | undefined
   isLoading: boolean
   showLegalEntityColumn?: boolean
+  legalEntityNames?: Record<string, string>
 }) {
   return (
     <Table>
@@ -81,9 +83,9 @@ export function HairOrdersTable({
                 <Table.Td c="dimmed">{ho.placedAt ? <ClientDate date={ho.placedAt} /> : "—"}</Table.Td>
                 {showLegalEntityColumn && (
                   <Table.Td>
-                    {ho.legalEntity ? (
+                    {legalEntityNames?.[ho.legalEntityId] ? (
                       <Badge variant="light" size="sm">
-                        {ho.legalEntity.name}
+                        {legalEntityNames[ho.legalEntityId]}
                       </Badge>
                     ) : null}
                   </Table.Td>

--- a/apps/web/src/components/reports-cards.tsx
+++ b/apps/web/src/components/reports-cards.tsx
@@ -1,6 +1,6 @@
 import { Card, Group, Stack, Table, Text } from "@mantine/core"
 
-import type { BankAccountMonthlyBreakdown, CashMonthlyBreakdown } from "@/functions/reports"
+import type { BankAccountMonthlyBreakdown } from "@/functions/reports"
 
 import { type Currency, formatMinor } from "@/lib/currency"
 
@@ -59,80 +59,6 @@ export function BankAccountReportCard({ a }: { a: BankAccountMonthlyBreakdown })
               {formatMinor(a.totalIn - a.totalOut, a.currency as Currency)}
             </Table.Td>
           </Table.Tr>
-        </Table.Tbody>
-      </Table>
-    </Card>
-  )
-}
-
-export function CashReportTable({ data }: { data: CashMonthlyBreakdown[] }) {
-  const rows: { month: number; currency: string; in: number; out: number }[] = []
-  for (const c of data) {
-    for (const m of c.months) {
-      if (m.in !== 0 || m.out !== 0) rows.push({ month: m.month, currency: c.currency, in: m.in, out: m.out })
-    }
-  }
-  rows.sort((a, b) => a.month - b.month || a.currency.localeCompare(b.currency))
-
-  return (
-    <Card withBorder>
-      <Group justify="space-between" mb="xs">
-        <Text fw={500}>Cash (manual transactions)</Text>
-      </Group>
-      <Table striped>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Month</Table.Th>
-            <Table.Th>Currency</Table.Th>
-            <Table.Th ta="right">In</Table.Th>
-            <Table.Th ta="right">Out</Table.Th>
-            <Table.Th ta="right">Net</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {rows.map((r) => {
-            const net = r.in - r.out
-            return (
-              <Table.Tr key={`${r.month}-${r.currency}`}>
-                <Table.Td>{MONTH_NAMES[r.month - 1]}</Table.Td>
-                <Table.Td>{r.currency}</Table.Td>
-                <Table.Td ta="right" c={r.in > 0 ? "teal" : "dimmed"}>
-                  {formatMinor(r.in, r.currency as Currency)}
-                </Table.Td>
-                <Table.Td ta="right" c={r.out > 0 ? "red" : "dimmed"}>
-                  {formatMinor(r.out, r.currency as Currency)}
-                </Table.Td>
-                <Table.Td ta="right" fw={500} c={net > 0 ? "teal" : net < 0 ? "red" : "dimmed"}>
-                  {formatMinor(net, r.currency as Currency)}
-                </Table.Td>
-              </Table.Tr>
-            )
-          })}
-          {rows.length === 0 && (
-            <Table.Tr>
-              <Table.Td colSpan={5} ta="center" c="dimmed">
-                No cash transactions.
-              </Table.Td>
-            </Table.Tr>
-          )}
-          {data.map((c) => {
-            const net = c.totalIn - c.totalOut
-            return (
-              <Table.Tr key={`total-${c.currency}`}>
-                <Table.Td fw={600}>Total</Table.Td>
-                <Table.Td fw={600}>{c.currency}</Table.Td>
-                <Table.Td ta="right" fw={600} c="teal">
-                  {formatMinor(c.totalIn, c.currency as Currency)}
-                </Table.Td>
-                <Table.Td ta="right" fw={600} c="red">
-                  {formatMinor(c.totalOut, c.currency as Currency)}
-                </Table.Td>
-                <Table.Td ta="right" fw={700} c={net > 0 ? "teal" : net < 0 ? "red" : "dimmed"}>
-                  {formatMinor(net, c.currency as Currency)}
-                </Table.Td>
-              </Table.Tr>
-            )
-          })}
         </Table.Tbody>
       </Table>
     </Card>

--- a/apps/web/src/components/transactions/create-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/create-transaction-dialog.tsx
@@ -16,14 +16,6 @@ type CreateTransactionDialogProps = {
   invalidateKeys: { queryKey: readonly unknown[] }[]
 }
 
-const todayIso = () => {
-  const d = new Date()
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, "0")
-  const day = String(d.getDate()).padStart(2, "0")
-  return `${year}-${month}-${day}`
-}
-
 export function CreateTransactionDialog({
   open,
   onOpenChange,
@@ -53,10 +45,6 @@ export function CreateTransactionDialog({
           notes: "",
           amountMajor: 0,
           currency: defaultCurrency,
-          type: "BANK",
-          status: "PENDING",
-          completedDateBy: todayIso(),
-          legalEntityId: "",
         }}
         submitLabel="Create"
         loading={mutation.isPending}

--- a/apps/web/src/components/transactions/edit-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/edit-transaction-dialog.tsx
@@ -15,10 +15,6 @@ type EditTransactionDialogProps = {
     notes: string | null
     amount: number
     currency: Currency | string
-    type: "BANK" | "CASH" | "PAYPAL" | string
-    status: "PENDING" | "COMPLETED" | string
-    completedDateBy: string
-    legalEntityId: string
   }
   invalidateKeys: { queryKey: readonly unknown[] }[]
 }
@@ -36,11 +32,6 @@ export function EditTransactionDialog({ open, onOpenChange, transaction, invalid
     onError: (error) => notifications.show({ color: "red", message: error.message }),
   })
 
-  const initialType: "BANK" | "CASH" | "PAYPAL" =
-    transaction.type === "BANK" || transaction.type === "CASH" || transaction.type === "PAYPAL"
-      ? transaction.type
-      : "BANK"
-  const initialStatus: "PENDING" | "COMPLETED" = transaction.status === "COMPLETED" ? "COMPLETED" : "PENDING"
   const initialCurrency: Currency = (CURRENCIES as readonly string[]).includes(transaction.currency)
     ? (transaction.currency as Currency)
     : "EUR"
@@ -53,10 +44,6 @@ export function EditTransactionDialog({ open, onOpenChange, transaction, invalid
           notes: transaction.notes ?? "",
           amountMajor: transaction.amount / 100,
           currency: initialCurrency,
-          type: initialType,
-          status: initialStatus,
-          completedDateBy: transaction.completedDateBy,
-          legalEntityId: transaction.legalEntityId,
         }}
         submitLabel="Save Changes"
         loading={mutation.isPending}

--- a/apps/web/src/components/transactions/transaction-form.tsx
+++ b/apps/web/src/components/transactions/transaction-form.tsx
@@ -1,22 +1,14 @@
-import { Button, Group, NativeSelect, NumberInput, Select, Stack, Textarea, TextInput } from "@mantine/core"
-import { DateInput } from "@mantine/dates"
+import { Button, Group, NativeSelect, NumberInput, Stack, Textarea, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
-import { listLegalEntities } from "@/functions/legal-entities"
 import { CURRENCY_OPTIONS, type Currency, currencySymbol } from "@/lib/currency"
-import { COUNTRY_FLAGS, type Country } from "@/lib/legal-entity"
 
 export type TransactionFormValues = {
   name: string
   notes: string
   amountMajor: number
   currency: Currency
-  type: "BANK" | "CASH" | "PAYPAL"
-  status: "PENDING" | "COMPLETED"
-  completedDateBy: string | null
-  legalEntityId: string
 }
 
 export type TransactionFormSubmit = {
@@ -24,10 +16,6 @@ export type TransactionFormSubmit = {
   notes: string | null
   amount: number
   currency: Currency
-  type: "BANK" | "CASH" | "PAYPAL"
-  status: "PENDING" | "COMPLETED"
-  completedDateBy: string
-  legalEntityId: string
 }
 
 type TransactionFormProps = {
@@ -38,75 +26,32 @@ type TransactionFormProps = {
 }
 
 export function TransactionForm({ initialValues, submitLabel, onSubmit, loading }: TransactionFormProps) {
-  const legalEntitiesQuery = useQuery({ queryKey: ["legal-entities"], queryFn: () => listLegalEntities() })
-
   const form = useForm<TransactionFormValues>({
     mode: "uncontrolled",
     initialValues,
     validate: {
-      completedDateBy: (value) => (value ? null : "Date is required"),
       amountMajor: (value) => (Number.isFinite(value) ? null : "Amount is required"),
     },
   })
 
   // react-doctor-disable-next-line react-doctor/no-derived-useState
-  const [status, setStatus] = useState<TransactionFormValues["status"]>(initialValues.status)
-  // react-doctor-disable-next-line react-doctor/no-derived-useState
   const [currency, setCurrency] = useState<Currency>(initialValues.currency)
-  const dateLabel = status === "COMPLETED" ? "When was it completed?" : "When should it be completed by?"
 
   return (
     <form
       onSubmit={form.onSubmit(async (values) => {
-        if (!values.completedDateBy) return
         await onSubmit({
           name: values.name.trim() || null,
           notes: values.notes.trim() || null,
           amount: Math.round(values.amountMajor * 100),
           currency: values.currency,
-          type: values.type,
-          status: values.status,
-          completedDateBy: values.completedDateBy,
-          legalEntityId: values.legalEntityId,
         })
       })}
     >
       <Stack>
         <TextInput label="Name" placeholder="Transaction name" {...form.getInputProps("name")} />
         <Textarea label="Notes" placeholder="Notes (optional)" autosize minRows={2} {...form.getInputProps("notes")} />
-        <Select
-          label="Legal entity"
-          required
-          data={(legalEntitiesQuery.data ?? []).map((le) => ({
-            value: le.id,
-            label: `${COUNTRY_FLAGS[le.country as Country] ?? ""} ${le.name}`,
-          }))}
-          value={form.values.legalEntityId}
-          onChange={(v) => form.setFieldValue("legalEntityId", v ?? "")}
-        />
         <Group grow>
-          <NativeSelect
-            label="Type"
-            data={[
-              { value: "BANK", label: "Bank" },
-              { value: "CASH", label: "Cash" },
-              { value: "PAYPAL", label: "PayPal" },
-            ]}
-            {...form.getInputProps("type")}
-          />
-          <NativeSelect
-            label="Status"
-            data={[
-              { value: "PENDING", label: "Pending" },
-              { value: "COMPLETED", label: "Completed" },
-            ]}
-            {...form.getInputProps("status")}
-            onChange={(event) => {
-              const next = event.currentTarget.value as TransactionFormValues["status"]
-              form.setFieldValue("status", next)
-              setStatus(next)
-            }}
-          />
           <NativeSelect
             label="Currency"
             data={CURRENCY_OPTIONS}
@@ -118,7 +63,6 @@ export function TransactionForm({ initialValues, submitLabel, onSubmit, loading 
             }}
           />
         </Group>
-        <DateInput label={dateLabel} valueFormat="DD MMM YYYY" required {...form.getInputProps("completedDateBy")} />
         <NumberInput
           label="Amount"
           prefix={currencySymbol(currency)}

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -1,7 +1,6 @@
-import { ActionIcon, Badge, Group, Menu, Table, Text, Tooltip } from "@mantine/core"
-import { IconAlertTriangle, IconCheck, IconClock, IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
+import { ActionIcon, Menu, Table, Text } from "@mantine/core"
+import { IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
-import dayjs from "dayjs"
 
 import { type Currency, formatMinor } from "@/lib/currency"
 
@@ -11,26 +10,15 @@ export type TransactionRow = {
   notes: string | null
   amount: number
   currency: Currency
-  type: "BANK" | "CASH" | "PAYPAL" | string
-  status: "PENDING" | "COMPLETED" | string
-  completedDateBy: string
   customerId: string | null
   appointmentId: string | null
-  legalEntityId: string
   customer?: { id: string; name: string } | null
-  legalEntity?: { id: string; name: string } | null
 }
 
 type TransactionsTableProps = {
   items: TransactionRow[]
   onEdit: (item: TransactionRow) => void
   onDelete: (item: TransactionRow) => void
-}
-
-const typeColor: Record<string, string> = {
-  BANK: "teal",
-  CASH: "blue",
-  PAYPAL: "grape",
 }
 
 export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTableProps) {
@@ -48,89 +36,48 @@ export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTable
         <Table.Tr>
           <Table.Th>Customer</Table.Th>
           <Table.Th>Name</Table.Th>
-          <Table.Th>Legal Entity</Table.Th>
-          <Table.Th>Type</Table.Th>
           <Table.Th>Amount</Table.Th>
-          <Table.Th>Completed</Table.Th>
           <Table.Th />
         </Table.Tr>
       </Table.Thead>
       <Table.Tbody>
-        {items.map((tx) => {
-          const isCompleted = tx.status === "COMPLETED"
-          const completedDate = dayjs(tx.completedDateBy)
-          const isOverdue = !isCompleted && completedDate.isBefore(dayjs(), "day")
-          const statusBadgeColor = isCompleted ? "green" : "pink"
-          const statusIcon = isCompleted ? <IconCheck size={12} /> : <IconClock size={12} />
-          return (
-            <Table.Tr key={tx.id}>
-              <Table.Td>
-                {tx.customer ? (
-                  <Text
-                    renderRoot={(props) => (
-                      <Link to="/customers/$customerId" params={{ customerId: tx.customer!.id }} {...props} />
-                    )}
-                    c="blue"
-                  >
-                    {tx.customer.name}
-                  </Text>
-                ) : (
-                  "—"
-                )}
-              </Table.Td>
-              <Table.Td>{tx.name ?? <Text c="dimmed">—</Text>}</Table.Td>
-              <Table.Td>
-                {tx.legalEntity ? (
-                  <Badge variant="outline" color="gray" size="sm">
-                    {tx.legalEntity.name}
-                  </Badge>
-                ) : (
-                  <Text c="dimmed">—</Text>
-                )}
-              </Table.Td>
-              <Table.Td>
-                <Badge color={typeColor[tx.type] ?? "gray"} variant="light">
-                  {tx.type}
-                </Badge>
-              </Table.Td>
-              <Table.Td>{formatMinor(tx.amount, tx.currency)}</Table.Td>
-              <Table.Td>
-                <Group gap="xs" align="center">
-                  <Badge color={statusBadgeColor} leftSection={statusIcon} radius="sm" size="sm" variant="light">
-                    {tx.status}
-                  </Badge>
-                  <Text size="xs" c={isOverdue ? "red" : "dimmed"} fw={500}>
-                    {completedDate.format("DD MMM YYYY")}
-                  </Text>
-                  {isOverdue && (
-                    <Tooltip label="Pending transaction is overdue" withArrow>
-                      <span style={{ display: "inline-flex" }} tabIndex={0} aria-label="Overdue">
-                        <IconAlertTriangle size={14} color="red" />
-                      </span>
-                    </Tooltip>
+        {items.map((tx) => (
+          <Table.Tr key={tx.id}>
+            <Table.Td>
+              {tx.customer ? (
+                <Text
+                  renderRoot={(props) => (
+                    <Link to="/customers/$customerId" params={{ customerId: tx.customer!.id }} {...props} />
                   )}
-                </Group>
-              </Table.Td>
-              <Table.Td>
-                <Menu shadow="md" width={140} position="bottom-end">
-                  <Menu.Target>
-                    <ActionIcon variant="subtle" size="sm" aria-label="Actions">
-                      <IconDots size={14} />
-                    </ActionIcon>
-                  </Menu.Target>
-                  <Menu.Dropdown>
-                    <Menu.Item leftSection={<IconPencil size={14} />} onClick={() => onEdit(tx)}>
-                      Update
-                    </Menu.Item>
-                    <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => onDelete(tx)}>
-                      Delete
-                    </Menu.Item>
-                  </Menu.Dropdown>
-                </Menu>
-              </Table.Td>
-            </Table.Tr>
-          )
-        })}
+                  c="blue"
+                >
+                  {tx.customer.name}
+                </Text>
+              ) : (
+                "—"
+              )}
+            </Table.Td>
+            <Table.Td>{tx.name ?? <Text c="dimmed">—</Text>}</Table.Td>
+            <Table.Td>{formatMinor(tx.amount, tx.currency)}</Table.Td>
+            <Table.Td>
+              <Menu shadow="md" width={140} position="bottom-end">
+                <Menu.Target>
+                  <ActionIcon variant="subtle" size="sm" aria-label="Actions">
+                    <IconDots size={14} />
+                  </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Item leftSection={<IconPencil size={14} />} onClick={() => onEdit(tx)}>
+                    Update
+                  </Menu.Item>
+                  <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => onDelete(tx)}>
+                    Delete
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            </Table.Td>
+          </Table.Tr>
+        ))}
       </Table.Tbody>
     </Table>
   )

--- a/apps/web/src/functions/bank-accounts.ts
+++ b/apps/web/src/functions/bank-accounts.ts
@@ -16,13 +16,6 @@ export const getBankAccount = createServerFn({ method: "GET" })
       with: {
         legalEntity: true,
         statementEntries: {
-          with: {
-            linkedTransaction: {
-              with: {
-                customer: { columns: { id: true, name: true } },
-              },
-            },
-          },
           orderBy: (e, { desc }) => [desc(e.date), desc(e.importedAt)],
         },
       },

--- a/apps/web/src/functions/bank-statement-entries.ts
+++ b/apps/web/src/functions/bank-statement-entries.ts
@@ -1,8 +1,6 @@
 import { db } from "@prive-admin-tanstack/db"
-import { personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
 import { bankAccount } from "@prive-admin-tanstack/db/schema/bank-account"
 import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
-import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
 import { createServerFn } from "@tanstack/react-start"
 import { and, desc, eq } from "drizzle-orm"
 import { z } from "zod"
@@ -68,7 +66,7 @@ export const listBankStatementEntries = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       bankAccountId: z.string().optional(),
-      status: z.enum(["PENDING", "LINKED", "IGNORED"]).optional(),
+      status: z.enum(["PENDING", "IGNORED"]).optional(),
     }),
   )
   .handler(async ({ data }) => {
@@ -80,7 +78,6 @@ export const listBankStatementEntries = createServerFn({ method: "GET" })
       where: conditions.length > 0 ? and(...conditions) : undefined,
       with: {
         bankAccount: { with: { legalEntity: true } },
-        linkedTransaction: true,
       },
       orderBy: [desc(bankStatementEntry.date), desc(bankStatementEntry.importedAt)],
       limit: 500,
@@ -95,76 +92,10 @@ export const getBankStatementEntry = createServerFn({ method: "GET" })
       where: eq(bankStatementEntry.id, data.id),
       with: {
         bankAccount: { with: { legalEntity: true } },
-        linkedTransaction: true,
       },
     })
     if (!row) throw new Error("Statement entry not found")
     return row
-  })
-
-export const promoteEntryToTransaction = createServerFn({ method: "POST" })
-  .middleware([requireAuthMiddleware])
-  .inputValidator(
-    z.object({
-      entryId: z.string().min(1),
-      customerId: z.string().min(1),
-      appointmentId: z.string().nullish(),
-      name: z.string().nullish(),
-      notes: z.string().nullish(),
-    }),
-  )
-  .handler(async ({ data }) => {
-    return await db.transaction(async (tx) => {
-      const entry = await tx.query.bankStatementEntry.findFirst({
-        where: eq(bankStatementEntry.id, data.entryId),
-        with: { bankAccount: { columns: { id: true, legalEntityId: true } } },
-      })
-      if (!entry) throw new Error("Statement entry not found")
-      if (entry.status === "LINKED") throw new Error("Entry already linked to a transaction")
-      if (entry.status === "IGNORED") throw new Error("Entry is marked ignored; un-ignore first")
-
-      if (data.appointmentId) {
-        const allowed = new Set<string>()
-        const appt = await tx.query.appointment.findFirst({
-          where: (a, { eq }) => eq(a.id, data.appointmentId!),
-          columns: { id: true, clientId: true },
-        })
-        if (!appt) throw new Error("Appointment not found")
-        allowed.add(appt.clientId)
-        const personnel = await tx
-          .select({ personnelId: personnelOnAppointments.personnelId })
-          .from(personnelOnAppointments)
-          .where(eq(personnelOnAppointments.appointmentId, data.appointmentId))
-        for (const p of personnel) allowed.add(p.personnelId)
-        if (!allowed.has(data.customerId)) {
-          throw new Error("Customer must be the appointment client or assigned personnel")
-        }
-      }
-
-      const [created] = await tx
-        .insert(transaction)
-        .values({
-          name: data.name ?? null,
-          notes: data.notes ?? entry.purpose ?? null,
-          amount: entry.amount,
-          currency: entry.currency,
-          type: "BANK",
-          status: "COMPLETED",
-          completedDateBy: entry.date,
-          customerId: data.customerId,
-          appointmentId: data.appointmentId ?? null,
-          legalEntityId: entry.bankAccount.legalEntityId,
-          bankAccountId: entry.bankAccount.id,
-        })
-        .returning()
-
-      await tx
-        .update(bankStatementEntry)
-        .set({ status: "LINKED", linkedTransactionId: created.id })
-        .where(eq(bankStatementEntry.id, entry.id))
-
-      return { transactionId: created.id, entryId: entry.id }
-    })
   })
 
 export const ignoreStatementEntry = createServerFn({ method: "POST" })
@@ -184,20 +115,11 @@ export const undoStatementEntry = createServerFn({ method: "POST" })
   .middleware([requireAuthMiddleware])
   .inputValidator(z.object({ id: z.string().min(1) }))
   .handler(async ({ data }) => {
-    return await db.transaction(async (tx) => {
-      const entry = await tx.query.bankStatementEntry.findFirst({
-        where: eq(bankStatementEntry.id, data.id),
-        columns: { id: true, status: true, linkedTransactionId: true },
-      })
-      if (!entry) throw new Error("Statement entry not found")
-      if (entry.status === "LINKED" && entry.linkedTransactionId) {
-        await tx.delete(transaction).where(eq(transaction.id, entry.linkedTransactionId))
-      }
-      const [row] = await tx
-        .update(bankStatementEntry)
-        .set({ status: "PENDING", linkedTransactionId: null })
-        .where(eq(bankStatementEntry.id, entry.id))
-        .returning({ id: bankStatementEntry.id, status: bankStatementEntry.status })
-      return row
-    })
+    const [row] = await db
+      .update(bankStatementEntry)
+      .set({ status: "PENDING" })
+      .where(eq(bankStatementEntry.id, data.id))
+      .returning({ id: bankStatementEntry.id, status: bankStatementEntry.status })
+    if (!row) throw new Error("Statement entry not found")
+    return row
   })

--- a/apps/web/src/functions/dashboard.ts
+++ b/apps/web/src/functions/dashboard.ts
@@ -1,4 +1,4 @@
-import { db, whereActiveLegalEntity } from "@prive-admin-tanstack/db"
+import { db } from "@prive-admin-tanstack/db"
 import { appointment } from "@prive-admin-tanstack/db/schema/appointment"
 import { hairAssigned, hairOrder } from "@prive-admin-tanstack/db/schema/hair"
 import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
@@ -10,6 +10,9 @@ import { requireAuthMiddleware } from "@/middleware/auth"
 
 const yearSchema = z.object({
   year: z.number().int().min(2000).max(3000),
+})
+
+const scopedYearSchema = yearSchema.extend({
   legalEntityId: z.string().optional(),
 })
 
@@ -29,20 +32,19 @@ export const getTransactionStatsForDate = createServerFn({ method: "GET" })
     const rows = await db
       .select({
         currency: transaction.currency,
-        month: sql<number>`extract(month from ${transaction.completedDateBy})::int`,
+        month: sql<number>`extract(month from ${appointment.startsAt})::int`,
         sum: sql<number>`coalesce(sum(${transaction.amount}), 0)::int`,
       })
       .from(transaction)
+      .innerJoin(appointment, eq(transaction.appointmentId, appointment.id))
       .where(
         and(
-          gte(transaction.completedDateBy, yearStart),
-          lt(transaction.completedDateBy, yearEnd),
-          eq(transaction.status, "COMPLETED"),
+          gte(appointment.startsAt, new Date(`${yearStart}T00:00:00.000Z`)),
+          lt(appointment.startsAt, new Date(`${yearEnd}T00:00:00.000Z`)),
           isNotNull(transaction.appointmentId),
-          data.legalEntityId ? whereActiveLegalEntity(transaction.legalEntityId, data.legalEntityId) : undefined,
         ),
       )
-      .groupBy(transaction.currency, sql`extract(month from ${transaction.completedDateBy})`)
+      .groupBy(transaction.currency, sql`extract(month from ${appointment.startsAt})`)
 
     return buildCurrencyBuckets(rows)
   })
@@ -56,7 +58,7 @@ export type HairMonthlyBreakdown = {
 
 export const getHairAssignedStatsForDate = createServerFn({ method: "GET" })
   .middleware([requireAuthMiddleware])
-  .inputValidator(yearSchema)
+  .inputValidator(scopedYearSchema)
   .handler(async ({ data }): Promise<HairMonthlyBreakdown> => {
     const { current } = yearlyRanges(data.year)
     const rows = await db
@@ -84,7 +86,7 @@ export const getHairAssignedStatsForDate = createServerFn({ method: "GET" })
 
 export const getHairAssignedThroughSaleStatsForDate = createServerFn({ method: "GET" })
   .middleware([requireAuthMiddleware])
-  .inputValidator(yearSchema)
+  .inputValidator(scopedYearSchema)
   .handler(async ({ data }): Promise<HairMonthlyBreakdown> => {
     const { current } = yearlyRanges(data.year)
     const rows = await db

--- a/apps/web/src/functions/hair-orders.ts
+++ b/apps/web/src/functions/hair-orders.ts
@@ -14,7 +14,7 @@ export const getHairOrders = createServerFn({ method: "GET" })
     const filter = data?.legalEntityId ? whereActiveLegalEntity(hairOrder.legalEntityId, data.legalEntityId) : undefined
     return db.query.hairOrder.findMany({
       where: filter,
-      with: { createdBy: true, customer: true, legalEntity: true },
+      with: { createdBy: true, customer: true },
       orderBy: (hairOrder, { asc }) => [asc(hairOrder.uid)],
     })
   })
@@ -28,7 +28,6 @@ export const getHairOrder = createServerFn({ method: "GET" })
       with: {
         createdBy: true,
         customer: true,
-        legalEntity: true,
         hairAssigned: { with: { client: true } },
         notes: { with: { createdBy: true } },
       },

--- a/apps/web/src/functions/reports.ts
+++ b/apps/web/src/functions/reports.ts
@@ -1,8 +1,6 @@
 import { db } from "@prive-admin-tanstack/db"
 import { bankAccount } from "@prive-admin-tanstack/db/schema/bank-account"
 import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
-import { legalEntity } from "@prive-admin-tanstack/db/schema/legal-entity"
-import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
 import { createServerFn } from "@tanstack/react-start"
 import { and, eq, gte, inArray, lt, sql } from "drizzle-orm"
 import { z } from "zod"
@@ -101,79 +99,4 @@ export const getBankAccountMonthlyBreakdown = createServerFn({ method: "GET" })
         totalOut,
       }
     })
-  })
-
-export type CashMonthlyBreakdown = {
-  legalEntityId: string
-  legalEntityName: string
-  currency: string
-  months: { month: number; in: number; out: number }[]
-  totalIn: number
-  totalOut: number
-}
-
-export const getCashMonthlyBreakdown = createServerFn({ method: "GET" })
-  .middleware([requireAuthMiddleware])
-  .inputValidator(yearSchema)
-  .handler(async ({ data }): Promise<CashMonthlyBreakdown[]> => {
-    const yearStart = `${data.year}-01-01`
-    const yearEnd = `${data.year + 1}-01-01`
-
-    const rows = await db
-      .select({
-        legalEntityId: transaction.legalEntityId,
-        legalEntityName: legalEntity.name,
-        currency: transaction.currency,
-        month: sql<number>`extract(month from ${transaction.completedDateBy})::int`,
-        sumIn: sql<number>`coalesce(sum(case when ${transaction.amount} > 0 then ${transaction.amount} else 0 end), 0)::int`,
-        sumOut: sql<number>`coalesce(sum(case when ${transaction.amount} < 0 then -${transaction.amount} else 0 end), 0)::int`,
-      })
-      .from(transaction)
-      .innerJoin(legalEntity, eq(transaction.legalEntityId, legalEntity.id))
-      .where(
-        and(
-          eq(transaction.type, "CASH"),
-          eq(transaction.status, "COMPLETED"),
-          gte(transaction.completedDateBy, yearStart),
-          lt(transaction.completedDateBy, yearEnd),
-          data.legalEntityId ? eq(transaction.legalEntityId, data.legalEntityId) : undefined,
-        ),
-      )
-      .groupBy(
-        transaction.legalEntityId,
-        legalEntity.name,
-        transaction.currency,
-        sql`extract(month from ${transaction.completedDateBy})`,
-      )
-
-    const grouped = new Map<string, CashMonthlyBreakdown>()
-    for (const r of rows) {
-      const key = `${r.legalEntityId}::${r.currency}`
-      const existing = grouped.get(key) ?? {
-        legalEntityId: r.legalEntityId,
-        legalEntityName: r.legalEntityName,
-        currency: r.currency,
-        months: [],
-        totalIn: 0,
-        totalOut: 0,
-      }
-      existing.months.push({ month: r.month, in: Number(r.sumIn), out: Number(r.sumOut) })
-      existing.totalIn += Number(r.sumIn)
-      existing.totalOut += Number(r.sumOut)
-      grouped.set(key, existing)
-    }
-
-    // Backfill missing months with zero entries (consistent shape) and sort.
-    const result: CashMonthlyBreakdown[] = []
-    for (const v of grouped.values()) {
-      const monthMap = new Map(v.months.map((m) => [m.month, m]))
-      const months: { month: number; in: number; out: number }[] = []
-      for (let mo = 1; mo <= 12; mo++) {
-        const b = monthMap.get(mo)
-        months.push({ month: mo, in: b?.in ?? 0, out: b?.out ?? 0 })
-      }
-      result.push({ ...v, months })
-    }
-    result.sort((a, b) => a.legalEntityName.localeCompare(b.legalEntityName) || a.currency.localeCompare(b.currency))
-    return result
   })

--- a/apps/web/src/functions/transactions.ts
+++ b/apps/web/src/functions/transactions.ts
@@ -8,19 +8,11 @@ import { z } from "zod"
 import { currencySchema } from "@/lib/currency"
 import { requireAuthMiddleware } from "@/middleware/auth"
 
-const transactionTypeSchema = z.enum(["BANK", "CASH", "PAYPAL"])
-const transactionStatusSchema = z.enum(["PENDING", "COMPLETED"])
-const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD")
-
 const transactionFieldsSchema = z.object({
   name: z.string().nullish(),
   notes: z.string().nullish(),
   amount: z.number().int(),
   currency: currencySchema,
-  type: transactionTypeSchema,
-  status: transactionStatusSchema,
-  completedDateBy: dateStringSchema,
-  legalEntityId: z.string().min(1, "Legal entity is required"),
 })
 
 export const getTransactionsByAppointmentId = createServerFn({ method: "GET" })
@@ -31,9 +23,8 @@ export const getTransactionsByAppointmentId = createServerFn({ method: "GET" })
       where: eq(transaction.appointmentId, data.appointmentId),
       with: {
         customer: { columns: { id: true, name: true } },
-        legalEntity: { columns: { id: true, name: true, type: true, country: true } },
       },
-      orderBy: (tx, { asc }) => [asc(tx.completedDateBy)],
+      orderBy: (tx, { asc }) => [asc(tx.createdAt)],
     })
   })
 
@@ -76,10 +67,6 @@ export const createTransaction = createServerFn({ method: "POST" })
           notes: data.notes ?? null,
           amount: data.amount,
           currency: data.currency,
-          type: data.type,
-          status: data.status,
-          completedDateBy: data.completedDateBy,
-          legalEntityId: data.legalEntityId,
         })
         .returning()
       return result
@@ -104,10 +91,6 @@ export const updateTransaction = createServerFn({ method: "POST" })
         notes: data.notes ?? null,
         amount: data.amount,
         currency: data.currency,
-        type: data.type,
-        status: data.status,
-        completedDateBy: data.completedDateBy,
-        legalEntityId: data.legalEntityId,
       })
       .where(eq(transaction.id, data.id))
       .returning()

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,4 @@
 @import "@prive-admin-tanstack/ui/globals.css";
+@import "@mantine/charts/styles.css";
 @import "@mantine/dates/styles.css";
 @import "@mantine/schedule/styles.css";

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,4 +1,3 @@
 @import "@prive-admin-tanstack/ui/globals.css";
-@import "@mantine/charts/styles.css";
 @import "@mantine/dates/styles.css";
 @import "@mantine/schedule/styles.css";

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -1,8 +1,6 @@
-import { DonutChart } from "@mantine/charts"
 import {
   ActionIcon,
   Anchor,
-  Badge,
   Button,
   Card,
   Checkbox,
@@ -24,7 +22,6 @@ import {
   IconCash,
   IconClock,
   IconDots,
-  IconLink,
   IconPlus,
   IconUser,
   IconUsers,
@@ -44,7 +41,6 @@ import { DeleteTransactionDialog } from "@/components/transactions/delete-transa
 import { EditTransactionDialog } from "@/components/transactions/edit-transaction-dialog"
 import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
 import { getAppointment, linkPersonnel } from "@/functions/appointments"
-import { listBankStatementEntries, promoteEntryToTransaction } from "@/functions/bank-statement-entries"
 import { getCustomers } from "@/functions/customers"
 import { getHairAssignedByAppointment } from "@/functions/hair-assigned"
 import { getTransactionsByAppointmentId } from "@/functions/transactions"
@@ -94,9 +90,6 @@ function AppointmentDetailPage() {
   const [createTxCustomerId, setCreateTxCustomerId] = useState<string | null>(null)
   const [editTx, setEditTx] = useState<TransactionRow | null>(null)
   const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
-  const [linkBankOpen, setLinkBankOpen] = useState(false)
-
-  const queryClient = useQueryClient()
 
   const { data: appointment, isLoading } = useQuery({
     queryKey: appointmentKeys.detail(appointmentId),
@@ -119,25 +112,16 @@ function AppointmentDetailPage() {
   })
 
   const txList = transactions ?? []
-  const totalsByCurrency: Record<Currency, { completed: number; pending: number; total: number }> = {
-    GBP: { completed: 0, pending: 0, total: 0 },
-    EUR: { completed: 0, pending: 0, total: 0 },
+  const totalsByCurrency: Record<Currency, { total: number }> = {
+    GBP: { total: 0 },
+    EUR: { total: 0 },
   }
   for (const t of txList) {
     const c = t.currency as Currency
     if (!(c in totalsByCurrency)) continue
     totalsByCurrency[c].total += t.amount
-    if (t.status === "COMPLETED") totalsByCurrency[c].completed += t.amount
-    else if (t.status === "PENDING") totalsByCurrency[c].pending += t.amount
   }
-  const currenciesPresent = CURRENCIES.filter(
-    (c) => totalsByCurrency[c].completed !== 0 || totalsByCurrency[c].pending !== 0,
-  )
-  const chartCurrency: Currency = currenciesPresent[0] ?? "EUR"
-  const chartData = [
-    { name: "Completed", value: Math.abs(totalsByCurrency[chartCurrency].completed), color: "green.4" },
-    { name: "Pending", value: Math.abs(totalsByCurrency[chartCurrency].pending), color: "pink.6" },
-  ]
+  const currenciesPresent = CURRENCIES.filter((c) => totalsByCurrency[c].total !== 0)
 
   if (isLoading) {
     return (
@@ -291,16 +275,9 @@ function AppointmentDetailPage() {
             </Text>
           ) : (
             <Group align="flex-start" gap="xl" wrap="wrap">
-              <DonutChart size={124} thickness={15} data={chartData} withLabels={false} />
               <Stack gap="md">
                 {currenciesPresent.length === 0 ? (
                   <Stack gap={2}>
-                    <Text size="sm">
-                      Completed: <b>{formatMinor(0, "EUR")}</b>
-                    </Text>
-                    <Text size="sm">
-                      Pending: <b>{formatMinor(0, "EUR")}</b>
-                    </Text>
                     <Text size="sm">
                       Total: <b>{formatMinor(0, "EUR")}</b>
                     </Text>
@@ -310,12 +287,6 @@ function AppointmentDetailPage() {
                     <Stack key={c} gap={2}>
                       <Text size="xs" c="dimmed" tt="uppercase">
                         {c}
-                      </Text>
-                      <Text size="sm">
-                        Completed: <b>{formatMinor(totalsByCurrency[c].completed, c)}</b>
-                      </Text>
-                      <Text size="sm">
-                        Pending: <b>{formatMinor(totalsByCurrency[c].pending, c)}</b>
                       </Text>
                       <Text size="sm">
                         Total: <b>{formatMinor(totalsByCurrency[c].total, c)}</b>
@@ -331,31 +302,19 @@ function AppointmentDetailPage() {
         <Card withBorder>
           <Group justify="space-between" mb="sm">
             <Title order={5}>Transactions</Title>
-            <Group gap="xs">
-              <Button
-                variant="default"
-                size="xs"
-                leftSection={<IconLink size={12} />}
-                onClick={() => setLinkBankOpen(true)}
-              >
-                Link bank entry
-              </Button>
-              <Button
-                variant="subtle"
-                size="xs"
-                leftSection={<IconPlus size={12} />}
-                onClick={() => openCreateTx(appointment.client.id)}
-              >
-                New
-              </Button>
-            </Group>
+            <Button
+              variant="subtle"
+              size="xs"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => openCreateTx(appointment.client.id)}
+            >
+              New
+            </Button>
           </Group>
           {(() => {
             const txRows: TransactionRow[] = txList.map((t) => ({
               ...t,
               currency: (CURRENCIES as readonly string[]).includes(t.currency) ? (t.currency as Currency) : "EUR",
-              legalEntityId: t.legalEntityId,
-              legalEntity: t.legalEntity ?? null,
             }))
             return <TransactionsTable items={txRows} onEdit={setEditTx} onDelete={setDeleteTx} />
           })()}
@@ -439,17 +398,6 @@ function AppointmentDetailPage() {
             invalidateKeys={txInvalidateKeys}
           />
         )}
-        <LinkBankEntryDialog
-          appointmentId={appointmentId}
-          customerId={appointment.client.id}
-          open={linkBankOpen}
-          onOpenChange={setLinkBankOpen}
-          onLinked={async () => {
-            await queryClient.invalidateQueries({ queryKey: ["bank-statement-entries"] })
-            await queryClient.invalidateQueries({ queryKey: transactionKeys.byAppointment(appointmentId) })
-            setLinkBankOpen(false)
-          }}
-        />
       </Stack>
     </Container>
   )
@@ -565,81 +513,6 @@ function PickPersonnelModal({ open, onOpenChange, appointmentId, assignedPersonn
             Confirm
           </Button>
         </Group>
-      </Stack>
-    </Modal>
-  )
-}
-
-function LinkBankEntryDialog({
-  appointmentId,
-  customerId,
-  open,
-  onOpenChange,
-  onLinked,
-}: {
-  appointmentId: string
-  customerId: string
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  onLinked: () => void
-}) {
-  const entriesQuery = useQuery({
-    queryKey: ["bank-statement-entries", "pending"],
-    queryFn: () => listBankStatementEntries({ data: { status: "PENDING" } }),
-    enabled: open,
-  })
-
-  const promote = useMutation({
-    mutationFn: (entryId: string) =>
-      promoteEntryToTransaction({
-        data: { entryId, appointmentId, customerId },
-      }),
-    onSuccess: () => {
-      notifications.show({ color: "green", message: "Linked" })
-      onLinked()
-    },
-    onError: (err: Error) => notifications.show({ color: "red", message: err.message }),
-  })
-
-  return (
-    <Modal opened={open} onClose={() => onOpenChange(false)} title="Link bank entry" size="lg">
-      <Stack>
-        {(entriesQuery.data ?? []).length === 0 ? (
-          <Text c="dimmed">No pending bank entries.</Text>
-        ) : (
-          <Table>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Date</Table.Th>
-                <Table.Th>In/Out</Table.Th>
-                <Table.Th>Amount</Table.Th>
-                <Table.Th>Counterparty</Table.Th>
-                <Table.Th>Account</Table.Th>
-                <Table.Th />
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {(entriesQuery.data ?? []).map((e) => (
-                <Table.Tr key={e.id}>
-                  <Table.Td>{e.date}</Table.Td>
-                  <Table.Td>
-                    <Badge variant="light" color={e.direction === "C" ? "green" : "red"}>
-                      {e.direction === "C" ? "In" : "Out"}
-                    </Badge>
-                  </Table.Td>
-                  <Table.Td>{formatMinor(e.amount, e.currency as Currency)}</Table.Td>
-                  <Table.Td>{e.counterpartyName ?? "—"}</Table.Td>
-                  <Table.Td>{e.bankAccount?.displayName}</Table.Td>
-                  <Table.Td>
-                    <Button size="xs" loading={promote.isPending} onClick={() => promote.mutate(e.id)}>
-                      Link
-                    </Button>
-                  </Table.Td>
-                </Table.Tr>
-              ))}
-            </Table.Tbody>
-          </Table>
-        )}
       </Stack>
     </Modal>
   )

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -40,6 +40,11 @@ import { getUserSettings } from "@/functions/user-settings"
 import { CURRENCIES, type Currency, formatMinor } from "@/lib/currency"
 import { appointmentKeys, customerKeys, hairAssignedKeys, transactionKeys, userSettingsKeys } from "@/lib/query-keys"
 
+const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => [currency, 0])) as Record<
+  Currency,
+  number
+>
+
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
   loader: async ({ context, params }) => {
@@ -104,16 +109,13 @@ function AppointmentDetailPage() {
   })
 
   const txList = transactions ?? []
-  const totalsByCurrency: Record<Currency, { total: number }> = {
-    GBP: { total: 0 },
-    EUR: { total: 0 },
-  }
+  const totalsByCurrency = { ...ZERO_TRANSACTION_TOTALS }
   for (const t of txList) {
     const c = t.currency as Currency
     if (!(c in totalsByCurrency)) continue
-    totalsByCurrency[c].total += t.amount
+    totalsByCurrency[c] += t.amount
   }
-  const currenciesPresent = CURRENCIES.filter((c) => totalsByCurrency[c].total !== 0)
+  const currenciesPresent = CURRENCIES.filter((c) => totalsByCurrency[c] !== 0)
 
   if (isLoading) {
     return (
@@ -281,7 +283,7 @@ function AppointmentDetailPage() {
                         {c}
                       </Text>
                       <Text size="sm">
-                        Total: <b>{formatMinor(totalsByCurrency[c].total, c)}</b>
+                        Total: <b>{formatMinor(totalsByCurrency[c], c)}</b>
                       </Text>
                     </Stack>
                   ))

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -17,15 +17,7 @@ import {
   Title,
 } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import {
-  IconArrowLeft,
-  IconCash,
-  IconClock,
-  IconDots,
-  IconPlus,
-  IconUser,
-  IconUsers,
-} from "@tabler/icons-react"
+import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useMemo, useState } from "react"

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -4,7 +4,7 @@ import { notifications } from "@mantine/notifications"
 import { IconPlus } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
 import { HairOrdersTable } from "@/components/hair-orders-table"
 import { PageHeader } from "@/components/page-header"
@@ -115,6 +115,10 @@ function HairOrdersPage() {
     queryFn: () => getHairOrders({ data: { legalEntityId: legalEntityFilter || undefined } }),
   })
   const [dialogOpen, setDialogOpen] = useState(false)
+  const legalEntityNames = useMemo(
+    () => Object.fromEntries((legalEntitiesQuery.data ?? []).map((le) => [le.id, le.name])),
+    [legalEntitiesQuery.data],
+  )
 
   return (
     <Container size="xl">
@@ -140,7 +144,7 @@ function HairOrdersPage() {
         }
       />
       <Section padding="lg">
-        <HairOrdersTable hairOrders={hairOrders} isLoading={isLoading} />
+        <HairOrdersTable hairOrders={hairOrders} isLoading={isLoading} legalEntityNames={legalEntityNames} />
       </Section>
 
       <CreateHairOrderDialog open={dialogOpen} onOpenChange={setDialogOpen} />

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -37,7 +37,6 @@ import { zodResolver } from "mantine-form-zod-resolver"
 import { useEffect, useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
-import { getAppointment, getAppointments } from "@/functions/appointments"
 import { createBankAccount, getBankAccount, updateBankAccount } from "@/functions/bank-accounts"
 import {
   assignAttachmentToEntry,
@@ -48,14 +47,11 @@ import {
   unassignAttachment,
 } from "@/functions/bank-statement-attachments"
 import {
-  getBankStatementEntry,
   ignoreStatementEntry,
   importBankCsv,
   listBankStatementEntries,
-  promoteEntryToTransaction,
   undoStatementEntry,
 } from "@/functions/bank-statement-entries"
-import { getCustomers } from "@/functions/customers"
 import { listLegalEntities } from "@/functions/legal-entities"
 import { CURRENCY_OPTIONS, type Currency, formatMinor } from "@/lib/currency"
 import { bankAccountSchema } from "@/lib/schemas"
@@ -69,7 +65,7 @@ function BankAccountRoute() {
   return bankAccountId === "new" ? <BankAccountNew /> : <BankAccountShow id={bankAccountId} />
 }
 
-type StatusFilter = "PENDING" | "LINKED" | "IGNORED" | "ALL"
+type StatusFilter = "PENDING" | "IGNORED" | "ALL"
 
 function BankAccountShow({ id }: { id: string }) {
   const queryClient = useQueryClient()
@@ -88,8 +84,6 @@ function BankAccountShow({ id }: { id: string }) {
     skipped: number
   } | null>(null)
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("PENDING")
-  const [linkAppointmentEntryId, setLinkAppointmentEntryId] = useState<string | null>(null)
-  const [standaloneEntryId, setStandaloneEntryId] = useState<string | null>(null)
   const [exportMonth, setExportMonth] = useState<Date | null>(() => {
     const d = new Date()
     return new Date(d.getFullYear(), d.getMonth(), 1)
@@ -238,7 +232,6 @@ function BankAccountShow({ id }: { id: string }) {
             label="Status"
             data={[
               { value: "PENDING", label: "Pending" },
-              { value: "LINKED", label: "Linked" },
               { value: "IGNORED", label: "Ignored" },
               { value: "ALL", label: "All" },
             ]}
@@ -337,14 +330,9 @@ function BankAccountShow({ id }: { id: string }) {
                         </Menu.Target>
                         <Menu.Dropdown>
                           {e.status === "PENDING" ? (
-                            <>
-                              <Menu.Item onClick={() => setLinkAppointmentEntryId(e.id)}>Link to appointment</Menu.Item>
-                              <Menu.Item onClick={() => setStandaloneEntryId(e.id)}>Promote standalone</Menu.Item>
-                              <Menu.Divider />
-                              <Menu.Item color="gray" onClick={() => ignoreMutation.mutate(e.id)}>
-                                Ignore
-                              </Menu.Item>
-                            </>
+                            <Menu.Item color="gray" onClick={() => ignoreMutation.mutate(e.id)}>
+                              Ignore
+                            </Menu.Item>
                           ) : (
                             <Menu.Item onClick={() => undoMutation.mutate(e.id)}>Undo ({e.status})</Menu.Item>
                           )}
@@ -383,8 +371,6 @@ function BankAccountShow({ id }: { id: string }) {
             : null
         }
       />
-      <LinkToAppointmentModal entryId={linkAppointmentEntryId} onClose={() => setLinkAppointmentEntryId(null)} />
-      <PromoteStandaloneModal entryId={standaloneEntryId} onClose={() => setStandaloneEntryId(null)} />
       <AttachmentPreviewDialog attachment={previewAttachment} onClose={() => setPreviewAttachment(null)} />
     </>
   )
@@ -564,218 +550,6 @@ function AttachmentsCell({
         </Stack>
       </Popover.Dropdown>
     </Popover>
-  )
-}
-
-function EntrySummary({
-  entry,
-}: {
-  entry: {
-    date: string
-    amount: number
-    currency: string
-    direction: string
-    counterpartyName: string | null
-    purpose: string | null
-  }
-}) {
-  return (
-    <>
-      <Text size="sm">
-        <strong>Counterparty:</strong> {entry.counterpartyName ?? "—"}
-      </Text>
-      <Text size="sm">
-        <strong>Amount:</strong> {formatMinor(entry.amount, entry.currency as Currency)} (
-        {entry.direction === "C" ? "in" : "out"})
-      </Text>
-      <Text size="sm">
-        <strong>Date:</strong> {entry.date}
-      </Text>
-      <Text size="sm">
-        <strong>Purpose:</strong> {entry.purpose ?? "—"}
-      </Text>
-    </>
-  )
-}
-
-function LinkToAppointmentModal({ entryId, onClose }: { entryId: string | null; onClose: () => void }) {
-  const queryClient = useQueryClient()
-  const opened = entryId !== null
-
-  const entryQuery = useQuery({
-    queryKey: ["bank-statement-entry", entryId],
-    queryFn: () => getBankStatementEntry({ data: { id: entryId! } }),
-    enabled: opened,
-  })
-  const appointmentsQuery = useQuery({
-    queryKey: ["appointments", "all"],
-    queryFn: () => getAppointments({ data: {} }),
-    enabled: opened,
-  })
-
-  const [appointmentId, setAppointmentId] = useState<string>("")
-  const [customerId, setCustomerId] = useState<string>("")
-
-  useEffect(() => {
-    if (!opened) {
-      setAppointmentId("")
-      setCustomerId("")
-    }
-  }, [opened])
-
-  const selectedAppointment = appointmentsQuery.data?.find((a) => a.id === appointmentId) ?? null
-
-  useEffect(() => {
-    if (selectedAppointment) {
-      setCustomerId(selectedAppointment.clientId)
-    } else {
-      setCustomerId("")
-    }
-  }, [selectedAppointment])
-
-  const appointmentDetailQuery = useQuery({
-    queryKey: ["appointment", appointmentId],
-    queryFn: () => getAppointment({ data: { id: appointmentId } }),
-    enabled: opened && appointmentId !== "",
-  })
-
-  const customerOptions: { value: string; label: string }[] = (() => {
-    const options: { value: string; label: string }[] = []
-    if (appointmentDetailQuery.data) {
-      const a = appointmentDetailQuery.data
-      options.push({ value: a.clientId, label: `${a.client.name} (client)` })
-      for (const p of a.personnel ?? []) {
-        if (p.personnel.id !== a.clientId) {
-          options.push({ value: p.personnel.id, label: `${p.personnel.name} (personnel)` })
-        }
-      }
-    }
-    return options
-  })()
-
-  const promote = useMutation({
-    mutationFn: () =>
-      promoteEntryToTransaction({
-        data: { entryId: entryId!, customerId, appointmentId, notes: entryQuery.data?.purpose ?? undefined },
-      }),
-    onSuccess: async () => {
-      notifications.show({ color: "green", message: "Linked to appointment" })
-      await queryClient.invalidateQueries({ queryKey: ["bank-statement-entries"] })
-      onClose()
-    },
-    onError: (err: Error) => notifications.show({ color: "red", message: err.message }),
-  })
-
-  return (
-    <Modal opened={opened} onClose={onClose} title="Link entry to appointment">
-      {entryQuery.data && (
-        <Stack>
-          <EntrySummary entry={entryQuery.data} />
-          <Select
-            label="Appointment"
-            required
-            searchable
-            data={(appointmentsQuery.data ?? []).map((a) => ({
-              value: a.id,
-              label: `${new Date(a.startsAt).toISOString().slice(0, 10)} — ${a.name} (${a.client?.name ?? "?"})`,
-            }))}
-            value={appointmentId}
-            onChange={(v) => setAppointmentId(v ?? "")}
-          />
-          <Select
-            label="Customer"
-            required
-            disabled={appointmentId === ""}
-            data={customerOptions}
-            value={customerId}
-            onChange={(v) => setCustomerId(v ?? "")}
-          />
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => promote.mutate()}
-              loading={promote.isPending}
-              disabled={!appointmentId || !customerId}
-            >
-              Link
-            </Button>
-          </Group>
-        </Stack>
-      )}
-    </Modal>
-  )
-}
-
-function PromoteStandaloneModal({ entryId, onClose }: { entryId: string | null; onClose: () => void }) {
-  const queryClient = useQueryClient()
-  const opened = entryId !== null
-
-  const entryQuery = useQuery({
-    queryKey: ["bank-statement-entry", entryId],
-    queryFn: () => getBankStatementEntry({ data: { id: entryId! } }),
-    enabled: opened,
-  })
-  const customersQuery = useQuery({
-    queryKey: ["customers"],
-    queryFn: () => getCustomers(),
-    enabled: opened,
-  })
-
-  const [customerId, setCustomerId] = useState<string>("")
-  const [name, setName] = useState<string>("")
-
-  useEffect(() => {
-    if (!opened) {
-      setCustomerId("")
-      setName("")
-    }
-  }, [opened])
-
-  const promote = useMutation({
-    mutationFn: () =>
-      promoteEntryToTransaction({
-        data: { entryId: entryId!, customerId, name: name || undefined, notes: entryQuery.data?.purpose ?? undefined },
-      }),
-    onSuccess: async () => {
-      notifications.show({ color: "green", message: "Promoted standalone" })
-      await queryClient.invalidateQueries({ queryKey: ["bank-statement-entries"] })
-      onClose()
-    },
-    onError: (err: Error) => notifications.show({ color: "red", message: err.message }),
-  })
-
-  return (
-    <Modal opened={opened} onClose={onClose} title="Promote standalone">
-      {entryQuery.data && (
-        <Stack>
-          <EntrySummary entry={entryQuery.data} />
-          <Select
-            label="Customer"
-            required
-            searchable
-            data={(customersQuery.data ?? []).map((c) => ({ value: c.id, label: c.name }))}
-            value={customerId}
-            onChange={(v) => setCustomerId(v ?? "")}
-          />
-          <TextInput
-            label="Name (optional)"
-            placeholder="Leave blank to default"
-            value={name}
-            onChange={(e) => setName(e.currentTarget.value)}
-          />
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button onClick={() => promote.mutate()} loading={promote.isPending} disabled={!customerId}>
-              Promote
-            </Button>
-          </Group>
-        </Stack>
-      )}
-    </Modal>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/reports.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/reports.tsx
@@ -3,9 +3,9 @@ import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
-import { BankAccountReportCard, CashReportTable } from "@/components/reports-cards"
+import { BankAccountReportCard } from "@/components/reports-cards"
 import { Section } from "@/components/section"
-import { getBankAccountMonthlyBreakdown, getCashMonthlyBreakdown } from "@/functions/reports"
+import { getBankAccountMonthlyBreakdown } from "@/functions/reports"
 
 const searchSchema = z.object({
   year: z.number().int().min(2000).max(3000).optional(),
@@ -29,11 +29,6 @@ function ReportsTab() {
     queryKey: ["reports", "bank", year, legalEntityId],
     queryFn: () => getBankAccountMonthlyBreakdown({ data: { year, legalEntityId } }),
   })
-  const cashQuery = useQuery({
-    queryKey: ["reports", "cash", year, legalEntityId],
-    queryFn: () => getCashMonthlyBreakdown({ data: { year, legalEntityId } }),
-  })
-
   const yearInput = (
     <NumberInput
       value={year}
@@ -65,16 +60,6 @@ function ReportsTab() {
               <BankAccountReportCard key={a.bankAccountId} a={a} />
             ))}
           </Stack>
-        )}
-      </Section>
-
-      <Section title="Cash" description="Manual cash transactions per month.">
-        {(cashQuery.data ?? []).length === 0 ? (
-          <Text c="dimmed" size="sm">
-            No cash transactions in {year}.
-          </Text>
-        ) : (
-          <CashReportTable data={cashQuery.data ?? []} />
         )}
       </Section>
     </Stack>

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       "version": "0.6.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1068.0",
+        "@mantine/charts": "^9.3.1",
         "@mantine/core": "^9.3.1",
         "@mantine/dates": "^9.3.1",
         "@mantine/form": "^9.3.1",
@@ -331,6 +332,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mantine/charts": ["@mantine/charts@9.3.1", "", { "peerDependencies": { "@mantine/core": "9.3.1", "@mantine/hooks": "9.3.1", "react": "^19.2.0", "react-dom": "^19.2.0", "recharts": ">=3.2.1" } }, "sha512-T09AnLs+yhjw97kqC2RHC58yj7YzaGRDRbANOONt7DPsRcSxHq8snQ9Qo4GrzxjcLUgXlN2eR1UfM4QHlY6y9A=="],
+
     "@mantine/core": ["@mantine/core@9.3.1", "", { "dependencies": { "@floating-ui/react": "^0.27.19", "clsx": "^2.1.1", "react-number-format": "^5.4.5", "react-remove-scroll": "^2.7.2", "type-fest": "^5.6.0" }, "peerDependencies": { "@mantine/hooks": "9.3.1", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-4rBoHpggSohayE+Os7lKdbsHTw7m/uZRKYjk9DN6cKBhQIjdiULdcG+b4b5CMVZSqZDHPgT70uWGI7yqkn8Ufw=="],
 
     "@mantine/dates": ["@mantine/dates@9.3.1", "", { "dependencies": { "clsx": "^2.1.1" }, "peerDependencies": { "@mantine/core": "9.3.1", "@mantine/hooks": "9.3.1", "dayjs": ">=1.0.0", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-Nh4XQyyV1AM0XRnUJugb1kNfCm++nkticsO8aroKmFPZ7cpGV7cjdL+4MJNPu1atS1EUePXl2VLLpKnrclpqOQ=="],
@@ -533,6 +536,8 @@
 
     "@prive-admin-tanstack/ui": ["@prive-admin-tanstack/ui@workspace:packages/ui"],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
@@ -584,6 +589,8 @@
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@t3-oss/env-core": ["@t3-oss/env-core@0.13.11", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ=="],
 
@@ -655,6 +662,24 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -666,6 +691,8 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
 
@@ -769,11 +796,35 @@
 
     "csv-parse": ["csv-parse@6.2.1", "", {}, "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -801,6 +852,8 @@
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
+    "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -808,6 +861,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -853,7 +908,11 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -1009,6 +1068,8 @@
 
     "react-number-format": ["react-number-format@5.4.5", "", { "peerDependencies": { "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="],
 
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1022,6 +1083,14 @@
     "readdir-glob": ["readdir-glob@3.0.0", "", { "dependencies": { "minimatch": "^10.2.2" } }, "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1081,6 +1150,8 @@
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -1123,6 +1194,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
@@ -1158,6 +1231,8 @@
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "h3/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,10 +16,9 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1068.0",
-        "@mantine/charts": "^9.3.1",
         "@mantine/core": "^9.3.1",
         "@mantine/dates": "^9.3.1",
         "@mantine/form": "^9.3.1",
@@ -61,7 +60,7 @@
     },
     "packages/auth": {
       "name": "@prive-admin-tanstack/auth",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@prive-admin-tanstack/db": "workspace:*",
         "@prive-admin-tanstack/env": "workspace:*",
@@ -74,11 +73,11 @@
     },
     "packages/config": {
       "name": "@prive-admin-tanstack/config",
-      "version": "0.6.0",
+      "version": "0.6.2",
     },
     "packages/db": {
       "name": "@prive-admin-tanstack/db",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@prive-admin-tanstack/env": "workspace:*",
@@ -97,7 +96,7 @@
     },
     "packages/env": {
       "name": "@prive-admin-tanstack/env",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@t3-oss/env-core": "^0.13.11",
         "dotenv": "catalog:",
@@ -111,7 +110,7 @@
     },
     "packages/ui": {
       "name": "@prive-admin-tanstack/ui",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@mantine/core": "^9.3.1",
         "@mantine/hooks": "^9.3.1",
@@ -332,8 +331,6 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mantine/charts": ["@mantine/charts@9.3.1", "", { "peerDependencies": { "@mantine/core": "9.3.1", "@mantine/hooks": "9.3.1", "react": "^19.2.0", "react-dom": "^19.2.0", "recharts": ">=3.2.1" } }, "sha512-T09AnLs+yhjw97kqC2RHC58yj7YzaGRDRbANOONt7DPsRcSxHq8snQ9Qo4GrzxjcLUgXlN2eR1UfM4QHlY6y9A=="],
-
     "@mantine/core": ["@mantine/core@9.3.1", "", { "dependencies": { "@floating-ui/react": "^0.27.19", "clsx": "^2.1.1", "react-number-format": "^5.4.5", "react-remove-scroll": "^2.7.2", "type-fest": "^5.6.0" }, "peerDependencies": { "@mantine/hooks": "9.3.1", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-4rBoHpggSohayE+Os7lKdbsHTw7m/uZRKYjk9DN6cKBhQIjdiULdcG+b4b5CMVZSqZDHPgT70uWGI7yqkn8Ufw=="],
 
     "@mantine/dates": ["@mantine/dates@9.3.1", "", { "dependencies": { "clsx": "^2.1.1" }, "peerDependencies": { "@mantine/core": "9.3.1", "@mantine/hooks": "9.3.1", "dayjs": ">=1.0.0", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-Nh4XQyyV1AM0XRnUJugb1kNfCm++nkticsO8aroKmFPZ7cpGV7cjdL+4MJNPu1atS1EUePXl2VLLpKnrclpqOQ=="],
@@ -536,8 +533,6 @@
 
     "@prive-admin-tanstack/ui": ["@prive-admin-tanstack/ui@workspace:packages/ui"],
 
-    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
-
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
@@ -589,8 +584,6 @@
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@t3-oss/env-core": ["@t3-oss/env-core@0.13.11", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ=="],
 
@@ -662,24 +655,6 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
-    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
-
-    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
-
-    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
-
-    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
-
-    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
-
-    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
-
-    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
-
-    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
-
-    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
-
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -691,8 +666,6 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
-
-    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
 
@@ -796,35 +769,11 @@
 
     "csv-parse": ["csv-parse@6.2.1", "", {}, "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="],
 
-    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
-
-    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
-
-    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
-
-    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
-
-    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
-
-    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
-
-    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
-
-    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
-
-    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
-
-    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
-
-    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
-
     "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -852,8 +801,6 @@
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
-    "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
-
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -861,8 +808,6 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -908,11 +853,7 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -1068,8 +1009,6 @@
 
     "react-number-format": ["react-number-format@5.4.5", "", { "peerDependencies": { "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="],
 
-    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
-
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1083,14 +1022,6 @@
     "readdir-glob": ["readdir-glob@3.0.0", "", { "dependencies": { "minimatch": "^10.2.2" } }, "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
-
-    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
-
-    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
-
-    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1150,8 +1081,6 @@
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
-    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
-
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -1194,8 +1123,6 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
-
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
@@ -1231,8 +1158,6 @@
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "h3/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,7 @@
         "src/middleware/**/*.{ts,tsx}!",
         "react-doctor.config.json"
       ],
+      "ignoreDependencies": ["@mantine/charts"],
       "project": ["src/**/*.{ts,tsx}!"]
     },
     "packages/auth": {

--- a/packages/db/src/migrations/0003_drop_transaction_linking.sql
+++ b/packages/db/src/migrations/0003_drop_transaction_linking.sql
@@ -1,0 +1,14 @@
+DELETE FROM "bank_statement_entry" WHERE "status" = 'LINKED' OR "linked_transaction_id" IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "bank_statement_entry" DROP CONSTRAINT "bank_statement_entry_linked_transaction_id_transaction_id_fk";
+--> statement-breakpoint
+ALTER TABLE "transaction" DROP CONSTRAINT "transaction_legal_entity_id_legal_entity_id_fk";
+--> statement-breakpoint
+ALTER TABLE "transaction" DROP CONSTRAINT "transaction_bank_account_id_bank_account_id_fk";
+--> statement-breakpoint
+ALTER TABLE "bank_statement_entry" DROP COLUMN "linked_transaction_id";--> statement-breakpoint
+ALTER TABLE "transaction" DROP COLUMN "type";--> statement-breakpoint
+ALTER TABLE "transaction" DROP COLUMN "status";--> statement-breakpoint
+ALTER TABLE "transaction" DROP COLUMN "completed_date_by";--> statement-breakpoint
+ALTER TABLE "transaction" DROP COLUMN "legal_entity_id";--> statement-breakpoint
+ALTER TABLE "transaction" DROP COLUMN "bank_account_id";

--- a/packages/db/src/migrations/meta/0003_snapshot.json
+++ b/packages/db/src/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1880 @@
+{
+  "id": "a9604c01-adff-4240-a477-f3b74282712b",
+  "prevId": "77189373-7587-4244-ac96-4396224f593b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salon_id": {
+          "name": "salon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_client_id_customer_id_fk": {
+          "name": "appointment_client_id_customer_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "appointment_salon_id_salon_id_fk": {
+          "name": "appointment_salon_id_salon_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "salon",
+          "columnsFrom": [
+            "salon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_personnel": {
+      "name": "appointment_personnel",
+      "schema": "",
+      "columns": {
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personnel_id": {
+          "name": "personnel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_personnel_appointment_id_appointment_id_fk": {
+          "name": "appointment_personnel_appointment_id_appointment_id_fk",
+          "tableFrom": "appointment_personnel",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "appointment_personnel_personnel_id_customer_id_fk": {
+          "name": "appointment_personnel_personnel_id_customer_id_fk",
+          "tableFrom": "appointment_personnel",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "personnel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "appointment_personnel_personnel_id_appointment_id_pk": {
+          "name": "appointment_personnel_personnel_id_appointment_id_pk",
+          "columns": [
+            "personnel_id",
+            "appointment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_account": {
+      "name": "bank_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legal_entity_id": {
+          "name": "legal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swift": {
+          "name": "swift",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_account_legal_entity_id_legal_entity_id_fk": {
+          "name": "bank_account_legal_entity_id_legal_entity_id_fk",
+          "tableFrom": "bank_account",
+          "tableTo": "legal_entity",
+          "columnsFrom": [
+            "legal_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_account_iban_unique": {
+          "name": "bank_account_iban_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iban"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_statement_attachment": {
+      "name": "bank_statement_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_statement_entry_id": {
+          "name": "bank_statement_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_statement_attachment_bank_statement_entry_id_bank_statement_entry_id_fk": {
+          "name": "bank_statement_attachment_bank_statement_entry_id_bank_statement_entry_id_fk",
+          "tableFrom": "bank_statement_attachment",
+          "tableTo": "bank_statement_entry",
+          "columnsFrom": [
+            "bank_statement_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_statement_attachment_uploaded_by_id_users_id_fk": {
+          "name": "bank_statement_attachment_uploaded_by_id_users_id_fk",
+          "tableFrom": "bank_statement_attachment",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_statement_attachment_r2_key_unique": {
+          "name": "bank_statement_attachment_r2_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "r2_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_statement_entry": {
+      "name": "bank_statement_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_number": {
+          "name": "doc_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_name": {
+          "name": "counterparty_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_iban": {
+          "name": "counterparty_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_bank": {
+          "name": "counterparty_bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swift": {
+          "name": "swift",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_statement_entry_bank_account_id_bank_account_id_fk": {
+          "name": "bank_statement_entry_bank_account_id_bank_account_id_fk",
+          "tableFrom": "bank_statement_entry",
+          "tableTo": "bank_account",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_statement_entry_account_ref_unique": {
+          "name": "bank_statement_entry_account_ref_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bank_account_id",
+            "external_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer": {
+      "name": "customer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_name_unique": {
+          "name": "customer_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hair_assigned": {
+      "name": "hair_assigned",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hair_order_id": {
+          "name": "hair_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_in_grams": {
+          "name": "weight_in_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sold_for": {
+          "name": "sold_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profit": {
+          "name": "profit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "price_per_gram": {
+          "name": "price_per_gram",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hair_assigned_appointment_id_appointment_id_fk": {
+          "name": "hair_assigned_appointment_id_appointment_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_hair_order_id_hair_order_id_fk": {
+          "name": "hair_assigned_hair_order_id_hair_order_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "hair_order",
+          "columnsFrom": [
+            "hair_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_client_id_customer_id_fk": {
+          "name": "hair_assigned_client_id_customer_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_created_by_id_users_id_fk": {
+          "name": "hair_assigned_created_by_id_users_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hair_order": {
+      "name": "hair_order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "weight_received": {
+          "name": "weight_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weight_used": {
+          "name": "weight_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "price_per_gram": {
+          "name": "price_per_gram",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_entity_id": {
+          "name": "legal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hair_order_customer_id_customer_id_fk": {
+          "name": "hair_order_customer_id_customer_id_fk",
+          "tableFrom": "hair_order",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_order_legal_entity_id_legal_entity_id_fk": {
+          "name": "hair_order_legal_entity_id_legal_entity_id_fk",
+          "tableFrom": "hair_order",
+          "tableTo": "legal_entity",
+          "columnsFrom": [
+            "legal_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "hair_order_created_by_id_users_id_fk": {
+          "name": "hair_order_created_by_id_users_id_fk",
+          "tableFrom": "hair_order",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hair_order_uid_unique": {
+          "name": "hair_order_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_currency": {
+          "name": "preferred_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant": {
+      "name": "product_variant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_variant_product_id_product_id_fk": {
+          "name": "product_variant_product_id_product_id_fk",
+          "tableFrom": "product_variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_variant_product_id_size_unique": {
+          "name": "product_variant_product_id_size_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "product_id",
+            "size"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PURCHASE'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_customer_id_customer_id_fk": {
+          "name": "order_customer_id_customer_id_fk",
+          "tableFrom": "order",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_item": {
+      "name": "order_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_item_order_id_order_id_fk": {
+          "name": "order_item_order_id_order_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_item_product_variant_id_product_variant_id_fk": {
+          "name": "order_item_product_variant_id_product_variant_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "product_variant",
+          "columnsFrom": [
+            "product_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_item_order_id_product_variant_id_unique": {
+          "name": "order_item_order_id_product_variant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order_id",
+            "product_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_customer_id_customer_id_fk": {
+          "name": "transaction_customer_id_customer_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_order_id_order_id_fk": {
+          "name": "transaction_order_id_order_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_appointment_id_appointment_id_fk": {
+          "name": "transaction_appointment_id_appointment_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legal_entity": {
+      "name": "legal_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.salon": {
+      "name": "salon",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hair_order_id": {
+          "name": "hair_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_customer_id_customer_id_fk": {
+          "name": "note_customer_id_customer_id_fk",
+          "tableFrom": "note",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_appointment_id_appointment_id_fk": {
+          "name": "note_appointment_id_appointment_id_fk",
+          "tableFrom": "note",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_hair_order_id_hair_order_id_fk": {
+          "name": "note_hair_order_id_hair_order_id_fk",
+          "tableFrom": "note",
+          "tableTo": "hair_order",
+          "columnsFrom": [
+            "hair_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_created_by_id_users_id_fk": {
+          "name": "note_created_by_id_users_id_fk",
+          "tableFrom": "note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778606017255,
       "tag": "0002_workable_microbe",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781464805882,
+      "tag": "0003_drop_transaction_linking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/bank-statement-entry.ts
+++ b/packages/db/src/schema/bank-statement-entry.ts
@@ -2,7 +2,6 @@ import { createId } from "@paralleldrive/cuid2"
 import { pgTable, integer, text, timestamp, date, unique } from "drizzle-orm/pg-core"
 
 import { bankAccount } from "./bank-account"
-import { transaction } from "./transaction"
 
 export const bankStatementEntry = pgTable(
   "bank_statement_entry",
@@ -23,10 +22,7 @@ export const bankStatementEntry = pgTable(
     swift: text("swift"),
     purpose: text("purpose"),
     transactionType: text("transaction_type"),
-    status: text("status").notNull().default("PENDING"), // 'PENDING' | 'LINKED' | 'IGNORED'
-    linkedTransactionId: text("linked_transaction_id").references(() => transaction.id, {
-      onDelete: "set null",
-    }),
+    status: text("status").notNull().default("PENDING"), // 'PENDING' | 'IGNORED'
     importedAt: timestamp("imported_at", { withTimezone: true }).defaultNow().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true })

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -86,14 +86,11 @@ export const transactionRelations = relations(transaction, ({ one }) => ({
   customer: one(customer, { fields: [transaction.customerId], references: [customer.id] }),
   order: one(order, { fields: [transaction.orderId], references: [order.id] }),
   appointment: one(appointment, { fields: [transaction.appointmentId], references: [appointment.id] }),
-  legalEntity: one(legalEntity, { fields: [transaction.legalEntityId], references: [legalEntity.id] }),
-  bankAccount: one(bankAccount, { fields: [transaction.bankAccountId], references: [bankAccount.id] }),
 }))
 
 // Hair relations
 export const hairOrderRelations = relations(hairOrder, ({ one, many }) => ({
   customer: one(customer, { fields: [hairOrder.customerId], references: [customer.id] }),
-  legalEntity: one(legalEntity, { fields: [hairOrder.legalEntityId], references: [legalEntity.id] }),
   createdBy: one(user, { fields: [hairOrder.createdById], references: [user.id] }),
   hairAssigned: many(hairAssigned),
   notes: many(note),
@@ -122,7 +119,6 @@ export const userSettingsRelations = relations(userSettings, ({ one }) => ({
 // Legal entity relations
 export const legalEntityRelations = relations(legalEntity, ({ many }) => ({
   bankAccounts: many(bankAccount),
-  transactions: many(transaction),
   hairOrders: many(hairOrder),
 }))
 
@@ -138,7 +134,6 @@ export const bankAccountRelations = relations(bankAccount, ({ one, many }) => ({
     references: [legalEntity.id],
   }),
   statementEntries: many(bankStatementEntry),
-  transactions: many(transaction),
 }))
 
 // Bank statement entry relations
@@ -146,10 +141,6 @@ export const bankStatementEntryRelations = relations(bankStatementEntry, ({ one,
   bankAccount: one(bankAccount, {
     fields: [bankStatementEntry.bankAccountId],
     references: [bankAccount.id],
-  }),
-  linkedTransaction: one(transaction, {
-    fields: [bankStatementEntry.linkedTransactionId],
-    references: [transaction.id],
   }),
   attachments: many(bankStatementAttachment),
 }))

--- a/packages/db/src/schema/transaction.ts
+++ b/packages/db/src/schema/transaction.ts
@@ -1,10 +1,8 @@
 import { createId } from "@paralleldrive/cuid2"
-import { pgTable, integer, text, timestamp, date } from "drizzle-orm/pg-core"
+import { pgTable, integer, text, timestamp } from "drizzle-orm/pg-core"
 
 import { appointment } from "./appointment"
-import { bankAccount } from "./bank-account"
 import { customer } from "./customer"
-import { legalEntity } from "./legal-entity"
 import { order } from "./order"
 
 export const transaction = pgTable("transaction", {
@@ -13,17 +11,8 @@ export const transaction = pgTable("transaction", {
   notes: text("notes"),
   amount: integer("amount").notNull(),
   currency: text("currency").notNull(),
-  type: text("type").notNull().default("BANK"),
-  status: text("status").notNull().default("PENDING"),
-  completedDateBy: date("completed_date_by").defaultNow().notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   customerId: text("customer_id").references(() => customer.id, { onDelete: "set null" }),
   orderId: text("order_id").references(() => order.id, { onDelete: "set null" }),
   appointmentId: text("appointment_id").references(() => appointment.id, { onDelete: "set null" }),
-  legalEntityId: text("legal_entity_id")
-    .notNull()
-    .references(() => legalEntity.id, { onDelete: "restrict" }),
-  bankAccountId: text("bank_account_id").references(() => bankAccount.id, { onDelete: "set null" }),
-  // Note: bank_statement_entry_id intentionally avoided here to break FK cycle.
-  // The link is owned only by bank_statement_entry.linkedTransactionId.
 })


### PR DESCRIPTION
## Summary
- remove bank statement entry promotion/linking to transactions and appointments
- drop transaction bank/legal-entity linkage fields and linked statement-entry relation
- fold cleanup into a single migration that deletes existing linked statement entries before dropping link columns
- remove hair order legal entity relation and derive list display names from loaded legal entities

## Tests
- bun run check-types
- focused oxlint on touched files