### PR TITLE
fix: harden runtime images for Trivy scans

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -40,10 +40,18 @@ FROM node:24-bookworm-slim AS runtime
 WORKDIR /app/apps/server
 ENV NODE_ENV=production
 
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/apps/server/dist /app/apps/server/dist
 COPY --from=build /app/apps/server/package.json /app/apps/server/package.json
 COPY --from=deps /app/node_modules /app/node_modules
 COPY --from=deps /app/apps/server/node_modules /app/apps/server/node_modules
+
+RUN find /app/node_modules -type f \
+  \( -name esbuild -o -name rolldown -o -name oxlint -o -name tsgolint -o -name tsx -o -name vite-plus \) \
+  -delete
 
 USER node
 EXPOSE 3000

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,6 +21,8 @@ RUN vp run --filter web build
 
 FROM nginx:alpine AS runtime
 
+RUN apk upgrade --no-cache
+
 COPY --from=build /app/apps/web/dist /usr/share/nginx/html
 COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -34,11 +34,19 @@ FROM node:24-bookworm-slim AS runtime
 WORKDIR /app/packages/db
 ENV NODE_ENV=production
 
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/packages/db/dist /app/packages/db/dist
 COPY --from=build /app/packages/db/src/migrations /app/packages/db/dist/migrations
 COPY --from=build /app/packages/db/package.json /app/packages/db/package.json
 COPY --from=deps /app/node_modules /app/node_modules
 COPY --from=deps /app/packages/db/node_modules /app/packages/db/node_modules
+
+RUN find /app/node_modules -type f \
+  \( -name esbuild -o -name rolldown -o -name oxlint -o -name tsgolint -o -name tsx -o -name vite-plus \) \
+  -delete
 
 USER node
 


### PR DESCRIPTION
## Summary
- upgrade OS packages in runtime Docker stages at build time
- remove Go-compiled build-tool executables from Node runtime images after production dependencies are copied

## Verification
- vp check
- vp test

This should land before #216 so the Trivy enforcement added there does not block on existing runtime image findings.