### PR TITLE
ci: stamp main images with revision labels

### DIFF
--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -52,6 +52,9 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image }}:${{ github.sha }}
             ${{ env.IMAGE_NAME_BASE }}-${{ matrix.image }}:main
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 


### PR DESCRIPTION
## Summary
- Add OCI revision/source labels to main image builds.
- Makes commit-tagged GHCR images differ by image config even when filesystem output is unchanged.
- Keeps the existing moving `main` tag behavior.

## Verification
- `vp install`
- `vp check`
- `git diff --check`
- `vp run --filter @prive-admin-tanstack/db test`

Note: root `vp test` currently discovers tests under local `.worktrees/...` directories and fails there; package-scoped DB tests pass.