### PR TITLE
ci: split image release workflows and tune GHCR cleanup

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -2,29 +2,37 @@ name: GHCR Cleanup
 
 on:
   schedule:
-    - cron: "0 4 * * 0"
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:
   cleanup:
-    name: Delete old container versions
+    name: Delete old ${{ matrix.package }} container versions
     runs-on: ubuntu-latest
 
     permissions:
       packages: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - prive-admin-web
+          - prive-admin-server
+          - prive-admin-migrate
+
     steps:
       - name: Delete untagged versions
         uses: actions/delete-package-versions@v5
         with:
-          package-name: prive-admin
+          package-name: ${{ matrix.package }}
           package-type: container
           delete-only-untagged-versions: true
 
-      - name: Keep last 10 tagged versions
+      - name: Keep latest and recent tagged versions
         uses: actions/delete-package-versions@v5
         with:
-          package-name: prive-admin
+          package-name: ${{ matrix.package }}
           package-type: container
           min-versions-to-keep: 10
-          ignore-versions: "^latest$"
+          ignore-versions: "^(latest|main)$"

--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -1,89 +1,67 @@
-name: PR Build Check
+name: Main Images
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_BASE: ghcr.io/${{ github.repository }}
+
 jobs:
-  build:
-    name: Source Build
+  build-scan-push:
+    name: Build, Scan, and Push Main Images
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-      pull-requests: write
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version: "24"
-          cache: true
-
-      - name: Install Dependencies
-        run: vp install --frozen-lockfile
-
-      - name: Check
-        run: vp check
-
-      - name: Check Types
-        run: vp run check-types
-
-      - name: Run Knip
-        run: vp exec knip --reporter github-actions
-
-      - name: Run Build
-        run: vp run build
-
-  docker-build:
-    name: Docker Image Build and Scan
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
+      packages: write
       security-events: write
-
     steps:
-      - name: Checkout Code
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build web image (no push)
+      - name: Build web
         uses: docker/build-push-action@v6
         with:
           file: apps/web/Dockerfile
           context: .
           platforms: linux/amd64
           load: true
-          tags: prive-admin-web:pr-${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_NAME_BASE }}-web:${{ github.sha }}
+            ${{ env.IMAGE_NAME_BASE }}-web:main
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
 
-      - name: Build server image (no push)
+      - name: Build server
         uses: docker/build-push-action@v6
         with:
           file: apps/server/Dockerfile
           context: .
           platforms: linux/amd64
           load: true
-          tags: prive-admin-server:pr-${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_NAME_BASE }}-server:${{ github.sha }}
+            ${{ env.IMAGE_NAME_BASE }}-server:main
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
 
-      - name: Build migrate image (no push)
+      - name: Build migrate
         uses: docker/build-push-action@v6
         with:
           file: packages/db/Dockerfile
           context: .
           platforms: linux/amd64
           load: true
-          tags: prive-admin-migrate:pr-${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_NAME_BASE }}-migrate:${{ github.sha }}
+            ${{ env.IMAGE_NAME_BASE }}-migrate:main
           cache-from: type=gha,scope=migrate
           cache-to: type=gha,mode=max,scope=migrate
 
@@ -92,7 +70,7 @@ jobs:
         continue-on-error: true
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: prive-admin-web:pr-${{ github.sha }}
+          image-ref: ${{ env.IMAGE_NAME_BASE }}-web:${{ github.sha }}
           format: sarif
           output: trivy-web-results.sarif
           severity: CRITICAL,HIGH
@@ -104,14 +82,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-web-results.sarif
-          category: trivy-pr-web
+          category: trivy-main-web
 
       - name: Scan server image with Trivy
         id: scan-server
         continue-on-error: true
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: prive-admin-server:pr-${{ github.sha }}
+          image-ref: ${{ env.IMAGE_NAME_BASE }}-server:${{ github.sha }}
           format: sarif
           output: trivy-server-results.sarif
           severity: CRITICAL,HIGH
@@ -123,14 +101,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-server-results.sarif
-          category: trivy-pr-server
+          category: trivy-main-server
 
       - name: Scan migrate image with Trivy
         id: scan-migrate
         continue-on-error: true
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: prive-admin-migrate:pr-${{ github.sha }}
+          image-ref: ${{ env.IMAGE_NAME_BASE }}-migrate:${{ github.sha }}
           format: sarif
           output: trivy-migrate-results.sarif
           severity: CRITICAL,HIGH
@@ -142,7 +120,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-migrate-results.sarif
-          category: trivy-pr-migrate
+          category: trivy-main-migrate
 
       - name: Fail if image scans failed
         run: |
@@ -161,3 +139,18 @@ jobs:
             failed=1
           fi
           exit "${failed}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images
+        run: |
+          set -euo pipefail
+          for image in web server migrate; do
+            docker image push "${IMAGE_NAME_BASE}-${image}:${GITHUB_SHA}"
+            docker image push "${IMAGE_NAME_BASE}-${image}:main"
+          done

--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -13,12 +13,11 @@ env:
 
 jobs:
   build-scan-push:
-    name: Build, Scan, and Push Main Images
+    name: Build and Push Main Images
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,81 +63,6 @@ jobs:
             ${{ env.IMAGE_NAME_BASE }}-migrate:main
           cache-from: type=gha,scope=migrate
           cache-to: type=gha,mode=max,scope=migrate
-
-      - name: Scan web image with Trivy
-        id: scan-web
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-web:${{ github.sha }}
-          format: sarif
-          output: trivy-web-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload web Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-web-results.sarif
-          category: trivy-main-web
-
-      - name: Scan server image with Trivy
-        id: scan-server
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-server:${{ github.sha }}
-          format: sarif
-          output: trivy-server-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload server Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-server-results.sarif
-          category: trivy-main-server
-
-      - name: Scan migrate image with Trivy
-        id: scan-migrate
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-migrate:${{ github.sha }}
-          format: sarif
-          output: trivy-migrate-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload migrate Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-migrate-results.sarif
-          category: trivy-main-migrate
-
-      - name: Fail if image scans failed
-        run: |
-          set -euo pipefail
-          failed=0
-          if [ "${{ steps.scan-web.outcome }}" != "success" ]; then
-            echo "web image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-server.outcome }}" != "success" ]; then
-            echo "server image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-migrate.outcome }}" != "success" ]; then
-            echo "migrate image scan failed" >&2
-            failed=1
-          fi
-          exit "${failed}"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -97,7 +97,7 @@ jobs:
           output: trivy-web-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "0"
+          exit-code: "1"
 
       - name: Upload web Trivy SARIF
         if: always()
@@ -116,7 +116,7 @@ jobs:
           output: trivy-server-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "0"
+          exit-code: "1"
 
       - name: Upload server Trivy SARIF
         if: always()
@@ -135,7 +135,7 @@ jobs:
           output: trivy-migrate-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "0"
+          exit-code: "1"
 
       - name: Upload migrate Trivy SARIF
         if: always()
@@ -143,3 +143,21 @@ jobs:
         with:
           sarif_file: trivy-migrate-results.sarif
           category: trivy-pr-migrate
+
+      - name: Fail if image scans failed
+        run: |
+          set -euo pipefail
+          failed=0
+          if [ "${{ steps.scan-web.outcome }}" != "success" ]; then
+            echo "web image scan failed" >&2
+            failed=1
+          fi
+          if [ "${{ steps.scan-server.outcome }}" != "success" ]; then
+            echo "server image scan failed" >&2
+            failed=1
+          fi
+          if [ "${{ steps.scan-migrate.outcome }}" != "success" ]; then
+            echo "migrate image scan failed" >&2
+            failed=1
+          fi
+          exit "${failed}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -97,7 +97,7 @@ jobs:
           output: trivy-web-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
 
       - name: Upload web Trivy SARIF
         if: always()
@@ -116,7 +116,7 @@ jobs:
           output: trivy-server-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
 
       - name: Upload server Trivy SARIF
         if: always()
@@ -135,7 +135,7 @@ jobs:
           output: trivy-migrate-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
 
       - name: Upload migrate Trivy SARIF
         if: always()
@@ -143,21 +143,3 @@ jobs:
         with:
           sarif_file: trivy-migrate-results.sarif
           category: trivy-pr-migrate
-
-      - name: Fail if image scans failed
-        run: |
-          set -euo pipefail
-          failed=0
-          if [ "${{ steps.scan-web.outcome }}" != "success" ]; then
-            echo "web image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-server.outcome }}" != "success" ]; then
-            echo "server image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-migrate.outcome }}" != "success" ]; then
-            echo "migrate image scan failed" >&2
-            failed=1
-          fi
-          exit "${failed}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,12 +40,11 @@ jobs:
         run: vp run build
 
   docker-build:
-    name: Docker Image Build and Scan
+    name: Docker Image Build
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      security-events: write
 
     steps:
       - name: Checkout Code
@@ -86,78 +85,3 @@ jobs:
           tags: prive-admin-migrate:pr-${{ github.sha }}
           cache-from: type=gha,scope=migrate
           cache-to: type=gha,mode=max,scope=migrate
-
-      - name: Scan web image with Trivy
-        id: scan-web
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: prive-admin-web:pr-${{ github.sha }}
-          format: sarif
-          output: trivy-web-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload web Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-web-results.sarif
-          category: trivy-pr-web
-
-      - name: Scan server image with Trivy
-        id: scan-server
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: prive-admin-server:pr-${{ github.sha }}
-          format: sarif
-          output: trivy-server-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload server Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-server-results.sarif
-          category: trivy-pr-server
-
-      - name: Scan migrate image with Trivy
-        id: scan-migrate
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: prive-admin-migrate:pr-${{ github.sha }}
-          format: sarif
-          output: trivy-migrate-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload migrate Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-migrate-results.sarif
-          category: trivy-pr-migrate
-
-      - name: Fail if image scans failed
-        run: |
-          set -euo pipefail
-          failed=0
-          if [ "${{ steps.scan-web.outcome }}" != "success" ]; then
-            echo "web image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-server.outcome }}" != "success" ]; then
-            echo "server image scan failed" >&2
-            failed=1
-          fi
-          if [ "${{ steps.scan-migrate.outcome }}" != "success" ]; then
-            echo "migrate image scan failed" >&2
-            failed=1
-          fi
-          exit "${failed}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,60 +96,49 @@ jobs:
           cache-from: type=gha,scope=migrate
           cache-to: type=gha,mode=max,scope=migrate
 
-      - name: Scan web image with Trivy
+  scan-images:
+    name: Scan ${{ matrix.image.name }} image
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: web
+          - name: server
+          - name: migrate
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-web:${{ steps.release.outputs.commit }}
+          image-ref: ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image.name }}:${{ needs.build-and-push.outputs.commit }}
           format: sarif
-          output: trivy-web-results.sarif
+          output: trivy-${{ matrix.image.name }}-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
 
-      - name: Upload web Trivy SARIF
+      - name: Upload Trivy SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: trivy-web-results.sarif
-          category: trivy-web
-
-      - name: Scan server image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-server:${{ steps.release.outputs.commit }}
-          format: sarif
-          output: trivy-server-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload server Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-server-results.sarif
-          category: trivy-server
-
-      - name: Scan migrate image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-migrate:${{ steps.release.outputs.commit }}
-          format: sarif
-          output: trivy-migrate-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload migrate Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-migrate-results.sarif
-          category: trivy-migrate
+          sarif_file: trivy-${{ matrix.image.name }}-results.sarif
+          category: trivy-${{ matrix.image.name }}
 
   pre-deploy-backup:
     name: Pre-deploy Postgres Backup
-    needs: build-and-push
+    needs: scan-images
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -230,7 +220,7 @@ jobs:
 
   deploy:
     name: Deploy to prive
-    needs: [build-and-push, pre-deploy-backup]
+    needs: [scan-images, pre-deploy-backup]
     runs-on: ubuntu-latest
     environment:
       name: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types:
+      - published
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -12,14 +12,12 @@ env:
   IMAGE_NAME_BASE: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push:
-    name: Build and Push Image
+  promote-release:
+    name: Promote Release Images
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    outputs:
-      commit: ${{ steps.release.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,74 +42,9 @@ jobs:
 
           echo "commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push web
-        uses: docker/build-push-action@v6
-        with:
-          file: apps/web/Dockerfile
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-web:latest
-            ${{ env.IMAGE_NAME_BASE }}-web:${{ steps.release.outputs.commit }}
-            ${{ env.IMAGE_NAME_BASE }}-web:${{ github.ref_name }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
-
-      - name: Build and push server
-        uses: docker/build-push-action@v6
-        with:
-          file: apps/server/Dockerfile
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-server:latest
-            ${{ env.IMAGE_NAME_BASE }}-server:${{ steps.release.outputs.commit }}
-            ${{ env.IMAGE_NAME_BASE }}-server:${{ github.ref_name }}
-          cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server
-
-      - name: Build and push migrate
-        uses: docker/build-push-action@v6
-        with:
-          file: packages/db/Dockerfile
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-migrate:latest
-            ${{ env.IMAGE_NAME_BASE }}-migrate:${{ steps.release.outputs.commit }}
-            ${{ env.IMAGE_NAME_BASE }}-migrate:${{ github.ref_name }}
-          cache-from: type=gha,scope=migrate
-          cache-to: type=gha,mode=max,scope=migrate
-
-  scan-images:
-    name: Scan ${{ matrix.image.name }} image
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - name: web
-          - name: server
-          - name: migrate
-    steps:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -119,26 +52,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image.name }}:${{ needs.build-and-push.outputs.commit }}
-          format: sarif
-          output: trivy-${{ matrix.image.name }}-results.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-
-      - name: Upload Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-${{ matrix.image.name }}-results.sarif
-          category: trivy-${{ matrix.image.name }}
+      - name: Promote commit images
+        run: |
+          set -euo pipefail
+          for image in web server migrate; do
+            source_image="${IMAGE_NAME_BASE}-${image}:${{ steps.release.outputs.commit }}"
+            for attempt in $(seq 1 20); do
+              if docker buildx imagetools inspect "${source_image}" > /dev/null; then
+                break
+              fi
+              if [ "${attempt}" -eq 20 ]; then
+                echo "Image ${source_image} was not found in GHCR after waiting" >&2
+                exit 1
+              fi
+              echo "Waiting for ${source_image} to be available in GHCR (${attempt}/20)"
+              sleep 15
+            done
+            docker buildx imagetools create \
+              -t "${IMAGE_NAME_BASE}-${image}:${GITHUB_REF_NAME}" \
+              -t "${IMAGE_NAME_BASE}-${image}:latest" \
+              "${source_image}"
+          done
 
   pre-deploy-backup:
     name: Pre-deploy Postgres Backup
-    needs: scan-images
+    needs: promote-release
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -220,7 +158,7 @@ jobs:
 
   deploy:
     name: Deploy to prive
-    needs: [scan-images, pre-deploy-backup]
+    needs: [promote-release, pre-deploy-backup]
     runs-on: ubuntu-latest
     environment:
       name: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,13 @@ env:
   IMAGE_NAME_BASE: ghcr.io/${{ github.repository }}
 
 jobs:
-  promote-release:
-    name: Promote Release Images
+  validate-release:
+    name: Validate Release
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,6 +43,20 @@ jobs:
 
           echo "commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
 
+  promote-release:
+    name: Promote ${{ matrix.image }} Release Image
+    needs: validate-release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - web
+          - server
+          - migrate
+    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -55,24 +70,23 @@ jobs:
       - name: Promote commit images
         run: |
           set -euo pipefail
-          for image in web server migrate; do
-            source_image="${IMAGE_NAME_BASE}-${image}:${{ steps.release.outputs.commit }}"
-            for attempt in $(seq 1 20); do
-              if docker buildx imagetools inspect "${source_image}" > /dev/null; then
-                break
-              fi
-              if [ "${attempt}" -eq 20 ]; then
-                echo "Image ${source_image} was not found in GHCR after waiting" >&2
-                exit 1
-              fi
-              echo "Waiting for ${source_image} to be available in GHCR (${attempt}/20)"
-              sleep 15
-            done
-            docker buildx imagetools create \
-              -t "${IMAGE_NAME_BASE}-${image}:${GITHUB_REF_NAME}" \
-              -t "${IMAGE_NAME_BASE}-${image}:latest" \
-              "${source_image}"
+          image="${{ matrix.image }}"
+          source_image="${IMAGE_NAME_BASE}-${image}:${{ needs.validate-release.outputs.commit }}"
+          for attempt in $(seq 1 20); do
+            if docker buildx imagetools inspect "${source_image}" > /dev/null; then
+              break
+            fi
+            if [ "${attempt}" -eq 20 ]; then
+              echo "Image ${source_image} was not found in GHCR after waiting" >&2
+              exit 1
+            fi
+            echo "Waiting for ${source_image} to be available in GHCR (${attempt}/20)"
+            sleep 15
           done
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME_BASE}-${image}:${GITHUB_REF_NAME}" \
+            -t "${IMAGE_NAME_BASE}-${image}:latest" \
+            "${source_image}"
 
   pre-deploy-backup:
     name: Pre-deploy Postgres Backup


### PR DESCRIPTION
## Summary
- split release image scanning into a `scan-images` matrix job for web, server, and migrate images
- use `fail-fast: false` so every image scan runs even when one image has HIGH/CRITICAL findings
- upload each image's SARIF from its own matrix leg and gate backup/deploy on the scan matrix

## Why
Run 28715376073 / job 85155681222 failed after the web Trivy scan exited 1. That skipped the later server and migrate scans, but their upload steps still ran with `if: always()`, producing secondary failures because `trivy-server-results.sarif` and `trivy-migrate-results.sarif` did not exist.

The matrix keeps each image scan isolated, so one image finding does not prevent the other image scans from running.

## Verification
- `node /private/tmp/prive-admin-release-workflow-test.mjs`
- `vp check`
- `vp test`
- `docker run --rm -v /Users/mselvenis/dev/prive-admin/.worktrees/fix-ci-build-28715376073:/repo -w /repo rhysd/actionlint:latest -ignore SC2029 .github/workflows/release.yml`

Note: plain actionlint reports pre-existing SC2029 warnings in unrelated SSH scripts, so SC2029 was ignored for workflow syntax validation.
