### PR TITLE
ci: refactor main image workflow matrix

### DIFF
--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -12,57 +12,25 @@ env:
   IMAGE_NAME_BASE: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-scan-push:
-    name: Build and Push Main Images
+  build-push:
+    name: Build and Push ${{ matrix.image }} Main Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: web
+            dockerfile: apps/web/Dockerfile
+          - image: server
+            dockerfile: apps/server/Dockerfile
+          - image: migrate
+            dockerfile: packages/db/Dockerfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build web
-        uses: docker/build-push-action@v6
-        with:
-          file: apps/web/Dockerfile
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-web:${{ github.sha }}
-            ${{ env.IMAGE_NAME_BASE }}-web:main
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
-
-      - name: Build server
-        uses: docker/build-push-action@v6
-        with:
-          file: apps/server/Dockerfile
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-server:${{ github.sha }}
-            ${{ env.IMAGE_NAME_BASE }}-server:main
-          cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server
-
-      - name: Build migrate
-        uses: docker/build-push-action@v6
-        with:
-          file: packages/db/Dockerfile
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: |
-            ${{ env.IMAGE_NAME_BASE }}-migrate:${{ github.sha }}
-            ${{ env.IMAGE_NAME_BASE }}-migrate:main
-          cache-from: type=gha,scope=migrate
-          cache-to: type=gha,mode=max,scope=migrate
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -71,10 +39,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          file: ${{ matrix.dockerfile }}
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: |
+            ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image }}:main
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+      - name: Push image
         run: |
           set -euo pipefail
-          for image in web server migrate; do
-            docker image push "${IMAGE_NAME_BASE}-${image}:${GITHUB_SHA}"
-            docker image push "${IMAGE_NAME_BASE}-${image}:main"
-          done
+          image="${{ matrix.image }}"
+          docker image push "${IMAGE_NAME_BASE}-${image}:${GITHUB_SHA}"
+          docker image push "${IMAGE_NAME_BASE}-${image}:main"


### PR DESCRIPTION
## Summary
- Convert the main image workflow to build each image through a matrix.
- Move GHCR login ahead of the build/push steps in each matrix job.
- Rename the job id to remove the stale scan reference.

## Test Plan
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main-images.yml"); puts "yaml ok"'
- [x] vp check