### PR TITLE
refactor: standardize tRPC resource router contracts

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,22 +11,16 @@
     "start": "node dist/index.mjs"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1068.0",
     "@hono/node-server": "catalog:",
     "@hono/trpc-server": "catalog:",
-    "@paralleldrive/cuid2": "^3.3.0",
     "@prive-admin-tanstack/api": "workspace:*",
     "@prive-admin-tanstack/auth": "workspace:*",
-    "@prive-admin-tanstack/db": "workspace:*",
     "@prive-admin-tanstack/env": "workspace:*",
     "@trpc/server": "catalog:",
-    "archiver": "^8.0.0",
-    "drizzle-orm": "^0.45.2",
     "hono": "catalog:"
   },
   "devDependencies": {
     "@prive-admin-tanstack/config": "workspace:*",
-    "@types/archiver": "^6.0.3",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,52 +1,13 @@
-import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3"
 import { serve } from "@hono/node-server"
 import { trpcServer } from "@hono/trpc-server"
-import { createId } from "@paralleldrive/cuid2"
 import { createContext } from "@prive-admin-tanstack/api/context"
-import { bucketName, r2 } from "@prive-admin-tanstack/api/r2"
+import { apiRoutes } from "@prive-admin-tanstack/api/http"
 import { appRouter } from "@prive-admin-tanstack/api/routers"
 import { auth } from "@prive-admin-tanstack/auth"
-import { db } from "@prive-admin-tanstack/db"
-import { bankStatementAttachment } from "@prive-admin-tanstack/db/schema/bank-statement-attachment"
-import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
 import { env } from "@prive-admin-tanstack/env/server"
-import * as archiverPkg from "archiver"
-import { and, eq, gte, lte } from "drizzle-orm"
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
-import { Readable } from "node:stream"
-
-const ZipArchive = (
-  archiverPkg as unknown as {
-    ZipArchive: new (opts?: unknown) => Readable & {
-      append: (src: Readable | Buffer, opts: { name: string }) => void
-      finalize: () => void
-      on: (ev: string, cb: (err: Error) => void) => void
-    }
-  }
-).ZipArchive
-
-const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
-
-function pad2(n: number) {
-  return String(n).padStart(2, "0")
-}
-
-function lastDay(year: number, month: number) {
-  return new Date(Date.UTC(year, month, 0)).getUTCDate()
-}
-
-function safeSegment(s: string | null | undefined) {
-  if (!s) return ""
-  return s.replace(/[^\w.-]+/g, "_").slice(0, 60)
-}
-
-async function requireSession(request: Request) {
-  const session = await auth.api.getSession({ headers: request.headers })
-  if (!session) return null
-  return session
-}
 
 const app = new Hono()
 
@@ -62,189 +23,7 @@ app.use(
 )
 
 app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw))
-
-app.post("/api/upload", async (c) => {
-  const session = await requireSession(c.req.raw)
-  if (!session) return c.json({ error: "Unauthorized" }, 401)
-
-  const formData = await c.req.raw.formData()
-  const file = formData.get("file") as globalThis.File | null
-  if (!file) return c.json({ error: "No file provided" }, 400)
-
-  try {
-    const safeName = file.name.replace(/[^\w.-]+/g, "_")
-    const key = `uploads/${Date.now()}-${safeName}`
-    const arrayBuffer = await file.arrayBuffer()
-    await r2.send(
-      new PutObjectCommand({
-        Bucket: bucketName,
-        Key: key,
-        Body: new Uint8Array(arrayBuffer),
-        ContentType: file.type || "application/octet-stream",
-      }),
-    )
-    return c.json({ key })
-  } catch (error) {
-    console.error("[upload]", error)
-    return c.json({ error: "Upload failed" }, 500)
-  }
-})
-
-app.post("/api/statement-attachments/upload", async (c) => {
-  const session = await requireSession(c.req.raw)
-  if (!session) return c.json({ error: "Unauthorized" }, 401)
-
-  const formData = await c.req.raw.formData()
-  const rawEntryId = formData.get("entryId")
-  const entryId = typeof rawEntryId === "string" && rawEntryId.length > 0 ? rawEntryId : null
-  const file = formData.get("file") as globalThis.File | null
-
-  if (!file) return c.json({ error: "No file provided" }, 400)
-  if (file.size > MAX_ATTACHMENT_BYTES) return c.json({ error: `File exceeds ${MAX_ATTACHMENT_BYTES} bytes` }, 413)
-
-  if (entryId) {
-    const entry = await db.query.bankStatementEntry.findFirst({
-      where: eq(bankStatementEntry.id, entryId),
-      columns: { id: true },
-    })
-    if (!entry) return c.json({ error: "Entry not found" }, 404)
-  }
-
-  const safeName = file.name.replace(/[^\w.-]+/g, "_")
-  const now = new Date()
-  const yyyy = now.getUTCFullYear()
-  const mm = pad2(now.getUTCMonth() + 1)
-  const attachmentId = createId()
-  const key = `statement_uploads/${yyyy}/${mm}/${attachmentId}-${safeName}`
-  const arrayBuffer = await file.arrayBuffer()
-
-  try {
-    await r2.send(
-      new PutObjectCommand({
-        Bucket: bucketName,
-        Key: key,
-        Body: new Uint8Array(arrayBuffer),
-        ContentType: file.type || "application/octet-stream",
-      }),
-    )
-  } catch (error) {
-    console.error("[statement-attachment upload] R2", error)
-    return c.json({ error: "Upload failed" }, 500)
-  }
-
-  const [row] = await db
-    .insert(bankStatementAttachment)
-    .values({
-      id: attachmentId,
-      bankStatementEntryId: entryId,
-      r2Key: key,
-      originalName: file.name,
-      contentType: file.type || "application/octet-stream",
-      size: file.size,
-      uploadedById: session.user.id,
-    })
-    .returning()
-
-  return c.json(row)
-})
-
-app.get("/api/statement-attachments/preview", async (c) => {
-  const session = await requireSession(c.req.raw)
-  if (!session) return c.json({ error: "Unauthorized" }, 401)
-
-  const id = c.req.query("id")
-  if (!id) return c.json({ error: "Missing id" }, 400)
-
-  const row = await db.query.bankStatementAttachment.findFirst({
-    where: eq(bankStatementAttachment.id, id),
-  })
-  if (!row) return c.json({ error: "Not found" }, 404)
-
-  let obj
-  try {
-    obj = await r2.send(new GetObjectCommand({ Bucket: bucketName, Key: row.r2Key }))
-  } catch (error) {
-    console.error("[statement-attachment preview] R2", error)
-    return c.json({ error: "Fetch failed" }, 500)
-  }
-  if (!obj.Body) return c.json({ error: "Empty body" }, 500)
-
-  const webStream = Readable.toWeb(obj.Body as Readable) as unknown as ReadableStream
-  const inlineSafeTypes = new Set([
-    "application/pdf",
-    "image/jpeg",
-    "image/png",
-    "image/gif",
-    "image/webp",
-    "text/plain",
-    "text/csv",
-  ])
-  const contentType = row.contentType || "application/octet-stream"
-  const disposition = inlineSafeTypes.has(contentType) ? "inline" : "attachment"
-  const filename = encodeURIComponent(row.originalName)
-
-  return new Response(webStream, {
-    headers: {
-      "Content-Type": contentType,
-      "Content-Disposition": `${disposition}; filename="${filename}"; filename*=UTF-8''${filename}`,
-      "Cache-Control": "private, max-age=60",
-      "X-Content-Type-Options": "nosniff",
-    },
-  })
-})
-
-app.get("/api/statement-attachments/export", async (c) => {
-  const session = await requireSession(c.req.raw)
-  if (!session) return c.json({ error: "Unauthorized" }, 401)
-
-  const year = Number(c.req.query("year"))
-  const month = Number(c.req.query("month"))
-  const bankAccountId = c.req.query("bankAccountId") || undefined
-
-  if (!Number.isInteger(year) || year < 2000 || year > 9999) return c.json({ error: "Invalid year" }, 400)
-  if (!Number.isInteger(month) || month < 1 || month > 12) return c.json({ error: "Invalid month" }, 400)
-
-  const start = `${year}-${pad2(month)}-01`
-  const end = `${year}-${pad2(month)}-${pad2(lastDay(year, month))}`
-
-  const conditions = [gte(bankStatementEntry.date, start), lte(bankStatementEntry.date, end)]
-  if (bankAccountId) conditions.push(eq(bankStatementEntry.bankAccountId, bankAccountId))
-
-  const rows = await db
-    .select({
-      attachment: bankStatementAttachment,
-      entry: bankStatementEntry,
-    })
-    .from(bankStatementAttachment)
-    .innerJoin(bankStatementEntry, eq(bankStatementAttachment.bankStatementEntryId, bankStatementEntry.id))
-    .where(and(...conditions))
-
-  const archive = new ZipArchive({ zlib: { level: 9 } })
-  archive.on("warning", (err: Error) => console.warn("[zip warning]", err))
-  archive.on("error", (err: Error) => console.error("[zip error]", err))
-
-  for (const { attachment, entry } of rows) {
-    const obj = await r2.send(new GetObjectCommand({ Bucket: bucketName, Key: attachment.r2Key }))
-    const body = obj.Body
-    if (!body) continue
-    const counterparty = safeSegment(entry.counterpartyName) || "unknown"
-    const name = `${entry.date}_${counterparty}_${attachment.originalName}`
-    archive.append(body as Readable, { name })
-  }
-
-  archive.finalize()
-
-  const webStream = Readable.toWeb(archive) as unknown as ReadableStream
-  const filename = `bank-statements-${year}-${pad2(month)}.zip`
-
-  return new Response(webStream, {
-    headers: {
-      "Content-Type": "application/zip",
-      "Content-Disposition": `attachment; filename="${filename}"`,
-    },
-  })
-})
-
+app.route("/api", apiRoutes)
 app.use(
   "/trpc/*",
   trpcServer({
@@ -252,7 +31,6 @@ app.use(
     createContext: (_opts, context) => createContext({ context }),
   }),
 )
-
 app.get("/", (c) => c.text("OK"))
 
 serve(

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -31,6 +31,7 @@ type SalonOption = {
 }
 
 const defaultStartsAtString = () => dayjs().startOf("hour").add(1, "hour").format("YYYY-MM-DD HH:mm:ss")
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
 
 export function CreateAppointmentDialog({
   open,
@@ -84,7 +85,8 @@ function CreateAppointmentForm({
     },
   })
 
-  const { data: customers } = useQuery(trpc.customers.list.queryOptions())
+  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const customers = customersData?.items ?? []
 
   const { data: salons } = useQuery(salonsQueryOptions)
 
@@ -126,7 +128,7 @@ function CreateAppointmentForm({
             label="Client"
             required
             searchable
-            data={(customers ?? []).map((c) => ({ value: c.id, label: c.name }))}
+            data={customers.map((c) => ({ value: c.id, label: c.name }))}
             {...form.getInputProps("clientId")}
           />
         )}
@@ -134,7 +136,7 @@ function CreateAppointmentForm({
           label="Master"
           required
           searchable
-          data={(customers ?? []).map((c) => ({ value: c.id, label: c.name }))}
+          data={customers.map((c) => ({ value: c.id, label: c.name }))}
           {...form.getInputProps("masterId")}
         />
         <Select

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -31,7 +31,7 @@ type SalonOption = {
 }
 
 const defaultStartsAtString = () => dayjs().startOf("hour").add(1, "hour").format("YYYY-MM-DD HH:mm:ss")
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 export function CreateAppointmentDialog({
   open,

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -67,7 +67,7 @@ function CreateAppointmentForm({
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const appointmentListQueryOptions = trpc.appointments.list.queryOptions(defaultAppointmentsListInput)
-  const salonsQueryOptions = trpc.salons.list.queryOptions()
+  const salonsQueryOptions = trpc.salons.list.queryOptions({})
 
   const form = useForm<FormValues>({
     initialValues: {

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -32,6 +32,7 @@ type SalonOption = {
 
 const defaultStartsAtString = () => dayjs().startOf("hour").add(1, "hour").format("YYYY-MM-DD HH:mm:ss")
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+const defaultAppointmentsListInput = { page: 1, pageSize: 100 }
 
 export function CreateAppointmentDialog({
   open,
@@ -65,7 +66,7 @@ function CreateAppointmentForm({
 }: Omit<CreateAppointmentDialogProps, "open" | "onOpenChange"> & { onClose: () => void }) {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const appointmentListQueryOptions = trpc.appointments.list.queryOptions({})
+  const appointmentListQueryOptions = trpc.appointments.list.queryOptions(defaultAppointmentsListInput)
   const salonsQueryOptions = trpc.salons.list.queryOptions()
 
   const form = useForm<FormValues>({

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -5,7 +5,9 @@ import { notifications } from "@mantine/notifications"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
+import { useState } from "react"
 
+import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 type CreateAppointmentDialogProps = {
@@ -68,6 +70,9 @@ function CreateAppointmentForm({
   const navigate = useNavigate()
   const appointmentListQueryOptions = trpc.appointments.list.queryOptions(defaultAppointmentsListInput)
   const salonsQueryOptions = trpc.salons.list.queryOptions({})
+  const [clientSearch, setClientSearch] = useState("")
+  const [masterSearch, setMasterSearch] = useState("")
+  const [selectedCustomerOptions, setSelectedCustomerOptions] = useState<Record<string, SelectOption>>({})
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -86,8 +91,29 @@ function CreateAppointmentForm({
     },
   })
 
-  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
-  const customers = customersData?.items ?? []
+  const { data: clientCustomersData } = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: clientSearch.trim() || undefined,
+    }),
+  )
+  const { data: masterCustomersData } = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: masterSearch.trim() || undefined,
+    }),
+  )
+  const clientCustomerOptions = (clientCustomersData?.items ?? []).map((c) => ({ value: c.id, label: c.name }))
+  const masterCustomerOptions = (masterCustomersData?.items ?? []).map((c) => ({ value: c.id, label: c.name }))
+  const clientOptions = withPinnedOption(clientCustomerOptions, selectedCustomerOptions[form.values.clientId])
+  const masterOptions = withPinnedOption(masterCustomerOptions, selectedCustomerOptions[form.values.masterId])
+
+  const rememberCustomerOption = (value: string | null, options: SelectOption[]) => {
+    if (!value) return
+    const option = options.find((candidate) => candidate.value === value)
+    if (!option) return
+    setSelectedCustomerOptions((current) => ({ ...current, [option.value]: option }))
+  }
 
   const { data: salons } = useQuery(salonsQueryOptions)
 
@@ -129,16 +155,30 @@ function CreateAppointmentForm({
             label="Client"
             required
             searchable
-            data={customers.map((c) => ({ value: c.id, label: c.name }))}
-            {...form.getInputProps("clientId")}
+            searchValue={clientSearch}
+            onSearchChange={setClientSearch}
+            data={clientOptions}
+            value={form.values.clientId}
+            onChange={(value) => {
+              form.setFieldValue("clientId", value ?? "")
+              rememberCustomerOption(value, clientOptions)
+            }}
+            error={form.errors.clientId}
           />
         )}
         <Select
           label="Master"
           required
           searchable
-          data={customers.map((c) => ({ value: c.id, label: c.name }))}
-          {...form.getInputProps("masterId")}
+          searchValue={masterSearch}
+          onSearchChange={setMasterSearch}
+          data={masterOptions}
+          value={form.values.masterId}
+          onChange={(value) => {
+            form.setFieldValue("masterId", value ?? "")
+            rememberCustomerOption(value, masterOptions)
+          }}
+          error={form.errors.masterId}
         />
         <Select
           label="Salon"

--- a/apps/web/src/components/cash-transactions/cash-transaction-form.tsx
+++ b/apps/web/src/components/cash-transactions/cash-transaction-form.tsx
@@ -1,8 +1,10 @@
 import { Button, Group, NativeSelect, NumberInput, Select, Stack, Textarea, TextInput } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
+import { useState } from "react"
 
 import { CURRENCY_OPTIONS, type Currency, currencySymbol } from "@/lib/currency"
+import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 
 const MIN_MINOR_AMOUNT = -2147483648
 const MAX_MINOR_AMOUNT = 2147483647
@@ -34,7 +36,10 @@ type CashTransactionFormSubmit = {
 
 type CashTransactionFormProps = {
   customers: CashTransactionFormCustomer[]
+  customerSearch: string
+  onCustomerSearchChange: (search: string) => void
   initialValues: CashTransactionFormValues
+  initialCustomerOption?: SelectOption | null
   submitLabel: string
   onSubmit: (values: CashTransactionFormSubmit) => void | Promise<void>
   loading?: boolean
@@ -42,11 +47,17 @@ type CashTransactionFormProps = {
 
 export function CashTransactionForm({
   customers,
+  customerSearch,
+  onCustomerSearchChange,
   initialValues,
+  initialCustomerOption,
   submitLabel,
   onSubmit,
   loading,
 }: CashTransactionFormProps) {
+  const [selectedCustomerOption, setSelectedCustomerOption] = useState<SelectOption | null>(
+    initialCustomerOption ?? null,
+  )
   const form = useForm<CashTransactionFormValues>({
     initialValues,
     validate: {
@@ -65,6 +76,10 @@ export function CashTransactionForm({
       },
     },
   })
+  const customerOptions = withPinnedOption(
+    customers.map((customer) => ({ value: customer.id, label: customer.name })),
+    selectedCustomerOption ?? initialCustomerOption,
+  )
 
   return (
     <form
@@ -84,8 +99,16 @@ export function CashTransactionForm({
           label="Customer"
           placeholder="Select a customer..."
           searchable
-          data={customers.map((customer) => ({ value: customer.id, label: customer.name }))}
-          {...form.getInputProps("customerId")}
+          searchValue={customerSearch}
+          onSearchChange={onCustomerSearchChange}
+          data={customerOptions}
+          value={form.values.customerId}
+          onChange={(value) => {
+            form.setFieldValue("customerId", value ?? "")
+            const option = customerOptions.find((candidate) => candidate.value === value)
+            if (option) setSelectedCustomerOption(option)
+          }}
+          error={form.errors.customerId}
         />
         <DateInput label="Date" valueFormat="DD MMM YYYY" {...form.getInputProps("createdAt")} />
         <TextInput

--- a/apps/web/src/components/cash-transactions/create-cash-transaction-dialog.tsx
+++ b/apps/web/src/components/cash-transactions/create-cash-transaction-dialog.tsx
@@ -1,7 +1,8 @@
 import { Modal } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import dayjs from "dayjs"
+import { useState } from "react"
 
 import {
   CashTransactionForm,
@@ -12,11 +13,21 @@ import { trpc } from "@/utils/trpc"
 type CreateCashTransactionDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  customers: CashTransactionFormCustomer[]
 }
 
-export function CreateCashTransactionDialog({ open, onOpenChange, customers }: CreateCashTransactionDialogProps) {
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+
+export function CreateCashTransactionDialog({ open, onOpenChange }: CreateCashTransactionDialogProps) {
   const queryClient = useQueryClient()
+  const [customerSearch, setCustomerSearch] = useState("")
+  const { data: customersData } = useQuery({
+    ...trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+    enabled: open,
+  })
+  const customers: CashTransactionFormCustomer[] = customersData?.items ?? []
 
   const mutation = useMutation({
     ...trpc.cashTransactions.create.mutationOptions(),
@@ -32,6 +43,8 @@ export function CreateCashTransactionDialog({ open, onOpenChange, customers }: C
     <Modal opened={open} onClose={() => onOpenChange(false)} title="New Cash Transaction">
       <CashTransactionForm
         customers={customers}
+        customerSearch={customerSearch}
+        onCustomerSearchChange={setCustomerSearch}
         initialValues={{
           customerId: "",
           createdAt: dayjs().format("YYYY-MM-DD"),

--- a/apps/web/src/components/cash-transactions/edit-cash-transaction-dialog.tsx
+++ b/apps/web/src/components/cash-transactions/edit-cash-transaction-dialog.tsx
@@ -1,7 +1,8 @@
 import { Modal } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import dayjs from "dayjs"
+import { useState } from "react"
 
 import {
   CashTransactionForm,
@@ -9,22 +10,31 @@ import {
 } from "@/components/cash-transactions/cash-transaction-form"
 import { type CashTransactionRow } from "@/components/cash-transactions/cash-transactions-table"
 import { coerceCashTransactionCurrency } from "@/components/cash-transactions/currency"
+import { type SelectOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 type EditCashTransactionDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   transaction: CashTransactionRow
-  customers: CashTransactionFormCustomer[]
 }
 
-export function EditCashTransactionDialog({
-  open,
-  onOpenChange,
-  transaction,
-  customers,
-}: EditCashTransactionDialogProps) {
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+
+export function EditCashTransactionDialog({ open, onOpenChange, transaction }: EditCashTransactionDialogProps) {
   const queryClient = useQueryClient()
+  const [customerSearch, setCustomerSearch] = useState("")
+  const { data: customersData } = useQuery({
+    ...trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+    enabled: open,
+  })
+  const customers: CashTransactionFormCustomer[] = customersData?.items ?? []
+  const initialCustomerOption: SelectOption | null = transaction.customer
+    ? { value: transaction.customer.id, label: transaction.customer.name }
+    : null
 
   const mutation = useMutation({
     ...trpc.cashTransactions.update.mutationOptions(),
@@ -43,6 +53,9 @@ export function EditCashTransactionDialog({
       <CashTransactionForm
         key={transaction.id}
         customers={customers}
+        customerSearch={customerSearch}
+        onCustomerSearchChange={setCustomerSearch}
+        initialCustomerOption={initialCustomerOption}
         initialValues={{
           customerId: transaction.customerId,
           createdAt: dayjs(transaction.createdAt).format("YYYY-MM-DD"),

--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -11,6 +11,7 @@ type CreateHairAssignedDialogProps = {
   clientId: string
   appointmentId?: string | null
   invalidateKeys: { queryKey: readonly unknown[] }[]
+  onSuccess?: () => void
 }
 
 export function CreateHairAssignedDialog({
@@ -19,6 +20,7 @@ export function CreateHairAssignedDialog({
   clientId,
   appointmentId,
   invalidateKeys,
+  onSuccess,
 }: CreateHairAssignedDialogProps) {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
   const queryClient = useQueryClient()
@@ -41,6 +43,7 @@ export function CreateHairAssignedDialog({
       if (selectedOrderId) {
         queryClient.invalidateQueries({ queryKey: trpc.hairOrders.get.queryOptions({ id: selectedOrderId }).queryKey })
       }
+      onSuccess?.()
       onOpenChange(false)
       setSelectedOrderId(null)
       notifications.show({ color: "green", message: "Hair assigned created" })

--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -23,6 +23,7 @@ export function CreateHairAssignedDialog({
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const { data: availableOrders, isLoading } = useQuery({
@@ -34,6 +35,7 @@ export function CreateHairAssignedDialog({
     ...trpc.hairAssigned.create.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      queryClient.invalidateQueries({ queryKey: hairAssignedListQueryKey })
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
       queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (selectedOrderId) {

--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -23,7 +23,7 @@ export function CreateHairAssignedDialog({
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
-  const hairOrdersListQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const { data: availableOrders, isLoading } = useQuery({
     ...availableOrdersQueryOptions,
@@ -35,9 +35,9 @@ export function CreateHairAssignedDialog({
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
-      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (selectedOrderId) {
-        queryClient.invalidateQueries({ queryKey: trpc.hairOrders.byId.queryOptions({ id: selectedOrderId }).queryKey })
+        queryClient.invalidateQueries({ queryKey: trpc.hairOrders.get.queryOptions({ id: selectedOrderId }).queryKey })
       }
       onOpenChange(false)
       setSelectedOrderId(null)

--- a/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
@@ -14,6 +14,7 @@ type DeleteHairAssignedDialogProps = {
     hairOrder?: { id: string; uid: number } | null
   }
   invalidateKeys: { queryKey: readonly unknown[] }[]
+  onSuccess?: () => void
 }
 
 export function DeleteHairAssignedDialog({
@@ -21,6 +22,7 @@ export function DeleteHairAssignedDialog({
   onOpenChange,
   hairAssigned,
   invalidateKeys,
+  onSuccess,
 }: DeleteHairAssignedDialogProps) {
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
@@ -39,6 +41,7 @@ export function DeleteHairAssignedDialog({
           queryKey: trpc.hairOrders.get.queryOptions({ id: hairAssigned.hairOrder.id }).queryKey,
         })
       }
+      onSuccess?.()
       onOpenChange(false)
       notifications.show({ color: "green", message: "Hair assigned deleted" })
     },

--- a/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
@@ -24,12 +24,14 @@ export function DeleteHairAssignedDialog({
 }: DeleteHairAssignedDialogProps) {
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairAssigned.delete.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      queryClient.invalidateQueries({ queryKey: hairAssignedListQueryKey })
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
       queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (hairAssigned.hairOrder) {

--- a/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
@@ -24,17 +24,17 @@ export function DeleteHairAssignedDialog({
 }: DeleteHairAssignedDialogProps) {
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
-  const hairOrdersListQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairAssigned.delete.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
-      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (hairAssigned.hairOrder) {
         queryClient.invalidateQueries({
-          queryKey: trpc.hairOrders.byId.queryOptions({ id: hairAssigned.hairOrder.id }).queryKey,
+          queryKey: trpc.hairOrders.get.queryOptions({ id: hairAssigned.hairOrder.id }).queryKey,
         })
       }
       onOpenChange(false)

--- a/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
@@ -20,12 +20,14 @@ export function EditHairAssignedDialog({
 }: EditHairAssignedDialogProps) {
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairAssigned.update.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      queryClient.invalidateQueries({ queryKey: hairAssignedListQueryKey })
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
       queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (hairAssigned.hairOrder) {

--- a/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
@@ -20,17 +20,17 @@ export function EditHairAssignedDialog({
 }: EditHairAssignedDialogProps) {
   const queryClient = useQueryClient()
   const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
-  const hairOrdersListQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairAssigned.update.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
       queryClient.invalidateQueries({ queryKey: availableOrdersQueryOptions.queryKey })
-      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       if (hairAssigned.hairOrder) {
         queryClient.invalidateQueries({
-          queryKey: trpc.hairOrders.byId.queryOptions({ id: hairAssigned.hairOrder.id }).queryKey,
+          queryKey: trpc.hairOrders.get.queryOptions({ id: hairAssigned.hairOrder.id }).queryKey,
         })
       }
       onOpenChange(false)

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 
-import { Group, Stack, Text, Title } from "@mantine/core"
+import { Box, Group, Stack, Title } from "@mantine/core"
 
 export function PageHeader({
   title,
@@ -18,9 +18,9 @@ export function PageHeader({
           {title}
         </Title>
         {description ? (
-          <Text size="sm" c="dimmed">
+          <Box c="dimmed" fz="sm">
             {description}
-          </Text>
+          </Box>
         ) : null}
       </Stack>
       {actions ? (

--- a/apps/web/src/components/section.tsx
+++ b/apps/web/src/components/section.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 
-import { Box, Card, Divider, Group, Stack, Text, Title } from "@mantine/core"
+import { Box, Card, Divider, Group, Stack, Title } from "@mantine/core"
 
 export function Section({
   title,
@@ -29,9 +29,9 @@ export function Section({
                 </Title>
               ) : null}
               {description ? (
-                <Text size="sm" c="dimmed">
+                <Box c="dimmed" fz="sm">
                   {description}
-                </Text>
+                </Box>
               ) : null}
             </Stack>
             {actions ? (

--- a/apps/web/src/components/transactions/create-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/create-transaction-dialog.tsx
@@ -14,6 +14,7 @@ type CreateTransactionDialogProps = {
   customerId: string
   defaultCurrency: Currency
   invalidateKeys: { queryKey: readonly unknown[] }[]
+  onSuccess?: () => void
 }
 
 export function CreateTransactionDialog({
@@ -23,6 +24,7 @@ export function CreateTransactionDialog({
   customerId,
   defaultCurrency,
   invalidateKeys,
+  onSuccess,
 }: CreateTransactionDialogProps) {
   const queryClient = useQueryClient()
 
@@ -30,6 +32,7 @@ export function CreateTransactionDialog({
     ...trpc.transactions.create.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onSuccess?.()
       onOpenChange(false)
       notifications.show({ color: "green", message: "Transaction created" })
     },

--- a/apps/web/src/components/transactions/delete-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/delete-transaction-dialog.tsx
@@ -16,6 +16,7 @@ type DeleteTransactionDialogProps = {
     customer?: { name: string } | null
   }
   invalidateKeys: { queryKey: readonly unknown[] }[]
+  onSuccess?: () => void
 }
 
 export function DeleteTransactionDialog({
@@ -23,6 +24,7 @@ export function DeleteTransactionDialog({
   onOpenChange,
   transaction,
   invalidateKeys,
+  onSuccess,
 }: DeleteTransactionDialogProps) {
   const queryClient = useQueryClient()
 
@@ -30,6 +32,7 @@ export function DeleteTransactionDialog({
     ...trpc.transactions.delete.mutationOptions(),
     onSuccess: () => {
       for (const key of invalidateKeys) queryClient.invalidateQueries(key)
+      onSuccess?.()
       onOpenChange(false)
       notifications.show({ color: "green", message: "Transaction deleted" })
     },

--- a/apps/web/src/lib/resource-pagination.test.ts
+++ b/apps/web/src/lib/resource-pagination.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import { clampPage, formatPageRange, withPinnedOption } from "./resource-pagination"
+
+describe("resource pagination helpers", () => {
+  it("formats the loaded item range for a paged resource", () => {
+    expect(formatPageRange({ page: 1, pageSize: 25, itemCount: 25, totalCount: 75 })).toBe("showing 1-25 of 75")
+    expect(formatPageRange({ page: 3, pageSize: 25, itemCount: 7, totalCount: 57 })).toBe("showing 51-57 of 57")
+  })
+
+  it("formats an empty resource range", () => {
+    expect(formatPageRange({ page: 1, pageSize: 25, itemCount: 0, totalCount: 0 })).toBe("showing 0 of 0")
+  })
+
+  it("clamps pages to the available total count", () => {
+    expect(clampPage({ page: 4, pageSize: 25, totalCount: 51 })).toBe(3)
+    expect(clampPage({ page: 0, pageSize: 25, totalCount: 0 })).toBe(1)
+  })
+
+  it("keeps an existing selected option when it is not in the searched page", () => {
+    expect(
+      withPinnedOption(
+        [
+          { value: "customer-1", label: "Alice" },
+          { value: "customer-2", label: "Beth" },
+        ],
+        { value: "customer-3", label: "Cara" },
+      ),
+    ).toEqual([
+      { value: "customer-3", label: "Cara" },
+      { value: "customer-1", label: "Alice" },
+      { value: "customer-2", label: "Beth" },
+    ])
+  })
+
+  it("does not duplicate an option that is already in the searched page", () => {
+    expect(
+      withPinnedOption(
+        [
+          { value: "customer-1", label: "Alice" },
+          { value: "customer-2", label: "Beth" },
+        ],
+        { value: "customer-2", label: "Beth" },
+      ),
+    ).toEqual([
+      { value: "customer-1", label: "Alice" },
+      { value: "customer-2", label: "Beth" },
+    ])
+  })
+})

--- a/apps/web/src/lib/resource-pagination.ts
+++ b/apps/web/src/lib/resource-pagination.ts
@@ -1,0 +1,32 @@
+export type SelectOption = {
+  value: string
+  label: string
+}
+
+export function clampPage({ page, pageSize, totalCount }: { page: number; pageSize: number; totalCount: number }) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+  return Math.min(Math.max(1, page), totalPages)
+}
+
+export function formatPageRange({
+  page,
+  pageSize,
+  itemCount,
+  totalCount,
+}: {
+  page: number
+  pageSize: number
+  itemCount: number
+  totalCount: number
+}) {
+  if (itemCount === 0) return `showing 0 of ${totalCount}`
+
+  const start = (page - 1) * pageSize + 1
+  const end = Math.min(start + itemCount - 1, totalCount)
+  return `showing ${start}-${end} of ${totalCount}`
+}
+
+export function withPinnedOption<TOption extends SelectOption>(options: TOption[], pinnedOption?: TOption | null) {
+  if (!pinnedOption || options.some((option) => option.value === pinnedOption.value)) return options
+  return [pinnedOption, ...options]
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import { UIProvider } from "@prive-admin-tanstack/ui/provider"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { RouterProvider } from "@tanstack/react-router"
 import { StrictMode } from "react"
@@ -15,7 +16,9 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} context={{ queryClient, trpc }} />
+      <UIProvider>
+        <RouterProvider router={router} context={{ queryClient, trpc }} />
+      </UIProvider>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,3 @@
-import { UIProvider } from "@prive-admin-tanstack/ui/provider"
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router"
 import { lazy, useEffect } from "react"
 
@@ -39,9 +38,7 @@ function RootComponent() {
   return (
     <>
       <LocaleProvider value={{ locale, timeZone }}>
-        <UIProvider>
-          <Outlet />
-        </UIProvider>
+        <Outlet />
       </LocaleProvider>
       <TanStackRouterDevtools position="bottom-left" />
     </>

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -8,6 +8,7 @@ import {
   Group,
   Menu,
   Modal,
+  Pagination,
   ScrollArea,
   Select,
   Skeleton,
@@ -21,7 +22,7 @@ import { notifications } from "@mantine/notifications"
 import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { ClientDate } from "@/components/client-date"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
@@ -34,6 +35,7 @@ import { DeleteTransactionDialog } from "@/components/transactions/delete-transa
 import { EditTransactionDialog } from "@/components/transactions/edit-transaction-dialog"
 import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
 import { CURRENCIES, type Currency, formatMinor } from "@/lib/currency"
+import { clampPage, formatPageRange, type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => [currency, 0])) as Record<
@@ -41,8 +43,7 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
   number
 >
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
-const boundedAppointmentDetailTransactionsListInput = { page: 1, pageSize: 100 }
-const boundedAppointmentDetailHairAssignedListInput = { page: 1, pageSize: 100 }
+const APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE = 25
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
@@ -51,13 +52,15 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
       context.queryClient.prefetchQuery(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
       context.queryClient.prefetchQuery(
         trpc.hairAssigned.list.queryOptions({
-          ...boundedAppointmentDetailHairAssignedListInput,
+          page: 1,
+          pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
           appointmentId: params.appointmentId,
         }),
       ),
       context.queryClient.prefetchQuery(
         trpc.transactions.list.queryOptions({
-          ...boundedAppointmentDetailTransactionsListInput,
+          page: 1,
+          pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
           appointmentId: params.appointmentId,
         }),
       ),
@@ -77,14 +80,18 @@ function AppointmentDetailPage() {
   const [createTxCustomerId, setCreateTxCustomerId] = useState<string | null>(null)
   const [editTx, setEditTx] = useState<TransactionRow | null>(null)
   const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
+  const [transactionsPage, setTransactionsPage] = useState(1)
+  const [hairAssignedPage, setHairAssignedPage] = useState(1)
 
   const appointmentQueryOptions = trpc.appointments.get.queryOptions({ id: appointmentId })
   const hairAssignedQueryOptions = trpc.hairAssigned.list.queryOptions({
-    ...boundedAppointmentDetailHairAssignedListInput,
+    page: hairAssignedPage,
+    pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
     appointmentId,
   })
   const transactionsQueryOptions = trpc.transactions.list.queryOptions({
-    ...boundedAppointmentDetailTransactionsListInput,
+    page: transactionsPage,
+    pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
     appointmentId,
   })
 
@@ -92,8 +99,14 @@ function AppointmentDetailPage() {
 
   const { data: hairAssignedData } = useQuery(hairAssignedQueryOptions)
   const hairAssigned = hairAssignedData?.items ?? []
+  const hairAssignedTotalCount = hairAssignedData?.totalCount ?? 0
+  const hairAssignedTotalPages = Math.max(1, Math.ceil(hairAssignedTotalCount / APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE))
+  const showHairAssignedPagination = hairAssignedTotalCount > APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE
 
   const { data: transactionsData } = useQuery(transactionsQueryOptions)
+  const transactionsTotalCount = transactionsData?.totalCount ?? 0
+  const transactionsTotalPages = Math.max(1, Math.ceil(transactionsTotalCount / APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE))
+  const showTransactionsPagination = transactionsTotalCount > APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE
 
   const { data: userSettings } = useQuery(trpc.userSettings.get.queryOptions())
 
@@ -105,6 +118,33 @@ function AppointmentDetailPage() {
     totalsByCurrency[c] += t.amount
   }
   const currenciesPresent = CURRENCIES.filter((c) => totalsByCurrency[c] !== 0)
+
+  useEffect(() => {
+    setTransactionsPage(1)
+    setHairAssignedPage(1)
+  }, [appointmentId])
+
+  useEffect(() => {
+    if (!transactionsData) return
+    setTransactionsPage((current) =>
+      clampPage({
+        page: current,
+        pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
+        totalCount: transactionsData.totalCount,
+      }),
+    )
+  }, [transactionsData])
+
+  useEffect(() => {
+    if (!hairAssignedData) return
+    setHairAssignedPage((current) =>
+      clampPage({
+        page: current,
+        pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
+        totalCount: hairAssignedData.totalCount,
+      }),
+    )
+  }, [hairAssignedData])
 
   if (isLoading) {
     return (
@@ -127,7 +167,7 @@ function AppointmentDetailPage() {
 
   const invalidateKeys = [
     { queryKey: appointmentQueryOptions.queryKey },
-    { queryKey: hairAssignedQueryOptions.queryKey },
+    { queryKey: trpc.hairAssigned.list.queryKey() },
     { queryKey: trpc.customers.summary.queryOptions({ id: appointment.client.id }).queryKey },
   ]
 
@@ -139,7 +179,7 @@ function AppointmentDetailPage() {
     ]),
   )
   const txInvalidateKeys = [
-    { queryKey: transactionsQueryOptions.queryKey },
+    { queryKey: trpc.transactions.list.queryKey() },
     ...transactionCustomerIds.map((id) => ({ queryKey: trpc.customers.summary.queryOptions({ id }).queryKey })),
   ]
 
@@ -277,7 +317,17 @@ function AppointmentDetailPage() {
 
           <Card withBorder>
             <Group justify="space-between" mb="sm">
-              <Title order={5}>Hair Assigned</Title>
+              <Stack gap={0}>
+                <Title order={5}>Hair Assigned</Title>
+                <Text size="xs" c="dimmed">
+                  {formatPageRange({
+                    page: hairAssignedPage,
+                    pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
+                    itemCount: hairAssigned.length,
+                    totalCount: hairAssignedTotalCount,
+                  })}
+                </Text>
+              </Stack>
               <Button
                 variant="subtle"
                 size="xs"
@@ -288,6 +338,18 @@ function AppointmentDetailPage() {
               </Button>
             </Group>
             <HairAssignedTable items={hairAssigned} showHairOrderColumn onEdit={setEditItem} onDelete={setDeleteItem} />
+            {showHairAssignedPagination && (
+              <Group justify="space-between" mt="md">
+                <Text size="sm" c="dimmed">
+                  Page {Math.min(hairAssignedPage, hairAssignedTotalPages)} of {hairAssignedTotalPages}
+                </Text>
+                <Pagination
+                  total={hairAssignedTotalPages}
+                  value={Math.min(hairAssignedPage, hairAssignedTotalPages)}
+                  onChange={setHairAssignedPage}
+                />
+              </Group>
+            )}
           </Card>
         </Group>
 
@@ -310,7 +372,7 @@ function AppointmentDetailPage() {
                 {currenciesPresent.length === 0 ? (
                   <Stack gap={2}>
                     <Text size="sm">
-                      Total: <b>{formatMinor(0, "EUR")}</b>
+                      Current page total: <b>{formatMinor(0, "EUR")}</b>
                     </Text>
                   </Stack>
                 ) : (
@@ -320,7 +382,7 @@ function AppointmentDetailPage() {
                         {c}
                       </Text>
                       <Text size="sm">
-                        Total: <b>{formatMinor(totalsByCurrency[c], c)}</b>
+                        Current page total: <b>{formatMinor(totalsByCurrency[c], c)}</b>
                       </Text>
                     </Stack>
                   ))
@@ -332,7 +394,17 @@ function AppointmentDetailPage() {
 
         <Card withBorder>
           <Group justify="space-between" mb="sm">
-            <Title order={5}>Transactions</Title>
+            <Stack gap={0}>
+              <Title order={5}>Transactions</Title>
+              <Text size="xs" c="dimmed">
+                {formatPageRange({
+                  page: transactionsPage,
+                  pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
+                  itemCount: txList.length,
+                  totalCount: transactionsTotalCount,
+                })}
+              </Text>
+            </Stack>
             <Button
               variant="subtle"
               size="xs"
@@ -349,6 +421,18 @@ function AppointmentDetailPage() {
             }))
             return <TransactionsTable items={txRows} onEdit={setEditTx} onDelete={setDeleteTx} />
           })()}
+          {showTransactionsPagination && (
+            <Group justify="space-between" mt="md">
+              <Text size="sm" c="dimmed">
+                Page {Math.min(transactionsPage, transactionsTotalPages)} of {transactionsTotalPages}
+              </Text>
+              <Pagination
+                total={transactionsTotalPages}
+                value={Math.min(transactionsPage, transactionsTotalPages)}
+                onChange={setTransactionsPage}
+              />
+            </Group>
+          )}
         </Card>
 
         <Card withBorder>
@@ -409,6 +493,7 @@ function AppointmentDetailPage() {
             onOpenChange={setChangeMasterOpen}
             appointmentId={appointmentId}
             currentMasterId={appointment.master.id}
+            currentMasterName={appointment.master.name}
           />
         )}
         <CreateTransactionDialog
@@ -455,15 +540,23 @@ type ChangeMasterModalProps = {
   onOpenChange: (open: boolean) => void
   appointmentId: string
   currentMasterId: string
+  currentMasterName: string
 }
 
-function ChangeMasterModal({ open, onOpenChange, appointmentId, currentMasterId }: ChangeMasterModalProps) {
+function ChangeMasterModal({
+  open,
+  onOpenChange,
+  appointmentId,
+  currentMasterId,
+  currentMasterName,
+}: ChangeMasterModalProps) {
   return (
     <Modal opened={open} onClose={() => onOpenChange(false)} title="Change master">
       {open && (
         <ChangeMasterForm
           appointmentId={appointmentId}
           currentMasterId={currentMasterId}
+          currentMasterName={currentMasterName}
           onClose={() => onOpenChange(false)}
         />
       )}
@@ -474,18 +567,32 @@ function ChangeMasterModal({ open, onOpenChange, appointmentId, currentMasterId 
 function ChangeMasterForm({
   appointmentId,
   currentMasterId,
+  currentMasterName,
   onClose,
 }: {
   appointmentId: string
   currentMasterId: string
+  currentMasterName: string
   onClose: () => void
 }) {
   const queryClient = useQueryClient()
   const [draftMasterId, setDraftMasterId] = useState<string | null>(null)
+  const [masterSearch, setMasterSearch] = useState("")
+  const [selectedMasterOption, setSelectedMasterOption] = useState<SelectOption | null>(null)
   const masterId = draftMasterId ?? currentMasterId
 
-  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const { data: customersData } = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: masterSearch.trim() || undefined,
+    }),
+  )
   const customers = customersData?.items ?? []
+  const customerOptions = customers.map((c) => ({ value: c.id, label: c.name }))
+  const masterOptions = withPinnedOption(
+    customerOptions,
+    selectedMasterOption ?? { value: currentMasterId, label: currentMasterName },
+  )
 
   const mutation = useMutation({
     ...trpc.appointments.update.mutationOptions(),
@@ -503,9 +610,15 @@ function ChangeMasterForm({
         label="Master"
         required
         searchable
+        searchValue={masterSearch}
+        onSearchChange={setMasterSearch}
         value={masterId}
-        onChange={setDraftMasterId}
-        data={customers.map((c) => ({ value: c.id, label: c.name }))}
+        onChange={(value) => {
+          setDraftMasterId(value)
+          const option = masterOptions.find((candidate) => candidate.value === value)
+          if (option) setSelectedMasterOption(option)
+        }}
+        data={masterOptions}
       />
       <Group justify="flex-end" gap="xs">
         <Button variant="default" onClick={onClose}>
@@ -529,20 +642,21 @@ function PickPersonnelModal({ open, onOpenChange, appointmentId, assignedPersonn
   const [search, setSearch] = useState("")
 
   const { data: customersData } = useQuery({
-    ...trpc.customers.list.queryOptions(defaultCustomersListInput),
+    ...trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: search.trim() || undefined,
+    }),
     enabled: open,
   })
   const customers = customersData?.items ?? []
 
   const available = useMemo(() => {
     const assigned = new Set(assignedPersonnelIds)
-    const term = search.trim().toLowerCase()
     return customers.filter((c) => {
       if (assigned.has(c.id)) return false
-      if (term && !c.name.toLowerCase().includes(term)) return false
       return true
     })
-  }, [customers, assignedPersonnelIds, search])
+  }, [customers, assignedPersonnelIds])
 
   const mutation = useMutation({
     ...trpc.appointments.linkPersonnel.mutationOptions(),

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -40,6 +40,7 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
   Currency,
   number
 >
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
@@ -473,7 +474,8 @@ function ChangeMasterForm({
   const [draftMasterId, setDraftMasterId] = useState<string | null>(null)
   const masterId = draftMasterId ?? currentMasterId
 
-  const { data: customers } = useQuery(trpc.customers.list.queryOptions())
+  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const customers = customersData?.items ?? []
 
   const mutation = useMutation({
     ...trpc.appointments.updateMaster.mutationOptions(),
@@ -493,7 +495,7 @@ function ChangeMasterForm({
         searchable
         value={masterId}
         onChange={setDraftMasterId}
-        data={(customers ?? []).map((c) => ({ value: c.id, label: c.name }))}
+        data={customers.map((c) => ({ value: c.id, label: c.name }))}
       />
       <Group justify="flex-end" gap="xs">
         <Button variant="default" onClick={onClose}>
@@ -516,15 +518,16 @@ function PickPersonnelModal({ open, onOpenChange, appointmentId, assignedPersonn
   const [selected, setSelected] = useState<string[]>([])
   const [search, setSearch] = useState("")
 
-  const { data: customers } = useQuery({
-    ...trpc.customers.list.queryOptions(),
+  const { data: customersData } = useQuery({
+    ...trpc.customers.list.queryOptions(defaultCustomersListInput),
     enabled: open,
   })
+  const customers = customersData?.items ?? []
 
   const available = useMemo(() => {
     const assigned = new Set(assignedPersonnelIds)
     const term = search.trim().toLowerCase()
-    return (customers ?? []).filter((c) => {
+    return customers.filter((c) => {
       if (assigned.has(c.id)) return false
       if (term && !c.name.toLowerCase().includes(term)) return false
       return true

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -42,6 +42,7 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
 >
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 const boundedAppointmentDetailTransactionsListInput = { page: 1, pageSize: 100 }
+const boundedAppointmentDetailHairAssignedListInput = { page: 1, pageSize: 100 }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
@@ -49,7 +50,10 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
     await Promise.all([
       context.queryClient.prefetchQuery(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
       context.queryClient.prefetchQuery(
-        trpc.hairAssigned.byAppointment.queryOptions({ appointmentId: params.appointmentId }),
+        trpc.hairAssigned.list.queryOptions({
+          ...boundedAppointmentDetailHairAssignedListInput,
+          appointmentId: params.appointmentId,
+        }),
       ),
       context.queryClient.prefetchQuery(
         trpc.transactions.list.queryOptions({
@@ -75,7 +79,10 @@ function AppointmentDetailPage() {
   const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
 
   const appointmentQueryOptions = trpc.appointments.get.queryOptions({ id: appointmentId })
-  const hairAssignedQueryOptions = trpc.hairAssigned.byAppointment.queryOptions({ appointmentId })
+  const hairAssignedQueryOptions = trpc.hairAssigned.list.queryOptions({
+    ...boundedAppointmentDetailHairAssignedListInput,
+    appointmentId,
+  })
   const transactionsQueryOptions = trpc.transactions.list.queryOptions({
     ...boundedAppointmentDetailTransactionsListInput,
     appointmentId,
@@ -83,7 +90,8 @@ function AppointmentDetailPage() {
 
   const { data: appointment, isLoading } = useQuery(appointmentQueryOptions)
 
-  const { data: hairAssigned } = useQuery(hairAssignedQueryOptions)
+  const { data: hairAssignedData } = useQuery(hairAssignedQueryOptions)
+  const hairAssigned = hairAssignedData?.items ?? []
 
   const { data: transactionsData } = useQuery(transactionsQueryOptions)
 
@@ -279,12 +287,7 @@ function AppointmentDetailPage() {
                 Add
               </Button>
             </Group>
-            <HairAssignedTable
-              items={hairAssigned ?? []}
-              showHairOrderColumn
-              onEdit={setEditItem}
-              onDelete={setDeleteItem}
-            />
+            <HairAssignedTable items={hairAssigned} showHairOrderColumn onEdit={setEditItem} onDelete={setDeleteItem} />
           </Card>
         </Group>
 

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -41,17 +41,21 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
   number
 >
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+const defaultAppointmentTransactionsListInput = { page: 1, pageSize: 25 }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
   loader: async ({ context, params }) => {
     await Promise.all([
-      context.queryClient.prefetchQuery(trpc.appointments.byId.queryOptions({ id: params.appointmentId })),
+      context.queryClient.prefetchQuery(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
       context.queryClient.prefetchQuery(
         trpc.hairAssigned.byAppointment.queryOptions({ appointmentId: params.appointmentId }),
       ),
       context.queryClient.prefetchQuery(
-        trpc.transactions.byAppointmentId.queryOptions({ appointmentId: params.appointmentId }),
+        trpc.transactions.list.queryOptions({
+          ...defaultAppointmentTransactionsListInput,
+          appointmentId: params.appointmentId,
+        }),
       ),
       context.queryClient.prefetchQuery(trpc.userSettings.get.queryOptions()),
     ])
@@ -70,19 +74,22 @@ function AppointmentDetailPage() {
   const [editTx, setEditTx] = useState<TransactionRow | null>(null)
   const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
 
-  const appointmentQueryOptions = trpc.appointments.byId.queryOptions({ id: appointmentId })
+  const appointmentQueryOptions = trpc.appointments.get.queryOptions({ id: appointmentId })
   const hairAssignedQueryOptions = trpc.hairAssigned.byAppointment.queryOptions({ appointmentId })
-  const transactionsQueryOptions = trpc.transactions.byAppointmentId.queryOptions({ appointmentId })
+  const transactionsQueryOptions = trpc.transactions.list.queryOptions({
+    ...defaultAppointmentTransactionsListInput,
+    appointmentId,
+  })
 
   const { data: appointment, isLoading } = useQuery(appointmentQueryOptions)
 
   const { data: hairAssigned } = useQuery(hairAssignedQueryOptions)
 
-  const { data: transactions } = useQuery(transactionsQueryOptions)
+  const { data: transactionsData } = useQuery(transactionsQueryOptions)
 
   const { data: userSettings } = useQuery(trpc.userSettings.get.queryOptions())
 
-  const txList = transactions ?? []
+  const txList = transactionsData?.items ?? []
   const totalsByCurrency = { ...ZERO_TRANSACTION_TOTALS }
   for (const t of txList) {
     const c = t.currency as Currency
@@ -478,9 +485,9 @@ function ChangeMasterForm({
   const customers = customersData?.items ?? []
 
   const mutation = useMutation({
-    ...trpc.appointments.updateMaster.mutationOptions(),
+    ...trpc.appointments.update.mutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: trpc.appointments.byId.queryOptions({ id: appointmentId }).queryKey })
+      queryClient.invalidateQueries({ queryKey: trpc.appointments.get.queryOptions({ id: appointmentId }).queryKey })
       notifications.show({ color: "green", message: "Master updated." })
       onClose()
     },
@@ -504,7 +511,7 @@ function ChangeMasterForm({
         <Button
           disabled={!masterId || masterId === currentMasterId}
           loading={mutation.isPending}
-          onClick={() => mutation.mutate({ appointmentId, masterId })}
+          onClick={() => mutation.mutate({ id: appointmentId, masterId })}
         >
           Save
         </Button>
@@ -537,7 +544,7 @@ function PickPersonnelModal({ open, onOpenChange, appointmentId, assignedPersonn
   const mutation = useMutation({
     ...trpc.appointments.linkPersonnel.mutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: trpc.appointments.byId.queryOptions({ id: appointmentId }).queryKey })
+      queryClient.invalidateQueries({ queryKey: trpc.appointments.get.queryOptions({ id: appointmentId }).queryKey })
       handleClose()
       notifications.show({ color: "green", message: "Personnel picked." })
     },

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -22,7 +22,7 @@ import { notifications } from "@mantine/notifications"
 import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { ClientDate } from "@/components/client-date"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
@@ -35,7 +35,7 @@ import { DeleteTransactionDialog } from "@/components/transactions/delete-transa
 import { EditTransactionDialog } from "@/components/transactions/edit-transaction-dialog"
 import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
 import { CURRENCIES, type Currency, formatMinor } from "@/lib/currency"
-import { clampPage, formatPageRange, type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
+import { formatPageRange, type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => [currency, 0])) as Record<
@@ -46,7 +46,7 @@ const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as
 const APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE = 25
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
-  component: AppointmentDetailPage,
+  component: AppointmentDetailRoute,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.prefetchQuery(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
@@ -69,8 +69,12 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
   },
 })
 
-function AppointmentDetailPage() {
+function AppointmentDetailRoute() {
   const { appointmentId } = Route.useParams()
+  return <AppointmentDetailPage key={appointmentId} appointmentId={appointmentId} />
+}
+
+function AppointmentDetailPage({ appointmentId }: { appointmentId: string }) {
   const [createOpen, setCreateOpen] = useState(false)
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
@@ -118,33 +122,6 @@ function AppointmentDetailPage() {
     totalsByCurrency[c] += t.amount
   }
   const currenciesPresent = CURRENCIES.filter((c) => totalsByCurrency[c] !== 0)
-
-  useEffect(() => {
-    setTransactionsPage(1)
-    setHairAssignedPage(1)
-  }, [appointmentId])
-
-  useEffect(() => {
-    if (!transactionsData) return
-    setTransactionsPage((current) =>
-      clampPage({
-        page: current,
-        pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
-        totalCount: transactionsData.totalCount,
-      }),
-    )
-  }, [transactionsData])
-
-  useEffect(() => {
-    if (!hairAssignedData) return
-    setHairAssignedPage((current) =>
-      clampPage({
-        page: current,
-        pageSize: APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
-        totalCount: hairAssignedData.totalCount,
-      }),
-    )
-  }, [hairAssignedData])
 
   if (isLoading) {
     return (
@@ -463,6 +440,7 @@ function AppointmentDetailPage() {
           clientId={appointment.client.id}
           appointmentId={appointmentId}
           invalidateKeys={invalidateKeys}
+          onSuccess={() => setHairAssignedPage(1)}
         />
         {editItem && (
           <EditHairAssignedDialog
@@ -478,6 +456,7 @@ function AppointmentDetailPage() {
             onOpenChange={(open) => !open && setDeleteItem(null)}
             hairAssigned={deleteItem}
             invalidateKeys={invalidateKeys}
+            onSuccess={() => setHairAssignedPage(1)}
           />
         )}
         <PickPersonnelModal
@@ -506,6 +485,7 @@ function AppointmentDetailPage() {
           customerId={txCustomerId}
           defaultCurrency={txDefaultCurrency}
           invalidateKeys={txInvalidateKeys}
+          onSuccess={() => setTransactionsPage(1)}
         />
         {editTx && (
           <EditTransactionDialog
@@ -521,6 +501,7 @@ function AppointmentDetailPage() {
             onOpenChange={(open) => !open && setDeleteTx(null)}
             transaction={deleteTx}
             invalidateKeys={txInvalidateKeys}
+            onSuccess={() => setTransactionsPage(1)}
           />
         )}
       </Stack>
@@ -587,7 +568,7 @@ function ChangeMasterForm({
       search: masterSearch.trim() || undefined,
     }),
   )
-  const customers = customersData?.items ?? []
+  const customers = useMemo(() => customersData?.items ?? [], [customersData?.items])
   const customerOptions = customers.map((c) => ({ value: c.id, label: c.name }))
   const masterOptions = withPinnedOption(
     customerOptions,
@@ -648,7 +629,7 @@ function PickPersonnelModal({ open, onOpenChange, appointmentId, assignedPersonn
     }),
     enabled: open,
   })
-  const customers = customersData?.items ?? []
+  const customers = useMemo(() => customersData?.items ?? [], [customersData?.items])
 
   const available = useMemo(() => {
     const assigned = new Set(assignedPersonnelIds)

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -40,7 +40,7 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
   Currency,
   number
 >
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -41,7 +41,7 @@ const ZERO_TRANSACTION_TOTALS = Object.fromEntries(CURRENCIES.map((currency) => 
   number
 >
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
-const defaultAppointmentTransactionsListInput = { page: 1, pageSize: 25 }
+const boundedAppointmentDetailTransactionsListInput = { page: 1, pageSize: 100 }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
   component: AppointmentDetailPage,
@@ -53,7 +53,7 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
       ),
       context.queryClient.prefetchQuery(
         trpc.transactions.list.queryOptions({
-          ...defaultAppointmentTransactionsListInput,
+          ...boundedAppointmentDetailTransactionsListInput,
           appointmentId: params.appointmentId,
         }),
       ),
@@ -77,7 +77,7 @@ function AppointmentDetailPage() {
   const appointmentQueryOptions = trpc.appointments.get.queryOptions({ id: appointmentId })
   const hairAssignedQueryOptions = trpc.hairAssigned.byAppointment.queryOptions({ appointmentId })
   const transactionsQueryOptions = trpc.transactions.list.queryOptions({
-    ...defaultAppointmentTransactionsListInput,
+    ...boundedAppointmentDetailTransactionsListInput,
     appointmentId,
   })
 

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -10,7 +10,7 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const appointmentsQueryOptions = trpc.appointments.list.queryOptions({})
+const appointmentsQueryOptions = trpc.appointments.list.queryOptions({ page: 1, pageSize: 100 })
 
 export const Route = createFileRoute("/_authenticated/calendar")({
   component: CalendarPage,
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_authenticated/calendar")({
 })
 
 function CalendarPage() {
-  const { data: appointments } = useQuery(appointmentsQueryOptions)
+  const { data: appointmentsData } = useQuery(appointmentsQueryOptions)
   const navigate = useNavigate()
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))
@@ -33,6 +33,7 @@ function CalendarPage() {
   }, [])
 
   const events = useMemo<ScheduleEventData[]>(() => {
+    const appointments = appointmentsData?.items ?? []
     return (appointments ?? []).map((a) => {
       const start = dayjs(a.startsAt)
       const end = start.add(1, "hour")
@@ -44,7 +45,7 @@ function CalendarPage() {
         color: "blue",
       }
     })
-  }, [appointments])
+  }, [appointmentsData])
 
   const goToAppointment = useCallback(
     (id: string) => {

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -10,22 +10,54 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const appointmentsQueryOptions = trpc.appointments.list.queryOptions({ page: 1, pageSize: 100 })
+const CALENDAR_APPOINTMENTS_PAGE_SIZE = 100
+
+function getVisibleDateRange(date: string, view: ScheduleViewLevel) {
+  const current = dayjs(date)
+  if (view === "day") {
+    return {
+      startDate: current.startOf("day").toISOString(),
+      endDate: current.endOf("day").toISOString(),
+    }
+  }
+
+  if (view === "week") {
+    const start = current.startOf("day").subtract((current.day() + 6) % 7, "day")
+    return {
+      startDate: start.toISOString(),
+      endDate: start.add(6, "day").endOf("day").toISOString(),
+    }
+  }
+
+  return {
+    startDate: current.startOf("month").toISOString(),
+    endDate: current.endOf("month").toISOString(),
+  }
+}
+
+function calendarAppointmentsQueryOptions(date: string, view: ScheduleViewLevel) {
+  return trpc.appointments.list.queryOptions({
+    page: 1,
+    pageSize: CALENDAR_APPOINTMENTS_PAGE_SIZE,
+    ...getVisibleDateRange(date, view),
+  })
+}
 
 export const Route = createFileRoute("/_authenticated/calendar")({
   component: CalendarPage,
   loader: async ({ context }) => {
-    await context.queryClient.prefetchQuery(appointmentsQueryOptions)
+    await context.queryClient.prefetchQuery(calendarAppointmentsQueryOptions(dayjs().format("YYYY-MM-DD"), "month"))
   },
 })
 
 function CalendarPage() {
-  const { data: appointmentsData } = useQuery(appointmentsQueryOptions)
   const navigate = useNavigate()
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))
   const [createOpen, setCreateOpen] = useState(false)
   const [defaultStartsAt, setDefaultStartsAt] = useState<string | null>(null)
+  const appointmentsQueryOptions = calendarAppointmentsQueryOptions(date, view)
+  const { data: appointmentsData } = useQuery(appointmentsQueryOptions)
 
   const openCreate = useCallback((startsAt: string | null) => {
     setDefaultStartsAt(startsAt)

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack } from "@mantine/core"
+import { Alert, Container, Stack, Text } from "@mantine/core"
 import { Schedule, type ScheduleEventData, type ScheduleViewLevel } from "@mantine/schedule"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
@@ -58,6 +58,9 @@ function CalendarPage() {
   const [defaultStartsAt, setDefaultStartsAt] = useState<string | null>(null)
   const appointmentsQueryOptions = calendarAppointmentsQueryOptions(date, view)
   const { data: appointmentsData } = useQuery(appointmentsQueryOptions)
+  const visibleAppointmentCount = appointmentsData?.items.length ?? 0
+  const appointmentTotalCount = appointmentsData?.totalCount ?? 0
+  const hasHiddenAppointments = appointmentTotalCount > visibleAppointmentCount
 
   const openCreate = useCallback((startsAt: string | null) => {
     setDefaultStartsAt(startsAt)
@@ -90,6 +93,14 @@ function CalendarPage() {
     <Container size="xl">
       <PageHeader title="Calendar" description="Click a slot to book or open an existing appointment." />
       <Stack>
+        {hasHiddenAppointments && (
+          <Alert color="yellow" variant="light">
+            <Text size="sm">
+              Showing first {visibleAppointmentCount} of {appointmentTotalCount} appointments in this range. Narrow the
+              view or date range.
+            </Text>
+          </Alert>
+        )}
         <Section padding="md">
           <Schedule
             events={events}

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -22,6 +22,7 @@ import { EditCashTransactionDialog } from "@/components/cash-transactions/edit-c
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { type Currency } from "@/lib/currency"
+import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 const PAGE_SIZE = 25
@@ -55,8 +56,15 @@ function CashPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [editing, setEditing] = useState<CashTransactionRow | null>(null)
   const [deleting, setDeleting] = useState<CashTransactionRow | null>(null)
+  const [customerSearch, setCustomerSearch] = useState("")
+  const [selectedCustomerOption, setSelectedCustomerOption] = useState<SelectOption | null>(null)
 
-  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const { data: customersData } = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+  )
 
   const queryFilter = {
     page,
@@ -74,6 +82,10 @@ function CashPage() {
   )
 
   const customers = customersData?.items ?? []
+  const customerOptions = withPinnedOption(
+    customers.map((customer) => ({ value: customer.id, label: customer.name })),
+    selectedCustomerOption,
+  )
   const totalCount = result?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
@@ -113,10 +125,14 @@ function CashPage() {
             placeholder="All customers"
             searchable
             clearable
-            data={customers.map((customer) => ({ value: customer.id, label: customer.name }))}
+            searchValue={customerSearch}
+            onSearchChange={setCustomerSearch}
+            data={customerOptions}
             value={filters.customerId}
             onChange={(value) => {
               updateFilters({ customerId: value ?? "" })
+              const option = customerOptions.find((candidate) => candidate.value === value)
+              setSelectedCustomerOption(option ?? null)
             }}
           />
           <NativeSelect
@@ -173,7 +189,7 @@ function CashPage() {
         </Group>
       </Section>
 
-      <CreateCashTransactionDialog open={createOpen} onOpenChange={setCreateOpen} customers={customers} />
+      <CreateCashTransactionDialog open={createOpen} onOpenChange={setCreateOpen} />
       {editing ? (
         <EditCashTransactionDialog
           open={!!editing}
@@ -181,7 +197,6 @@ function CashPage() {
             if (!open) setEditing(null)
           }}
           transaction={editing}
-          customers={customers}
         />
       ) : null}
       {deleting ? (

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -25,6 +25,7 @@ import { type Currency } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
 const PAGE_SIZE = 25
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
 
 type CashTransactionDirection = "all" | "received" | "paid"
 type CashTransactionCurrencyFilter = Currency | ""
@@ -55,7 +56,7 @@ function CashPage() {
   const [editing, setEditing] = useState<CashTransactionRow | null>(null)
   const [deleting, setDeleting] = useState<CashTransactionRow | null>(null)
 
-  const { data: customersData } = useQuery(trpc.customers.list.queryOptions())
+  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
 
   const queryFilter = {
     page,
@@ -72,7 +73,7 @@ function CashPage() {
     trpc.cashTransactions.list.queryOptions(queryFilter, { placeholderData: (previousData) => previousData }),
   )
 
-  const customers = customersData ?? []
+  const customers = customersData?.items ?? []
   const totalCount = result?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -25,7 +25,7 @@ import { type Currency } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
 const PAGE_SIZE = 25
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 type CashTransactionDirection = "all" | "received" | "paid"
 type CashTransactionCurrencyFilter = Currency | ""

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -40,7 +40,9 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
     await Promise.all([
       context.queryClient.prefetchQuery(trpc.customers.get.queryOptions({ id: params.customerId })),
       context.queryClient.prefetchQuery(trpc.customers.summary.queryOptions({ id: params.customerId })),
-      context.queryClient.prefetchQuery(trpc.appointments.byCustomerId.queryOptions({ customerId: params.customerId })),
+      context.queryClient.prefetchQuery(
+        trpc.appointments.list.queryOptions({ page: 1, pageSize: 25, customerId: params.customerId }),
+      ),
       context.queryClient.prefetchQuery(trpc.notes.list.queryOptions({ customerId: params.customerId })),
       context.queryClient.prefetchQuery(trpc.hairAssigned.byCustomer.queryOptions({ customerId: params.customerId })),
     ])
@@ -174,12 +176,13 @@ function CustomerDetailPage() {
   const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
   const queryClient = useQueryClient()
   const customerSummaryQueryOptions = trpc.customers.summary.queryOptions({ id: customerId })
-  const customerAppointmentsQueryOptions = trpc.appointments.byCustomerId.queryOptions({ customerId })
+  const customerAppointmentsQueryOptions = trpc.appointments.list.queryOptions({ page: 1, pageSize: 25, customerId })
   const hairAssignedQueryOptions = trpc.hairAssigned.byCustomer.queryOptions({ customerId })
 
   const { data: customer, isLoading } = useQuery(trpc.customers.get.queryOptions({ id: customerId }))
 
-  const { data: appointments } = useQuery(customerAppointmentsQueryOptions)
+  const { data: appointmentsData } = useQuery(customerAppointmentsQueryOptions)
+  const appointments = appointmentsData?.items ?? []
 
   const notesQueryOptions = trpc.notes.list.queryOptions({ customerId })
   const { data: notes } = useQuery(notesQueryOptions)

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -34,11 +34,13 @@ import { Section } from "@/components/section"
 import { CURRENCIES, formatMinor } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
   component: CustomerDetailPage,
   loader: async ({ context, params }) => {
     await Promise.all([
-      context.queryClient.prefetchQuery(trpc.customers.byId.queryOptions({ id: params.customerId })),
+      context.queryClient.prefetchQuery(trpc.customers.get.queryOptions({ id: params.customerId })),
       context.queryClient.prefetchQuery(trpc.customers.summary.queryOptions({ id: params.customerId })),
       context.queryClient.prefetchQuery(trpc.appointments.byCustomerId.queryOptions({ customerId: params.customerId })),
       context.queryClient.prefetchQuery(trpc.notes.list.queryOptions({ customerId: params.customerId })),
@@ -80,8 +82,10 @@ function EditCustomerDialog({
     ...trpc.customers.update.mutationOptions(),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: trpc.customers.list.queryOptions().queryKey }),
-        queryClient.invalidateQueries({ queryKey: trpc.customers.byId.queryOptions({ id: customer.id }).queryKey }),
+        queryClient.invalidateQueries({
+          queryKey: trpc.customers.list.queryOptions(defaultCustomersListInput).queryKey,
+        }),
+        queryClient.invalidateQueries({ queryKey: trpc.customers.get.queryOptions({ id: customer.id }).queryKey }),
         queryClient.invalidateQueries({ queryKey: trpc.customers.summary.queryOptions({ id: customer.id }).queryKey }),
       ])
       onOpenChange(false)
@@ -175,7 +179,7 @@ function CustomerDetailPage() {
   const customerAppointmentsQueryOptions = trpc.appointments.byCustomerId.queryOptions({ customerId })
   const hairAssignedQueryOptions = trpc.hairAssigned.byCustomer.queryOptions({ customerId })
 
-  const { data: customer, isLoading } = useQuery(trpc.customers.byId.queryOptions({ id: customerId }))
+  const { data: customer, isLoading } = useQuery(trpc.customers.get.queryOptions({ id: customerId }))
 
   const { data: appointments } = useQuery(customerAppointmentsQueryOptions)
 

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -35,6 +35,7 @@ import { CURRENCIES, formatMinor } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
 const CUSTOMER_APPOINTMENTS_PAGE_SIZE = 25
+const CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE = 25
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
   component: CustomerDetailPage,
@@ -50,7 +51,13 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
         }),
       ),
       context.queryClient.prefetchQuery(trpc.notes.list.queryOptions({ customerId: params.customerId })),
-      context.queryClient.prefetchQuery(trpc.hairAssigned.byCustomer.queryOptions({ customerId: params.customerId })),
+      context.queryClient.prefetchQuery(
+        trpc.hairAssigned.list.queryOptions({
+          page: 1,
+          pageSize: CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE,
+          customerId: params.customerId,
+        }),
+      ),
     ])
   },
 })
@@ -181,6 +188,7 @@ function CustomerDetailPage() {
   const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
   const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
   const [appointmentsPage, setAppointmentsPage] = useState(1)
+  const [hairAssignedPage, setHairAssignedPage] = useState(1)
   const queryClient = useQueryClient()
   const customerSummaryQueryOptions = trpc.customers.summary.queryOptions({ id: customerId })
   const customerAppointmentsQueryOptions = trpc.appointments.list.queryOptions({
@@ -188,7 +196,11 @@ function CustomerDetailPage() {
     pageSize: CUSTOMER_APPOINTMENTS_PAGE_SIZE,
     customerId,
   })
-  const hairAssignedQueryOptions = trpc.hairAssigned.byCustomer.queryOptions({ customerId })
+  const hairAssignedQueryOptions = trpc.hairAssigned.list.queryOptions({
+    page: hairAssignedPage,
+    pageSize: CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE,
+    customerId,
+  })
 
   const { data: customer, isLoading } = useQuery(trpc.customers.get.queryOptions({ id: customerId }))
 
@@ -204,10 +216,16 @@ function CustomerDetailPage() {
 
   const { data: summary } = useQuery(customerSummaryQueryOptions)
 
-  const { data: hairAssigned } = useQuery(hairAssignedQueryOptions)
+  const { data: hairAssignedData } = useQuery(hairAssignedQueryOptions)
+  const hairAssigned = hairAssignedData?.items ?? []
+  const hairAssignedTotalCount = hairAssignedData?.totalCount ?? 0
+  const hairAssignedTotalPages = Math.max(1, Math.ceil(hairAssignedTotalCount / CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE))
+  const hasHairAssignedOnCurrentPage = hairAssigned.length > 0
+  const showHairAssignedPagination = hairAssignedTotalCount > CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE
 
   useEffect(() => {
     setAppointmentsPage(1)
+    setHairAssignedPage(1)
   }, [customerId])
 
   useEffect(() => {
@@ -215,6 +233,12 @@ function CustomerDetailPage() {
       setAppointmentsPage(appointmentsTotalPages)
     }
   }, [appointmentsData, appointmentsPage, appointmentsTotalPages])
+
+  useEffect(() => {
+    if (hairAssignedData && hairAssignedPage > hairAssignedTotalPages) {
+      setHairAssignedPage(hairAssignedTotalPages)
+    }
+  }, [hairAssignedData, hairAssignedPage, hairAssignedTotalPages])
 
   const deleteNoteMutation = useMutation({
     ...trpc.notes.delete.mutationOptions(),
@@ -445,7 +469,13 @@ function CustomerDetailPage() {
           <Tabs.Panel value="hair-sales" pt="md">
             <HairSalesPanel
               customerId={customerId}
-              hairAssigned={hairAssigned ?? []}
+              hairAssigned={hairAssigned}
+              hasItemsOnCurrentPage={hasHairAssignedOnCurrentPage}
+              showPagination={showHairAssignedPagination}
+              totalCount={hairAssignedTotalCount}
+              totalPages={hairAssignedTotalPages}
+              page={hairAssignedPage}
+              onPageChange={setHairAssignedPage}
               onCreate={() => setHairCreateOpen(true)}
               onEdit={setHairEditItem}
               onDelete={setHairDeleteItem}
@@ -506,12 +536,24 @@ type HairAssignedItem = HairAssignedRow & { appointmentId?: string | null }
 
 function HairSalesPanel({
   hairAssigned,
+  hasItemsOnCurrentPage,
+  showPagination,
+  totalCount,
+  totalPages,
+  page,
+  onPageChange,
   onCreate,
   onEdit,
   onDelete,
 }: {
   customerId: string
   hairAssigned: HairAssignedItem[]
+  hasItemsOnCurrentPage: boolean
+  showPagination: boolean
+  totalCount: number
+  totalPages: number
+  page: number
+  onPageChange: (page: number) => void
   onCreate: () => void
   onEdit: (item: HairAssignedRow) => void
   onDelete: (item: HairAssignedRow) => void
@@ -521,34 +563,65 @@ function HairSalesPanel({
 
   return (
     <Stack>
-      <Card withBorder>
-        <Title order={5} mb="sm">
-          Hair Sales through Appointment
-        </Title>
-        {throughAppointment.length > 0 ? (
-          <HairAssignedTable items={throughAppointment} showHairOrderColumn onEdit={onEdit} onDelete={onDelete} />
-        ) : (
-          <Text size="sm" c="dimmed">
-            No appointment-tied hair sales.
-          </Text>
-        )}
-      </Card>
+      {hasItemsOnCurrentPage || showPagination ? (
+        <>
+          <Card withBorder>
+            <Title order={5} mb="sm">
+              Hair Sales through Appointment
+            </Title>
+            {throughAppointment.length > 0 ? (
+              <HairAssignedTable items={throughAppointment} showHairOrderColumn onEdit={onEdit} onDelete={onDelete} />
+            ) : (
+              <Text size="sm" c="dimmed">
+                No appointment-tied hair sales on this page.
+              </Text>
+            )}
+          </Card>
 
-      <Card withBorder>
-        <Group justify="space-between" mb="sm">
-          <Title order={5}>Hair Sales Individual</Title>
-          <Button variant="subtle" size="xs" leftSection={<IconPlus size={12} />} onClick={onCreate}>
-            New
-          </Button>
-        </Group>
-        {individual.length > 0 ? (
-          <HairAssignedTable items={individual} showHairOrderColumn onEdit={onEdit} onDelete={onDelete} />
-        ) : (
+          <Card withBorder>
+            <Group justify="space-between" mb="sm">
+              <Title order={5}>Hair Sales Individual</Title>
+              <Button variant="subtle" size="xs" leftSection={<IconPlus size={12} />} onClick={onCreate}>
+                New
+              </Button>
+            </Group>
+            {individual.length > 0 ? (
+              <HairAssignedTable items={individual} showHairOrderColumn onEdit={onEdit} onDelete={onDelete} />
+            ) : (
+              <Text size="sm" c="dimmed">
+                No individual hair sales on this page.
+              </Text>
+            )}
+          </Card>
+          {showPagination && (
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">
+                {totalCount} hair sale{totalCount === 1 ? "" : "s"} · Page {Math.min(page, totalPages)} of {totalPages}
+              </Text>
+              <Group gap="xs">
+                <Button variant="default" disabled={page <= 1} onClick={() => onPageChange(Math.max(1, page - 1))}>
+                  Previous
+                </Button>
+                <Button variant="default" disabled={page >= totalPages} onClick={() => onPageChange(page + 1)}>
+                  Next
+                </Button>
+              </Group>
+            </Group>
+          )}
+        </>
+      ) : (
+        <Card withBorder>
+          <Group justify="space-between" mb="sm">
+            <Title order={5}>Hair Sales Individual</Title>
+            <Button variant="subtle" size="xs" leftSection={<IconPlus size={12} />} onClick={onCreate}>
+              New
+            </Button>
+          </Group>
           <Text size="sm" c="dimmed">
-            No individual hair sales.
+            No hair sales yet.
           </Text>
-        )}
-      </Card>
+        </Card>
+      )}
     </Stack>
   )
 }

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -34,8 +34,6 @@ import { Section } from "@/components/section"
 import { CURRENCIES, formatMinor } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
-
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
   component: CustomerDetailPage,
   loader: async ({ context, params }) => {
@@ -83,7 +81,7 @@ function EditCustomerDialog({
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: trpc.customers.list.queryOptions(defaultCustomersListInput).queryKey,
+          queryKey: trpc.customers.list.queryKey(),
         }),
         queryClient.invalidateQueries({ queryKey: trpc.customers.get.queryOptions({ id: customer.id }).queryKey }),
         queryClient.invalidateQueries({ queryKey: trpc.customers.summary.queryOptions({ id: customer.id }).queryKey }),

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -21,7 +21,7 @@ import { notifications } from "@mantine/notifications"
 import { IconArrowLeft, IconPencil, IconPhone, IconPlus, IconTrash } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
 import { ClientDate } from "@/components/client-date"
@@ -196,6 +196,8 @@ function CustomerDetailPage() {
   const appointments = appointmentsData?.items ?? []
   const appointmentsTotalCount = appointmentsData?.totalCount ?? 0
   const appointmentsTotalPages = Math.max(1, Math.ceil(appointmentsTotalCount / CUSTOMER_APPOINTMENTS_PAGE_SIZE))
+  const hasAppointmentsOnCurrentPage = appointments.length > 0
+  const showAppointmentsPagination = appointmentsTotalCount > CUSTOMER_APPOINTMENTS_PAGE_SIZE
 
   const notesQueryOptions = trpc.notes.list.queryOptions({ customerId })
   const { data: notes } = useQuery(notesQueryOptions)
@@ -203,6 +205,16 @@ function CustomerDetailPage() {
   const { data: summary } = useQuery(customerSummaryQueryOptions)
 
   const { data: hairAssigned } = useQuery(hairAssignedQueryOptions)
+
+  useEffect(() => {
+    setAppointmentsPage(1)
+  }, [customerId])
+
+  useEffect(() => {
+    if (appointmentsData && appointmentsPage > appointmentsTotalPages) {
+      setAppointmentsPage(appointmentsTotalPages)
+    }
+  }, [appointmentsData, appointmentsPage, appointmentsTotalPages])
 
   const deleteNoteMutation = useMutation({
     ...trpc.notes.delete.mutationOptions(),
@@ -316,59 +328,67 @@ function CustomerDetailPage() {
                   New
                 </Button>
               }
-              padding={appointments && appointments.length > 0 ? 0 : "lg"}
+              padding={hasAppointmentsOnCurrentPage || showAppointmentsPagination ? 0 : "lg"}
             >
-              {appointments && appointments.length > 0 ? (
+              {hasAppointmentsOnCurrentPage || showAppointmentsPagination ? (
                 <>
-                  <Table>
-                    <Table.Thead>
-                      <Table.Tr>
-                        <Table.Th>Name</Table.Th>
-                        <Table.Th>Date</Table.Th>
-                      </Table.Tr>
-                    </Table.Thead>
-                    <Table.Tbody>
-                      {appointments.map((a) => (
-                        <Table.Tr key={a.id}>
-                          <Table.Td>
-                            <Text
-                              renderRoot={(props) => (
-                                <Link to="/appointments/$appointmentId" params={{ appointmentId: a.id }} {...props} />
-                              )}
-                              c="blue"
-                            >
-                              {a.name}
-                            </Text>
-                          </Table.Td>
-                          <Table.Td c="dimmed">
-                            <ClientDate date={a.startsAt} />
-                          </Table.Td>
+                  {hasAppointmentsOnCurrentPage ? (
+                    <Table>
+                      <Table.Thead>
+                        <Table.Tr>
+                          <Table.Th>Name</Table.Th>
+                          <Table.Th>Date</Table.Th>
                         </Table.Tr>
-                      ))}
-                    </Table.Tbody>
-                  </Table>
-                  <Group justify="space-between" p="md">
-                    <Text size="sm" c="dimmed">
-                      {appointmentsTotalCount} appointment{appointmentsTotalCount === 1 ? "" : "s"} · Page{" "}
-                      {Math.min(appointmentsPage, appointmentsTotalPages)} of {appointmentsTotalPages}
+                      </Table.Thead>
+                      <Table.Tbody>
+                        {appointments.map((a) => (
+                          <Table.Tr key={a.id}>
+                            <Table.Td>
+                              <Text
+                                renderRoot={(props) => (
+                                  <Link to="/appointments/$appointmentId" params={{ appointmentId: a.id }} {...props} />
+                                )}
+                                c="blue"
+                              >
+                                {a.name}
+                              </Text>
+                            </Table.Td>
+                            <Table.Td c="dimmed">
+                              <ClientDate date={a.startsAt} />
+                            </Table.Td>
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                  ) : (
+                    <Text size="sm" c="dimmed" p="lg">
+                      No appointments on this page.
                     </Text>
-                    <Group gap="xs">
-                      <Button
-                        variant="default"
-                        disabled={appointmentsPage <= 1}
-                        onClick={() => setAppointmentsPage((current) => Math.max(1, current - 1))}
-                      >
-                        Previous
-                      </Button>
-                      <Button
-                        variant="default"
-                        disabled={appointmentsPage >= appointmentsTotalPages}
-                        onClick={() => setAppointmentsPage((current) => current + 1)}
-                      >
-                        Next
-                      </Button>
+                  )}
+                  {showAppointmentsPagination && (
+                    <Group justify="space-between" p="md">
+                      <Text size="sm" c="dimmed">
+                        {appointmentsTotalCount} appointment{appointmentsTotalCount === 1 ? "" : "s"} · Page{" "}
+                        {Math.min(appointmentsPage, appointmentsTotalPages)} of {appointmentsTotalPages}
+                      </Text>
+                      <Group gap="xs">
+                        <Button
+                          variant="default"
+                          disabled={appointmentsPage <= 1}
+                          onClick={() => setAppointmentsPage((current) => Math.max(1, current - 1))}
+                        >
+                          Previous
+                        </Button>
+                        <Button
+                          variant="default"
+                          disabled={appointmentsPage >= appointmentsTotalPages}
+                          onClick={() => setAppointmentsPage((current) => current + 1)}
+                        >
+                          Next
+                        </Button>
+                      </Group>
                     </Group>
-                  </Group>
+                  )}
                 </>
               ) : (
                 <Text size="sm" c="dimmed">
@@ -440,7 +460,7 @@ function CustomerDetailPage() {
           onOpenChange={setAppointmentCreateOpen}
           defaultClientId={customerId}
           invalidateKeys={[
-            { queryKey: customerAppointmentsQueryOptions.queryKey },
+            { queryKey: trpc.appointments.list.queryKey() },
             { queryKey: customerSummaryQueryOptions.queryKey },
           ]}
           navigateOnSuccess

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -34,6 +34,8 @@ import { Section } from "@/components/section"
 import { CURRENCIES, formatMinor } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
 
+const CUSTOMER_APPOINTMENTS_PAGE_SIZE = 25
+
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
   component: CustomerDetailPage,
   loader: async ({ context, params }) => {
@@ -41,7 +43,11 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
       context.queryClient.prefetchQuery(trpc.customers.get.queryOptions({ id: params.customerId })),
       context.queryClient.prefetchQuery(trpc.customers.summary.queryOptions({ id: params.customerId })),
       context.queryClient.prefetchQuery(
-        trpc.appointments.list.queryOptions({ page: 1, pageSize: 25, customerId: params.customerId }),
+        trpc.appointments.list.queryOptions({
+          page: 1,
+          pageSize: CUSTOMER_APPOINTMENTS_PAGE_SIZE,
+          customerId: params.customerId,
+        }),
       ),
       context.queryClient.prefetchQuery(trpc.notes.list.queryOptions({ customerId: params.customerId })),
       context.queryClient.prefetchQuery(trpc.hairAssigned.byCustomer.queryOptions({ customerId: params.customerId })),
@@ -174,15 +180,22 @@ function CustomerDetailPage() {
   const [hairCreateOpen, setHairCreateOpen] = useState(false)
   const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
   const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
+  const [appointmentsPage, setAppointmentsPage] = useState(1)
   const queryClient = useQueryClient()
   const customerSummaryQueryOptions = trpc.customers.summary.queryOptions({ id: customerId })
-  const customerAppointmentsQueryOptions = trpc.appointments.list.queryOptions({ page: 1, pageSize: 25, customerId })
+  const customerAppointmentsQueryOptions = trpc.appointments.list.queryOptions({
+    page: appointmentsPage,
+    pageSize: CUSTOMER_APPOINTMENTS_PAGE_SIZE,
+    customerId,
+  })
   const hairAssignedQueryOptions = trpc.hairAssigned.byCustomer.queryOptions({ customerId })
 
   const { data: customer, isLoading } = useQuery(trpc.customers.get.queryOptions({ id: customerId }))
 
   const { data: appointmentsData } = useQuery(customerAppointmentsQueryOptions)
   const appointments = appointmentsData?.items ?? []
+  const appointmentsTotalCount = appointmentsData?.totalCount ?? 0
+  const appointmentsTotalPages = Math.max(1, Math.ceil(appointmentsTotalCount / CUSTOMER_APPOINTMENTS_PAGE_SIZE))
 
   const notesQueryOptions = trpc.notes.list.queryOptions({ customerId })
   const { data: notes } = useQuery(notesQueryOptions)
@@ -306,33 +319,57 @@ function CustomerDetailPage() {
               padding={appointments && appointments.length > 0 ? 0 : "lg"}
             >
               {appointments && appointments.length > 0 ? (
-                <Table>
-                  <Table.Thead>
-                    <Table.Tr>
-                      <Table.Th>Name</Table.Th>
-                      <Table.Th>Date</Table.Th>
-                    </Table.Tr>
-                  </Table.Thead>
-                  <Table.Tbody>
-                    {appointments.map((a) => (
-                      <Table.Tr key={a.id}>
-                        <Table.Td>
-                          <Text
-                            renderRoot={(props) => (
-                              <Link to="/appointments/$appointmentId" params={{ appointmentId: a.id }} {...props} />
-                            )}
-                            c="blue"
-                          >
-                            {a.name}
-                          </Text>
-                        </Table.Td>
-                        <Table.Td c="dimmed">
-                          <ClientDate date={a.startsAt} />
-                        </Table.Td>
+                <>
+                  <Table>
+                    <Table.Thead>
+                      <Table.Tr>
+                        <Table.Th>Name</Table.Th>
+                        <Table.Th>Date</Table.Th>
                       </Table.Tr>
-                    ))}
-                  </Table.Tbody>
-                </Table>
+                    </Table.Thead>
+                    <Table.Tbody>
+                      {appointments.map((a) => (
+                        <Table.Tr key={a.id}>
+                          <Table.Td>
+                            <Text
+                              renderRoot={(props) => (
+                                <Link to="/appointments/$appointmentId" params={{ appointmentId: a.id }} {...props} />
+                              )}
+                              c="blue"
+                            >
+                              {a.name}
+                            </Text>
+                          </Table.Td>
+                          <Table.Td c="dimmed">
+                            <ClientDate date={a.startsAt} />
+                          </Table.Td>
+                        </Table.Tr>
+                      ))}
+                    </Table.Tbody>
+                  </Table>
+                  <Group justify="space-between" p="md">
+                    <Text size="sm" c="dimmed">
+                      {appointmentsTotalCount} appointment{appointmentsTotalCount === 1 ? "" : "s"} · Page{" "}
+                      {Math.min(appointmentsPage, appointmentsTotalPages)} of {appointmentsTotalPages}
+                    </Text>
+                    <Group gap="xs">
+                      <Button
+                        variant="default"
+                        disabled={appointmentsPage <= 1}
+                        onClick={() => setAppointmentsPage((current) => Math.max(1, current - 1))}
+                      >
+                        Previous
+                      </Button>
+                      <Button
+                        variant="default"
+                        disabled={appointmentsPage >= appointmentsTotalPages}
+                        onClick={() => setAppointmentsPage((current) => current + 1)}
+                      >
+                        Next
+                      </Button>
+                    </Group>
+                  </Group>
+                </>
               ) : (
                 <Text size="sm" c="dimmed">
                   No appointments yet.

--- a/apps/web/src/routes/_authenticated/customers/$customerId.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId.tsx
@@ -21,7 +21,7 @@ import { notifications } from "@mantine/notifications"
 import { IconArrowLeft, IconPencil, IconPhone, IconPlus, IconTrash } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
 import { ClientDate } from "@/components/client-date"
@@ -38,7 +38,7 @@ const CUSTOMER_APPOINTMENTS_PAGE_SIZE = 25
 const CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE = 25
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
-  component: CustomerDetailPage,
+  component: CustomerDetailRoute,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.prefetchQuery(trpc.customers.get.queryOptions({ id: params.customerId })),
@@ -61,6 +61,11 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
     ])
   },
 })
+
+function CustomerDetailRoute() {
+  const { customerId } = Route.useParams()
+  return <CustomerDetailPage key={customerId} customerId={customerId} />
+}
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
@@ -179,8 +184,7 @@ function AddNoteDialog({
   )
 }
 
-function CustomerDetailPage() {
-  const { customerId } = Route.useParams()
+function CustomerDetailPage({ customerId }: { customerId: string }) {
   const [editOpen, setEditOpen] = useState(false)
   const [noteOpen, setNoteOpen] = useState(false)
   const [appointmentCreateOpen, setAppointmentCreateOpen] = useState(false)
@@ -222,23 +226,6 @@ function CustomerDetailPage() {
   const hairAssignedTotalPages = Math.max(1, Math.ceil(hairAssignedTotalCount / CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE))
   const hasHairAssignedOnCurrentPage = hairAssigned.length > 0
   const showHairAssignedPagination = hairAssignedTotalCount > CUSTOMER_HAIR_ASSIGNED_PAGE_SIZE
-
-  useEffect(() => {
-    setAppointmentsPage(1)
-    setHairAssignedPage(1)
-  }, [customerId])
-
-  useEffect(() => {
-    if (appointmentsData && appointmentsPage > appointmentsTotalPages) {
-      setAppointmentsPage(appointmentsTotalPages)
-    }
-  }, [appointmentsData, appointmentsPage, appointmentsTotalPages])
-
-  useEffect(() => {
-    if (hairAssignedData && hairAssignedPage > hairAssignedTotalPages) {
-      setHairAssignedPage(hairAssignedTotalPages)
-    }
-  }, [hairAssignedData, hairAssignedPage, hairAssignedTotalPages])
 
   const deleteNoteMutation = useMutation({
     ...trpc.notes.delete.mutationOptions(),
@@ -504,6 +491,7 @@ function CustomerDetailPage() {
             { queryKey: hairAssignedQueryOptions.queryKey },
             { queryKey: customerSummaryQueryOptions.queryKey },
           ]}
+          onSuccess={() => setHairAssignedPage(1)}
         />
         {hairEditItem && (
           <EditHairAssignedDialog
@@ -525,6 +513,7 @@ function CustomerDetailPage() {
               { queryKey: hairAssignedQueryOptions.queryKey },
               { queryKey: customerSummaryQueryOptions.queryKey },
             ]}
+            onSuccess={() => setHairAssignedPage(1)}
           />
         )}
       </Stack>

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, Group, Modal, Skeleton, Stack, Table, Text, TextInput } from "@mantine/core"
+import { Button, Container, Group, Modal, Pagination, Skeleton, Stack, Table, Text, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
@@ -161,18 +161,7 @@ function CustomersPage() {
           <Text size="sm" c="dimmed">
             Page {Math.min(page, totalPages)} of {totalPages}
           </Text>
-          <Group gap="xs">
-            <Button
-              variant="default"
-              disabled={page <= 1}
-              onClick={() => setPage((current) => Math.max(1, current - 1))}
-            >
-              Previous
-            </Button>
-            <Button variant="default" disabled={page >= totalPages} onClick={() => setPage((current) => current + 1)}>
-              Next
-            </Button>
-          </Group>
+          <Pagination total={totalPages} value={Math.min(page, totalPages)} onChange={setPage} />
         </Group>
       </Section>
 

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -1,7 +1,7 @@
-import { Button, Container, Modal, Skeleton, Stack, Table, Text, TextInput } from "@mantine/core"
+import { Button, Container, Group, Modal, Skeleton, Stack, Table, Text, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
-import { IconPlus } from "@tabler/icons-react"
+import { IconPlus, IconSearch } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
@@ -11,7 +11,8 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const PAGE_SIZE = 25
+const defaultCustomersListInput = { page: 1, pageSize: PAGE_SIZE, search: undefined as string | undefined }
 const customersQueryOptions = trpc.customers.list.queryOptions(defaultCustomersListInput)
 
 export const Route = createFileRoute("/_authenticated/customers/")({
@@ -27,7 +28,7 @@ function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChang
   const mutation = useMutation({
     ...trpc.customers.create.mutationOptions(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: customersQueryOptions.queryKey })
+      await queryClient.invalidateQueries({ queryKey: trpc.customers.list.queryKey() })
       onOpenChange(false)
       notifications.show({ color: "green", message: "Customer created" })
     },
@@ -61,8 +62,19 @@ function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChang
 }
 
 function CustomersPage() {
-  const { data, isLoading } = useQuery(customersQueryOptions)
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState("")
+  const listInput = {
+    page,
+    pageSize: PAGE_SIZE,
+    search: search.trim() || undefined,
+  }
+  const { data, isLoading } = useQuery(
+    trpc.customers.list.queryOptions(listInput, { placeholderData: (previousData) => previousData }),
+  )
   const customers = data?.items ?? []
+  const totalCount = data?.totalCount ?? 0
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const [dialogOpen, setDialogOpen] = useState(false)
 
   return (
@@ -77,6 +89,23 @@ function CustomersPage() {
         }
       />
       <Section padding={0}>
+        <Group p="md" justify="space-between" align="flex-end">
+          <TextInput
+            label="Search"
+            placeholder="Search customers"
+            leftSection={<IconSearch size={16} />}
+            value={search}
+            onChange={(event) => {
+              setSearch(event.currentTarget.value)
+              setPage(1)
+            }}
+            miw={260}
+            flex={1}
+          />
+          <Text size="sm" c="dimmed">
+            {totalCount} customer{totalCount === 1 ? "" : "s"}
+          </Text>
+        </Group>
         <Table>
           <Table.Thead>
             <Table.Tr>
@@ -122,12 +151,29 @@ function CustomersPage() {
             {!isLoading && customers.length === 0 && (
               <Table.Tr>
                 <Table.Td colSpan={3} ta="center" c="dimmed">
-                  No customers yet. Create your first one.
+                  {search.trim() ? "No customers match your search." : "No customers yet. Create your first one."}
                 </Table.Td>
               </Table.Tr>
             )}
           </Table.Tbody>
         </Table>
+        <Group justify="space-between" p="md">
+          <Text size="sm" c="dimmed">
+            Page {Math.min(page, totalPages)} of {totalPages}
+          </Text>
+          <Group gap="xs">
+            <Button
+              variant="default"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              Previous
+            </Button>
+            <Button variant="default" disabled={page >= totalPages} onClick={() => setPage((current) => current + 1)}>
+              Next
+            </Button>
+          </Group>
+        </Group>
       </Section>
 
       <CustomerFormDialog open={dialogOpen} onOpenChange={setDialogOpen} />

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -11,7 +11,8 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const customersQueryOptions = trpc.customers.list.queryOptions()
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const customersQueryOptions = trpc.customers.list.queryOptions(defaultCustomersListInput)
 
 export const Route = createFileRoute("/_authenticated/customers/")({
   component: CustomersPage,
@@ -60,7 +61,8 @@ function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChang
 }
 
 function CustomersPage() {
-  const { data: customers, isLoading } = useQuery(customersQueryOptions)
+  const { data, isLoading } = useQuery(customersQueryOptions)
+  const customers = data?.items ?? []
   const [dialogOpen, setDialogOpen] = useState(false)
 
   return (
@@ -98,7 +100,7 @@ function CustomersPage() {
                     </Table.Td>
                   </Table.Tr>
                 ))
-              : customers?.map((c) => (
+              : customers.map((c) => (
                   <Table.Tr key={c.id}>
                     <Table.Td>
                       <Text
@@ -117,7 +119,7 @@ function CustomersPage() {
                     </Table.Td>
                   </Table.Tr>
                 ))}
-            {!isLoading && customers?.length === 0 && (
+            {!isLoading && customers.length === 0 && (
               <Table.Tr>
                 <Table.Td colSpan={3} ta="center" c="dimmed">
                   No customers yet. Create your first one.

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -34,7 +34,7 @@ import { trpc } from "@/utils/trpc"
 export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")({
   component: HairOrderDetailPage,
   loader: async ({ context, params }) => {
-    await context.queryClient.prefetchQuery(trpc.hairOrders.byId.queryOptions({ id: params.hairOrderId }))
+    await context.queryClient.prefetchQuery(trpc.hairOrders.get.queryOptions({ id: params.hairOrderId }))
   },
 })
 
@@ -47,8 +47,8 @@ function HairOrderDetailPage() {
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
   const [editOrderOpen, setEditOrderOpen] = useState(false)
-  const hairOrderQueryOptions = trpc.hairOrders.byId.queryOptions({ id: hairOrderId })
-  const hairOrdersListQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrderQueryOptions = trpc.hairOrders.get.queryOptions({ id: hairOrderId })
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const { data: hairOrder, isLoading } = useQuery(hairOrderQueryOptions)
 
@@ -63,7 +63,7 @@ function HairOrderDetailPage() {
     ...trpc.hairOrders.recalculatePrices.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: hairOrderQueryOptions.queryKey })
-      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       for (const key of assignedClientSummaryKeys) queryClient.invalidateQueries(key)
       notifications.show({ color: "green", message: "Prices recalculated" })
     },
@@ -258,14 +258,14 @@ type EditHairOrderModalProps = {
 
 function EditHairOrderModal({ open, onOpenChange, hairOrder }: EditHairOrderModalProps) {
   const queryClient = useQueryClient()
-  const hairOrderQueryOptions = trpc.hairOrders.byId.queryOptions({ id: hairOrder.id })
-  const hairOrdersListQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrderQueryOptions = trpc.hairOrders.get.queryOptions({ id: hairOrder.id })
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairOrders.update.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: hairOrderQueryOptions.queryKey })
-      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       onOpenChange(false)
       notifications.show({ color: "green", message: "Hair order updated" })
     },

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -48,6 +48,7 @@ function HairOrderDetailPage() {
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
   const [editOrderOpen, setEditOrderOpen] = useState(false)
   const hairOrderQueryOptions = trpc.hairOrders.get.queryOptions({ id: hairOrderId })
+  const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const { data: hairOrder, isLoading } = useQuery(hairOrderQueryOptions)
@@ -63,6 +64,7 @@ function HairOrderDetailPage() {
     ...trpc.hairOrders.recalculatePrices.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: hairOrderQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairAssignedListQueryKey })
       queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       for (const key of assignedClientSummaryKeys) queryClient.invalidateQueries(key)
       notifications.show({ color: "green", message: "Prices recalculated" })

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -12,6 +12,8 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+
 export const Route = createFileRoute("/_authenticated/hair-orders/")({
   component: HairOrdersPage,
 })
@@ -19,7 +21,8 @@ export const Route = createFileRoute("/_authenticated/hair-orders/")({
 function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const queryClient = useQueryClient()
 
-  const { data: customers } = useQuery(trpc.customers.list.queryOptions())
+  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const customers = customersData?.items ?? []
   const hairOrdersQueryOptions = trpc.hairOrders.list.queryOptions()
 
   const mutation = useMutation({
@@ -61,7 +64,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
             label="Customer"
             placeholder="Select a customer..."
             searchable
-            data={(customers ?? []).map((c) => ({ value: c.id, label: c.name }))}
+            data={customers.map((c) => ({ value: c.id, label: c.name }))}
             {...form.getInputProps("customerId")}
           />
           <DateInput label="Placed At" valueFormat="DD MMM YYYY" {...form.getInputProps("placedAt")} />

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -12,7 +12,7 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 export const Route = createFileRoute("/_authenticated/hair-orders/")({
   component: HairOrdersPage,

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -10,6 +10,7 @@ import { useState } from "react"
 import { HairOrdersTable } from "@/components/hair-orders-table"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
+import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 import { trpc } from "@/utils/trpc"
 
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
@@ -21,9 +22,20 @@ export const Route = createFileRoute("/_authenticated/hair-orders/")({
 
 function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const queryClient = useQueryClient()
+  const [customerSearch, setCustomerSearch] = useState("")
+  const [selectedCustomerOption, setSelectedCustomerOption] = useState<SelectOption | null>(null)
 
-  const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
+  const { data: customersData } = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+  )
   const customers = customersData?.items ?? []
+  const customerOptions = withPinnedOption(
+    customers.map((c) => ({ value: c.id, label: c.name })),
+    selectedCustomerOption,
+  )
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
@@ -65,8 +77,16 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
             label="Customer"
             placeholder="Select a customer..."
             searchable
-            data={customers.map((c) => ({ value: c.id, label: c.name }))}
-            {...form.getInputProps("customerId")}
+            searchValue={customerSearch}
+            onSearchChange={setCustomerSearch}
+            data={customerOptions}
+            value={form.values.customerId}
+            onChange={(value) => {
+              form.setFieldValue("customerId", value ?? "")
+              const option = customerOptions.find((candidate) => candidate.value === value)
+              if (option) setSelectedCustomerOption(option)
+            }}
+            error={form.errors.customerId}
           />
           <DateInput label="Placed At" valueFormat="DD MMM YYYY" {...form.getInputProps("placedAt")} />
           <Group grow>

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, Group, Modal, NumberInput, Select, Stack } from "@mantine/core"
+import { Button, Container, Group, Modal, NumberInput, Select, Stack, Text } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
@@ -13,6 +13,7 @@ import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+const HAIR_ORDERS_PAGE_SIZE = 25
 
 export const Route = createFileRoute("/_authenticated/hair-orders/")({
   component: HairOrdersPage,
@@ -23,12 +24,12 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
 
   const { data: customersData } = useQuery(trpc.customers.list.queryOptions(defaultCustomersListInput))
   const customers = customersData?.items ?? []
-  const hairOrdersQueryOptions = trpc.hairOrders.list.queryOptions()
+  const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
   const mutation = useMutation({
     ...trpc.hairOrders.create.mutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: hairOrdersQueryOptions.queryKey })
+      queryClient.invalidateQueries({ queryKey: hairOrdersListQueryKey })
       onOpenChange(false)
       notifications.show({ color: "green", message: "Hair order created" })
     },
@@ -82,8 +83,15 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
 }
 
 function HairOrdersPage() {
-  const { data: hairOrders, isLoading } = useQuery(trpc.hairOrders.list.queryOptions())
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [page, setPage] = useState(1)
+  const { data: hairOrdersData, isLoading } = useQuery(
+    trpc.hairOrders.list.queryOptions({ page, pageSize: HAIR_ORDERS_PAGE_SIZE }),
+  )
+  const hairOrders = hairOrdersData?.items ?? []
+  const totalCount = hairOrdersData?.totalCount ?? 0
+  const totalPages = Math.max(1, Math.ceil(totalCount / HAIR_ORDERS_PAGE_SIZE))
+  const showPagination = totalCount > HAIR_ORDERS_PAGE_SIZE
 
   return (
     <Container size="xl">
@@ -98,6 +106,25 @@ function HairOrdersPage() {
       />
       <Section padding="lg">
         <HairOrdersTable hairOrders={hairOrders} isLoading={isLoading} />
+        {showPagination && (
+          <Group justify="space-between" mt="md">
+            <Text size="sm" c="dimmed">
+              {totalCount} hair order{totalCount === 1 ? "" : "s"} · Page {Math.min(page, totalPages)} of {totalPages}
+            </Text>
+            <Group gap="xs">
+              <Button
+                variant="default"
+                disabled={page <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </Button>
+              <Button variant="default" disabled={page >= totalPages} onClick={() => setPage((current) => current + 1)}>
+                Next
+              </Button>
+            </Group>
+          </Group>
+        )}
       </Section>
 
       <CreateHairOrderDialog open={dialogOpen} onOpenChange={setDialogOpen} />

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -35,7 +35,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { zodResolver } from "mantine-form-zod-resolver"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
 import { CURRENCY_OPTIONS, type Currency, formatMinor } from "@/lib/currency"
@@ -50,7 +50,7 @@ const STATEMENT_ENTRIES_PAGE_SIZE = 25
 
 function BankAccountRoute() {
   const { bankAccountId } = Route.useParams()
-  return bankAccountId === "new" ? <BankAccountNew /> : <BankAccountShow id={bankAccountId} />
+  return bankAccountId === "new" ? <BankAccountNew /> : <BankAccountShow key={bankAccountId} id={bankAccountId} />
 }
 
 type StatusFilter = "PENDING" | "IGNORED" | "ALL"
@@ -88,16 +88,6 @@ function BankAccountShow({ id }: { id: string }) {
   const entriesTotalPages = Math.max(1, Math.ceil(entriesTotalCount / STATEMENT_ENTRIES_PAGE_SIZE))
   const showEntriesPagination = entriesTotalCount > STATEMENT_ENTRIES_PAGE_SIZE
 
-  useEffect(() => {
-    setEntriesPage(1)
-  }, [id, statusFilter])
-
-  useEffect(() => {
-    if (statementEntriesData && entriesPage > entriesTotalPages) {
-      setEntriesPage(entriesTotalPages)
-    }
-  }, [statementEntriesData, entriesPage, entriesTotalPages])
-
   const { data: attachmentCounts } = useQuery(trpc.bankStatementAttachments.counts.queryOptions())
 
   const importMutation = useMutation({
@@ -105,6 +95,7 @@ function BankAccountShow({ id }: { id: string }) {
     onSuccess: async (result) => {
       setImportResult(result)
       setFile(null)
+      setEntriesPage(1)
       notifications.show({
         color: "green",
         message: `Imported ${result.inserted} new entries (${result.skipped} duplicates skipped)`,
@@ -117,6 +108,7 @@ function BankAccountShow({ id }: { id: string }) {
   const ignoreMutation = useMutation({
     ...trpc.bankStatementEntries.ignore.mutationOptions(),
     onSuccess: async () => {
+      setEntriesPage(1)
       notifications.show({ color: "yellow", message: "Marked as ignored" })
       await queryClient.invalidateQueries({ queryKey: trpc.bankStatementEntries.list.queryKey() })
     },
@@ -126,6 +118,7 @@ function BankAccountShow({ id }: { id: string }) {
   const undoMutation = useMutation({
     ...trpc.bankStatementEntries.undo.mutationOptions(),
     onSuccess: async () => {
+      setEntriesPage(1)
       notifications.show({ color: "green", message: "Restored to pending" })
       await queryClient.invalidateQueries({ queryKey: trpc.bankStatementEntries.list.queryKey() })
     },

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -9,6 +9,7 @@ import {
   Group,
   Menu,
   Modal,
+  Pagination,
   Popover,
   Select,
   Stack,
@@ -45,6 +46,8 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
   component: BankAccountRoute,
 })
 
+const STATEMENT_ENTRIES_PAGE_SIZE = 25
+
 function BankAccountRoute() {
   const { bankAccountId } = Route.useParams()
   return bankAccountId === "new" ? <BankAccountNew /> : <BankAccountShow id={bankAccountId} />
@@ -68,15 +71,22 @@ function BankAccountShow({ id }: { id: string }) {
     return new Date(d.getFullYear(), d.getMonth(), 1)
   })
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
+  const [entriesPage, setEntriesPage] = useState(1)
 
-  const bankAccountQueryOptions = trpc.bankAccounts.byId.queryOptions({ id })
+  const bankAccountQueryOptions = trpc.bankAccounts.get.queryOptions({ id })
   const statementEntriesQueryOptions = trpc.bankStatementEntries.list.queryOptions({
     bankAccountId: id,
     status: statusFilter === "ALL" ? undefined : statusFilter,
+    page: entriesPage,
+    pageSize: STATEMENT_ENTRIES_PAGE_SIZE,
   })
   const { data: bankAccount } = useQuery(bankAccountQueryOptions)
 
-  const { data: entries = [] } = useQuery(statementEntriesQueryOptions)
+  const { data: statementEntriesData } = useQuery(statementEntriesQueryOptions)
+  const entries = statementEntriesData?.items ?? []
+  const entriesTotalCount = statementEntriesData?.totalCount ?? 0
+  const entriesTotalPages = Math.max(1, Math.ceil(entriesTotalCount / STATEMENT_ENTRIES_PAGE_SIZE))
+  const showEntriesPagination = entriesTotalCount > STATEMENT_ENTRIES_PAGE_SIZE
 
   const { data: attachmentCounts } = useQuery(trpc.bankStatementAttachments.counts.queryOptions())
 
@@ -210,7 +220,10 @@ function BankAccountShow({ id }: { id: string }) {
               { value: "ALL", label: "All" },
             ]}
             value={statusFilter}
-            onChange={(v) => setStatusFilter((v as StatusFilter) ?? "PENDING")}
+            onChange={(v) => {
+              setStatusFilter((v as StatusFilter) ?? "PENDING")
+              setEntriesPage(1)
+            }}
             w={180}
           />
           <Popover position="bottom-end" withArrow shadow="md" width={260}>
@@ -325,6 +338,19 @@ function BankAccountShow({ id }: { id: string }) {
               )}
             </Table.Tbody>
           </Table>
+          {showEntriesPagination && (
+            <Group justify="space-between" mt="md">
+              <Text size="sm" c="dimmed">
+                {entriesTotalCount} entr{entriesTotalCount === 1 ? "y" : "ies"} · Page{" "}
+                {Math.min(entriesPage, entriesTotalPages)} of {entriesTotalPages}
+              </Text>
+              <Pagination
+                total={entriesTotalPages}
+                value={Math.min(entriesPage, entriesTotalPages)}
+                onChange={setEntriesPage}
+              />
+            </Group>
+          )}
         </Card>
       </Stack>
 
@@ -370,14 +396,13 @@ function AttachmentsCell({
   })
 
   const { data: unassignedAttachments = [] } = useQuery({
-    ...trpc.bankStatementAttachments.unassigned.queryOptions(),
+    ...trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
     enabled: opened,
   })
 
   const invalidate = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() }),
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.unassigned.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.counts.queryKey() }),
     ])
   }
@@ -562,7 +587,7 @@ function EditBankAccountModal({
   initial: FormValues
 }) {
   const queryClient = useQueryClient()
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions())
+  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
 
   const form = useForm<FormValues & { id: string }>({
     initialValues: {
@@ -578,10 +603,10 @@ function EditBankAccountModal({
       notifications.show({ color: "green", message: "Saved" })
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: trpc.bankAccounts.byId.queryOptions({ id: bankAccountId }).queryKey,
+          queryKey: trpc.bankAccounts.get.queryOptions({ id: bankAccountId }).queryKey,
         }),
         queryClient.invalidateQueries({
-          queryKey: trpc.legalEntities.byId.queryOptions({ id: values.legalEntityId }).queryKey,
+          queryKey: trpc.legalEntities.get.queryOptions({ id: values.legalEntityId }).queryKey,
         }),
       ])
       onClose()
@@ -635,7 +660,7 @@ function BankAccountNew() {
   const { legalEntityId: pathLegalEntityId } = Route.useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions())
+  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -654,7 +679,7 @@ function BankAccountNew() {
     onSuccess: async (_, values) => {
       notifications.show({ color: "green", message: "Saved" })
       await queryClient.invalidateQueries({
-        queryKey: trpc.legalEntities.byId.queryOptions({ id: values.legalEntityId }).queryKey,
+        queryKey: trpc.legalEntities.get.queryOptions({ id: values.legalEntityId }).queryKey,
       })
       navigate({
         to: "/legal-entities/$legalEntityId/bank-accounts",

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -35,7 +35,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { zodResolver } from "mantine-form-zod-resolver"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
 import { CURRENCY_OPTIONS, type Currency, formatMinor } from "@/lib/currency"
@@ -87,6 +87,16 @@ function BankAccountShow({ id }: { id: string }) {
   const entriesTotalCount = statementEntriesData?.totalCount ?? 0
   const entriesTotalPages = Math.max(1, Math.ceil(entriesTotalCount / STATEMENT_ENTRIES_PAGE_SIZE))
   const showEntriesPagination = entriesTotalCount > STATEMENT_ENTRIES_PAGE_SIZE
+
+  useEffect(() => {
+    setEntriesPage(1)
+  }, [id, statusFilter])
+
+  useEffect(() => {
+    if (statementEntriesData && entriesPage > entriesTotalPages) {
+      setEntriesPage(entriesTotalPages)
+    }
+  }, [statementEntriesData, entriesPage, entriesTotalPages])
 
   const { data: attachmentCounts } = useQuery(trpc.bankStatementAttachments.counts.queryOptions())
 

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
 
 function BankAccountsTab() {
   const { legalEntityId } = Route.useParams()
-  const { data: legalEntity } = useQuery(trpc.legalEntities.byId.queryOptions({ id: legalEntityId }))
+  const { data: legalEntity } = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
   const bankAccounts = legalEntity?.bankAccounts ?? []
 
   return (

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
@@ -20,12 +20,17 @@ function DocumentsTab() {
   const [fileInputKey, setFileInputKey] = useState(0)
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
 
-  const { data: unassignedDocuments = [] } = useQuery(trpc.bankStatementAttachments.unassigned.queryOptions())
+  const { data: unassignedDocuments = [] } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  )
 
-  const { data: assignableEntries = [] } = useQuery(trpc.bankStatementEntries.list.queryOptions({ status: "PENDING" }))
+  const { data: assignableEntriesData } = useQuery(
+    trpc.bankStatementEntries.list.queryOptions({ status: "PENDING", page: 1, pageSize: 100 }),
+  )
+  const assignableEntries = assignableEntriesData?.items ?? []
 
   const invalidate = async () => {
-    await queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.unassigned.queryKey() })
+    await queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() })
     await queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.counts.queryKey() })
   }
 

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
@@ -1,4 +1,15 @@
-import { ActionIcon, FileInput, Select, Stack, Table, Text, Tooltip, UnstyledButton } from "@mantine/core"
+import {
+  ActionIcon,
+  FileInput,
+  Group,
+  Pagination,
+  Select,
+  Stack,
+  Table,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from "@mantine/core"
 import { notifications } from "@mantine/notifications"
 import { IconTrash } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
@@ -14,20 +25,30 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
   component: DocumentsTab,
 })
 
+const ASSIGNABLE_ENTRIES_PAGE_SIZE = 100
+
 function DocumentsTab() {
   const queryClient = useQueryClient()
   const [busy, setBusy] = useState(false)
   const [fileInputKey, setFileInputKey] = useState(0)
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
+  const [assignableEntriesPage, setAssignableEntriesPage] = useState(1)
 
   const { data: unassignedDocuments = [] } = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
   )
 
   const { data: assignableEntriesData } = useQuery(
-    trpc.bankStatementEntries.list.queryOptions({ status: "PENDING", page: 1, pageSize: 100 }),
+    trpc.bankStatementEntries.list.queryOptions({
+      status: "PENDING",
+      page: assignableEntriesPage,
+      pageSize: ASSIGNABLE_ENTRIES_PAGE_SIZE,
+    }),
   )
   const assignableEntries = assignableEntriesData?.items ?? []
+  const assignableEntriesTotalCount = assignableEntriesData?.totalCount ?? 0
+  const assignableEntriesTotalPages = Math.max(1, Math.ceil(assignableEntriesTotalCount / ASSIGNABLE_ENTRIES_PAGE_SIZE))
+  const showAssignableEntriesPagination = assignableEntriesTotalCount > ASSIGNABLE_ENTRIES_PAGE_SIZE
 
   const invalidate = async () => {
     await queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() })
@@ -102,6 +123,20 @@ function DocumentsTab() {
         padding={items.length > 0 ? 0 : "lg"}
       >
         <Stack gap="md">
+          {showAssignableEntriesPagination && (
+            <Group justify="space-between" px="md" pt="md">
+              <Text size="sm" c="dimmed">
+                {assignableEntriesTotalCount} pending entr{assignableEntriesTotalCount === 1 ? "y" : "ies"} · Page{" "}
+                {Math.min(assignableEntriesPage, assignableEntriesTotalPages)} of {assignableEntriesTotalPages}
+              </Text>
+              <Pagination
+                size="sm"
+                total={assignableEntriesTotalPages}
+                value={Math.min(assignableEntriesPage, assignableEntriesTotalPages)}
+                onChange={setAssignableEntriesPage}
+              />
+            </Group>
+          )}
           {items.length > 0 && (
             <Table>
               <Table.Thead>

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -19,7 +19,7 @@ function LegalEntityLayout() {
   const { legalEntityId } = Route.useParams()
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
 
-  const { data: legalEntity } = useQuery(trpc.legalEntities.byId.queryOptions({ id: legalEntityId }))
+  const { data: legalEntity } = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
 
   const country = legalEntity?.country as Country | undefined
   const description = legalEntity
@@ -93,8 +93,8 @@ function EditLegalEntityForm({
   onClose: () => void
 }) {
   const queryClient = useQueryClient()
-  const legalEntitiesQueryOptions = trpc.legalEntities.list.queryOptions()
-  const legalEntityQueryOptions = trpc.legalEntities.byId.queryOptions({ id: initialValues.id })
+  const legalEntitiesQueryOptions = trpc.legalEntities.list.queryOptions({})
+  const legalEntityQueryOptions = trpc.legalEntities.get.queryOptions({ id: initialValues.id })
 
   const form = useForm<EditValues & { id: string }>({
     initialValues,

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
 })
 
 function SalonsTab() {
-  const { data: salons = [] } = useQuery(trpc.salons.list.queryOptions())
+  const { data: salons = [] } = useQuery(trpc.salons.list.queryOptions({}))
 
   return (
     <Section

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute("/_authenticated/legal-entities/")({
 })
 
 function LegalEntitiesIndex() {
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions())
+  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
 
   return (
     <Container size="xl">

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -99,7 +99,9 @@ export const Route = createFileRoute("/_authenticated")({
 function AuthenticatedLayout() {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false)
 
-  const { data: unassignedAttachments = [] } = useQuery(trpc.bankStatementAttachments.unassigned.queryOptions())
+  const { data: unassignedAttachments = [] } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  )
   const badges = { unassigned: unassignedAttachments.length }
 
   return (
@@ -162,7 +164,7 @@ function SidebarNav({ badges, onNavigate }: { badges: { unassigned: number }; on
   const entityTab = entityMatch?.[2] ?? "overview"
 
   const { data: entity } = useQuery({
-    ...trpc.legalEntities.byId.queryOptions({ id: entityId ?? "" }),
+    ...trpc.legalEntities.get.queryOptions({ id: entityId ?? "" }),
     enabled: !!entityId,
   })
 

--- a/apps/web/src/routes/_authenticated/salons/$salonId.tsx
+++ b/apps/web/src/routes/_authenticated/salons/$salonId.tsx
@@ -20,8 +20,8 @@ function SalonEdit() {
   const isNew = salonId === "new"
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const salonsQueryOptions = trpc.salons.list.queryOptions()
-  const salonQueryOptions = trpc.salons.byId.queryOptions({ id: salonId })
+  const salonsQueryOptions = trpc.salons.list.queryOptions({})
+  const salonQueryOptions = trpc.salons.get.queryOptions({ id: salonId })
 
   const { data: salon } = useQuery({
     ...salonQueryOptions,

--- a/docs/superpowers/plans/2026-07-05-trpc-resource-router-standardization.md
+++ b/docs/superpowers/plans/2026-07-05-trpc-resource-router-standardization.md
@@ -1,0 +1,674 @@
+# tRPC Resource Router Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize the existing tRPC API around resource-oriented router contracts and update all web call sites in the same change.
+
+**Architecture:** Keep `packages/api/src/routers/*` as the JSON business API and keep Hono as the transport host for `/trpc/*`, auth, and file endpoints. Add shared list helpers, migrate routers to `list`/`get`/`create`/`update`/`delete` where those capabilities already exist, and keep explicit domain actions only for workflow operations.
+
+**Tech Stack:** TypeScript, tRPC v11, Hono, Drizzle ORM, Zod, React Query, TanStack Router, Vite+.
+
+---
+
+## File Structure
+
+- Create `packages/api/src/pagination.ts`: shared page/search schemas, offset helper, page envelope helper.
+- Create `packages/api/src/pagination.test.ts`: unit tests for pagination defaults, bounds, search trimming, offset, and envelope output.
+- Modify `packages/api/package.json`: add `test` and `test:watch` scripts.
+- Modify `packages/api/src/routers/customers.ts`: make this the reference resource router with `list`, `get`, `create`, `update`, `summary`.
+- Modify `packages/api/src/routers/appointments.ts`: rename `byId` to `get`, fold `byCustomerId` into paged/filterable `list`, rename `updateMaster` to `update`, keep `linkPersonnel`.
+- Modify `packages/api/src/routers/transactions.ts`: replace `byAppointmentId` with paged/filterable `list`.
+- Modify `packages/api/src/routers/cash-transactions.ts`: reuse shared pagination helpers without changing the public capability set.
+- Modify `packages/api/src/routers/hair-orders.ts`: rename `byId` to `get`, make `list` object-shaped and paged.
+- Modify `packages/api/src/routers/hair-assigned.ts`: replace `byAppointment` and `byCustomer` with `list` filters, keep `availableOrders`.
+- Modify `packages/api/src/routers/bank-accounts.ts`: rename `byId` to `get`.
+- Modify `packages/api/src/routers/bank-statement-entries.ts`: rename `byId` to `get`, align `list` pagination with shared helpers.
+- Modify `packages/api/src/routers/bank-statement-attachments.ts`: combine assigned/unassigned row reads under `list`, keep `counts`, `assign`, `unassign`, `delete`.
+- Modify `packages/api/src/routers/legal-entities.ts` and `packages/api/src/routers/salons.ts`: rename `byId` to `get`, make list inputs object-shaped where currently absent.
+- Modify `apps/web/src/**/*.tsx` and `apps/web/src/**/*.ts`: update tRPC procedure names, list result handling, loaders, invalidation keys, and table rendering for paged envelopes.
+
+## Task 1: Add Shared Pagination Helpers
+
+**Files:**
+- Create: `packages/api/src/pagination.ts`
+- Create: `packages/api/src/pagination.test.ts`
+- Modify: `packages/api/package.json`
+
+- [ ] **Step 1: Add the API package test scripts**
+
+Modify `packages/api/package.json` scripts to:
+
+```json
+{
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "vp test run",
+    "test:watch": "vp test"
+  }
+}
+```
+
+- [ ] **Step 2: Write failing pagination helper tests**
+
+Create `packages/api/src/pagination.test.ts`:
+
+```ts
+import { describe, expect, it } from "vite-plus/test"
+
+import { getOffset, pageSchema, pagedResult, searchSchema } from "./pagination"
+
+describe("pagination helpers", () => {
+  it("defaults page and pageSize", () => {
+    expect(pageSchema.parse({})).toEqual({ page: 1, pageSize: 25 })
+  })
+
+  it("rejects unsafe page sizes", () => {
+    expect(() => pageSchema.parse({ page: 1, pageSize: 101 })).toThrow()
+    expect(() => pageSchema.parse({ page: 0, pageSize: 25 })).toThrow()
+  })
+
+  it("trims blank search to undefined", () => {
+    expect(searchSchema.parse("  alice  ")).toBe("alice")
+    expect(searchSchema.parse("   ")).toBeUndefined()
+    expect(searchSchema.parse(undefined)).toBeUndefined()
+  })
+
+  it("calculates offsets", () => {
+    expect(getOffset({ page: 1, pageSize: 25 })).toBe(0)
+    expect(getOffset({ page: 3, pageSize: 25 })).toBe(50)
+  })
+
+  it("returns the standard page envelope", () => {
+    expect(pagedResult([{ id: "c1" }], { page: 2, pageSize: 10 }, 31)).toEqual({
+      items: [{ id: "c1" }],
+      page: 2,
+      pageSize: 10,
+      totalCount: 31,
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run the failing helper tests**
+
+Run: `vp run --filter @prive-admin-tanstack/api test -- pagination.test.ts`
+
+Expected: fail because `packages/api/src/pagination.ts` does not exist.
+
+- [ ] **Step 4: Implement pagination helpers**
+
+Create `packages/api/src/pagination.ts`:
+
+```ts
+import { z } from "zod"
+
+export const pageSchema = z.object({
+  page: z.number().int().min(1).max(1000).default(1),
+  pageSize: z.number().int().min(1).max(100).default(25),
+})
+
+export const searchSchema = z
+  .string()
+  .trim()
+  .max(120)
+  .optional()
+  .transform((value) => (value ? value : undefined))
+
+export type PageInput = z.infer<typeof pageSchema>
+
+export function getOffset(input: PageInput) {
+  return (input.page - 1) * input.pageSize
+}
+
+export function pagedResult<T>(items: T[], input: PageInput, totalCount: number) {
+  return {
+    items,
+    page: input.page,
+    pageSize: input.pageSize,
+    totalCount,
+  }
+}
+```
+
+- [ ] **Step 5: Run helper tests**
+
+Run: `vp run --filter @prive-admin-tanstack/api test -- pagination.test.ts`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit helper foundation**
+
+Run:
+
+```bash
+git add packages/api/package.json packages/api/src/pagination.ts packages/api/src/pagination.test.ts
+git commit -m "test(api): add pagination helper contract"
+```
+
+## Task 2: Standardize Customers As The Reference Router
+
+**Files:**
+- Modify: `packages/api/src/routers/customers.ts`
+- Modify: `apps/web/src/routes/_authenticated/customers/index.tsx`
+- Modify: `apps/web/src/routes/_authenticated/customers/$customerId.tsx`
+
+- [ ] **Step 1: Replace customer router with paged list and get**
+
+Modify `packages/api/src/routers/customers.ts` so the router has this shape:
+
+```ts
+const customerListSchema = pageSchema.extend({
+  search: searchSchema,
+})
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, "\\$&")
+}
+
+export const customersRouter = router({
+  list: protectedProcedure.input(customerListSchema).query(async ({ input }) => {
+    const where = input.search
+      ? or(ilike(customer.name, `%${escapeLikePattern(input.search)}%`), ilike(customer.phoneNumber, `%${escapeLikePattern(input.search)}%`))
+      : undefined
+
+    const items = await db.query.customer.findMany({
+      where,
+      orderBy: (customer, { asc }) => [asc(customer.name)],
+      limit: input.pageSize,
+      offset: getOffset(input),
+    })
+
+    const [countRow] = await db.select({ totalCount: count() }).from(customer).where(where)
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
+  }),
+
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
+    const result = await db.query.customer.findFirst({
+      where: eq(customer.id, input.id),
+    })
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Customer not found" })
+    return result
+  }),
+
+  create: protectedProcedure.input(customerInputSchema).mutation(async ({ input }) => {
+    const [result] = await db.insert(customer).values({ name: input.name, phoneNumber: input.phoneNumber }).returning()
+    return result
+  }),
+
+  update: protectedProcedure.input(customerInputSchema.required({ id: true })).mutation(async ({ input }) => {
+    const [result] = await db
+      .update(customer)
+      .set({ name: input.name, phoneNumber: input.phoneNumber })
+      .where(eq(customer.id, input.id))
+      .returning()
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Customer not found" })
+    return result
+  }),
+})
+```
+
+Keep the current `summary` procedure implementation in `customersRouter` after `update`; do not change its input, output, or aggregation logic in this task. Add imports for `count`, `ilike`, `or`, `getOffset`, `pageSchema`, `pagedResult`, and `searchSchema`.
+
+- [ ] **Step 2: Run type check and observe customer call-site failures**
+
+Run: `vp run -r check-types`
+
+Expected: fail on `trpc.customers.byId` and on places that treat `customers.list` data as an array.
+
+- [ ] **Step 3: Update customer list route for paged response**
+
+In `apps/web/src/routes/_authenticated/customers/index.tsx`, use explicit list input:
+
+```ts
+const defaultCustomersListInput = { page: 1, pageSize: 25, search: undefined as string | undefined }
+const customersQueryOptions = trpc.customers.list.queryOptions(defaultCustomersListInput)
+```
+
+In `CustomersPage`, read items from the envelope:
+
+```ts
+const { data, isLoading } = useQuery(customersQueryOptions)
+const customers = data?.items ?? []
+```
+
+Replace `customers?.map` with `customers.map` and `customers?.length === 0` with `customers.length === 0`.
+
+- [ ] **Step 4: Update customer detail route procedure names**
+
+In `apps/web/src/routes/_authenticated/customers/$customerId.tsx`, replace:
+
+```ts
+trpc.customers.byId.queryOptions({ id: params.customerId })
+trpc.customers.byId.queryOptions({ id: customerId })
+```
+
+with:
+
+```ts
+trpc.customers.get.queryOptions({ id: params.customerId })
+trpc.customers.get.queryOptions({ id: customerId })
+```
+
+Update invalidation from `trpc.customers.byId` to `trpc.customers.get`.
+
+- [ ] **Step 5: Run type check**
+
+Run: `vp run -r check-types`
+
+Expected: no customer-related errors. Other routers may still have old names until later tasks.
+
+- [ ] **Step 6: Commit customer reference router**
+
+Run:
+
+```bash
+git add packages/api/src/routers/customers.ts apps/web/src/routes/_authenticated/customers/index.tsx 'apps/web/src/routes/_authenticated/customers/$customerId.tsx'
+git commit -m "refactor(api): standardize customer router"
+```
+
+## Task 3: Standardize Appointment And Transaction Resource Reads
+
+**Files:**
+- Modify: `packages/api/src/routers/appointments.ts`
+- Modify: `packages/api/src/routers/transactions.ts`
+- Modify: `apps/web/src/routes/_authenticated/customers/$customerId.tsx`
+- Modify: files reported by `rg -n "appointments\\.(byId|byCustomerId|updateMaster)|transactions\\.byAppointmentId" apps/web/src`
+
+- [ ] **Step 1: Update appointment router names and list filters**
+
+In `packages/api/src/routers/appointments.ts`, define:
+
+```ts
+const appointmentListSchema = pageSchema.extend({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  customerId: z.string().optional(),
+  salonId: z.string().optional(),
+})
+```
+
+Change `byId` to `get`. Change `list` to build conditions for `startDate`, `endDate`, `customerId`, and `salonId`, apply `limit`, `offset`, and return `pagedResult(items, input, totalCount)`.
+
+Change `updateMaster` to:
+
+```ts
+update: protectedProcedure
+  .input(z.object({ id: z.string().min(1), masterId: z.string().min(1) }))
+  .mutation(async ({ input }) => {
+    const [result] = await db.update(appointment).set({ masterId: input.masterId }).where(eq(appointment.id, input.id)).returning()
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" })
+    return result
+  })
+```
+
+Remove `byCustomerId`.
+
+- [ ] **Step 2: Update transactions router list**
+
+In `packages/api/src/routers/transactions.ts`, replace `byAppointmentId` with:
+
+```ts
+const transactionListSchema = pageSchema.extend({
+  appointmentId: z.string().optional(),
+  customerId: z.string().optional(),
+  currency: currencySchema.optional(),
+})
+```
+
+Implement `list` with filters, `limit`, `offset`, and `pagedResult`. If `appointmentId` is provided, preserve the existing appointment existence check and `NOT_FOUND` behavior before querying transactions.
+
+- [ ] **Step 3: Run type check and identify web failures**
+
+Run: `vp run -r check-types`
+
+Expected: fail on old appointment and transaction procedure names and array handling for newly paged responses.
+
+- [ ] **Step 4: Update web call sites**
+
+Run: `rg -n "appointments\\.(byId|byCustomerId|updateMaster)|transactions\\.byAppointmentId" apps/web/src`
+
+For each result:
+
+```ts
+trpc.appointments.byId.queryOptions({ id })
+```
+
+becomes:
+
+```ts
+trpc.appointments.get.queryOptions({ id })
+```
+
+```ts
+trpc.appointments.byCustomerId.queryOptions({ customerId })
+```
+
+becomes:
+
+```ts
+trpc.appointments.list.queryOptions({ page: 1, pageSize: 25, customerId })
+```
+
+```ts
+trpc.appointments.updateMaster.mutationOptions()
+```
+
+becomes:
+
+```ts
+trpc.appointments.update.mutationOptions()
+```
+
+and mutation variables change from `{ appointmentId, masterId }` to `{ id: appointmentId, masterId }`.
+
+```ts
+trpc.transactions.byAppointmentId.queryOptions({ appointmentId })
+```
+
+becomes:
+
+```ts
+trpc.transactions.list.queryOptions({ page: 1, pageSize: 25, appointmentId })
+```
+
+Where list data is rendered, use `data?.items ?? []`.
+
+- [ ] **Step 5: Run type check**
+
+Run: `vp run -r check-types`
+
+Expected: no appointment or transaction procedure-name errors.
+
+- [ ] **Step 6: Commit appointment and transaction standardization**
+
+Run:
+
+```bash
+git add packages/api/src/routers/appointments.ts packages/api/src/routers/transactions.ts apps/web/src
+git commit -m "refactor(api): standardize appointment and transaction reads"
+```
+
+## Task 4: Standardize Hair Routers
+
+**Files:**
+- Modify: `packages/api/src/routers/hair-orders.ts`
+- Modify: `packages/api/src/routers/hair-assigned.ts`
+- Modify: files reported by `rg -n "hairOrders\\.byId|hairAssigned\\.(byAppointment|byCustomer)" apps/web/src`
+
+- [ ] **Step 1: Update hair orders router**
+
+In `packages/api/src/routers/hair-orders.ts`, rename `byId` to `get`. Change `list` to accept:
+
+```ts
+const hairOrderListSchema = pageSchema.extend({
+  customerId: z.string().optional(),
+  status: z.enum(["PENDING", "COMPLETED"]).optional(),
+})
+```
+
+Use `and(...conditions)` when filters exist, order by the current order, apply `limit` and `offset`, and return `pagedResult(items, input, totalCount)`.
+
+- [ ] **Step 2: Update hair assigned router**
+
+In `packages/api/src/routers/hair-assigned.ts`, replace `byAppointment` and `byCustomer` with:
+
+```ts
+const hairAssignedListSchema = pageSchema.extend({
+  appointmentId: z.string().optional(),
+  customerId: z.string().optional(),
+})
+```
+
+Implement `list` with the existing relation includes, filters, `limit`, `offset`, and `pagedResult`. Keep `availableOrders`, `create`, `update`, and `delete`.
+
+- [ ] **Step 3: Update web call sites**
+
+Run: `rg -n "hairOrders\\.byId|hairAssigned\\.(byAppointment|byCustomer)" apps/web/src`
+
+Replace:
+
+```ts
+trpc.hairOrders.byId.queryOptions({ id })
+```
+
+with:
+
+```ts
+trpc.hairOrders.get.queryOptions({ id })
+```
+
+Replace:
+
+```ts
+trpc.hairAssigned.byCustomer.queryOptions({ customerId })
+trpc.hairAssigned.byAppointment.queryOptions({ appointmentId })
+```
+
+with:
+
+```ts
+trpc.hairAssigned.list.queryOptions({ page: 1, pageSize: 25, customerId })
+trpc.hairAssigned.list.queryOptions({ page: 1, pageSize: 25, appointmentId })
+```
+
+Use `data?.items ?? []` where tables expect arrays.
+
+- [ ] **Step 4: Run type check**
+
+Run: `vp run -r check-types`
+
+Expected: no hair router procedure-name errors.
+
+- [ ] **Step 5: Commit hair router standardization**
+
+Run:
+
+```bash
+git add packages/api/src/routers/hair-orders.ts packages/api/src/routers/hair-assigned.ts apps/web/src
+git commit -m "refactor(api): standardize hair routers"
+```
+
+## Task 5: Standardize Bank And Reference Routers
+
+**Files:**
+- Modify: `packages/api/src/routers/bank-accounts.ts`
+- Modify: `packages/api/src/routers/bank-statement-entries.ts`
+- Modify: `packages/api/src/routers/bank-statement-attachments.ts`
+- Modify: `packages/api/src/routers/legal-entities.ts`
+- Modify: `packages/api/src/routers/salons.ts`
+- Modify: matching web call sites under `apps/web/src`
+
+- [ ] **Step 1: Rename single-resource reads**
+
+Rename these procedures:
+
+```ts
+bankAccounts.byId -> bankAccounts.get
+bankStatementEntries.byId -> bankStatementEntries.get
+legalEntities.byId -> legalEntities.get
+salons.byId -> salons.get
+```
+
+Keep the existing bodies and `NOT_FOUND` behavior.
+
+- [ ] **Step 2: Make simple reference lists object-shaped**
+
+For `legalEntities.list` and `salons.list`, use input schemas:
+
+```ts
+const simpleListSchema = z.object({}).optional().default({})
+```
+
+Keep return values unpaged only if the current screens use them as bounded option/reference lists. Do not add missing create/delete operations.
+
+- [ ] **Step 3: Standardize bank statement entry list**
+
+In `bank-statement-entries.ts`, merge the existing list filters with `pageSchema`, use `getOffset(input)`, and return `pagedResult(items, input, totalCount)`.
+
+- [ ] **Step 4: Standardize attachment row reads**
+
+In `bank-statement-attachments.ts`, replace `unassigned` with `list({ assigned: false })` support:
+
+```ts
+const attachmentListSchema = z.object({
+  entryId: z.string().min(1).optional(),
+  assigned: z.boolean().optional(),
+})
+```
+
+Keep `counts`, `assign`, `unassign`, and `delete`. Keep Hono upload, preview, and export endpoints unchanged.
+
+- [ ] **Step 5: Update web call sites**
+
+Run:
+
+```bash
+rg -n "bankAccounts\\.byId|bankStatementEntries\\.byId|legalEntities\\.byId|salons\\.byId|bankStatementAttachments\\.unassigned" apps/web/src
+```
+
+Replace each old name with the standardized name. For bank statement entry paged data, use `data?.items ?? []`.
+
+- [ ] **Step 6: Run type check**
+
+Run: `vp run -r check-types`
+
+Expected: no bank/reference router procedure-name errors.
+
+- [ ] **Step 7: Commit bank and reference standardization**
+
+Run:
+
+```bash
+git add packages/api/src/routers apps/web/src
+git commit -m "refactor(api): standardize bank and reference routers"
+```
+
+## Task 6: Align Existing Good Routers And Query Invalidations
+
+**Files:**
+- Modify: `packages/api/src/routers/cash-transactions.ts`
+- Modify: web files reported by `rg -n "invalidateQueries|queryKey\\(|queryOptions\\(" apps/web/src`
+
+- [ ] **Step 1: Reuse shared pagination in cash transactions**
+
+In `cash-transactions.ts`, replace local page/pageSize fields with:
+
+```ts
+const listSchema = pageSchema.extend({
+  search: searchSchema,
+  customerId: z.string().optional(),
+  currency: currencySchema.optional(),
+  direction: z.enum(["all", "received", "paid"]).default("all"),
+  dateFrom: z.iso.date().optional(),
+  dateTo: z.iso.date().optional(),
+})
+```
+
+Replace manual offset calculation with `getOffset(input)` and wrap the return with `pagedResult(rows, input, countRow?.totalCount ?? 0)`.
+
+- [ ] **Step 2: Audit all tRPC invalidations**
+
+Run:
+
+```bash
+rg -n "trpc\\.[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.(queryKey|queryOptions)|invalidateQueries" apps/web/src
+```
+
+For renamed procedures, update invalidation to the new names. For paged lists, prefer invalidating the router list key broadly:
+
+```ts
+queryClient.invalidateQueries({ queryKey: trpc.customers.list.queryKey() })
+```
+
+Use exact input query keys only when the mutation is known to affect a single loaded query.
+
+- [ ] **Step 3: Search for old API names**
+
+Run:
+
+```bash
+rg -n "\\.(byId|byCustomerId|byAppointmentId|byCustomer|byAppointment|updateMaster|unassigned)\\b" packages/api/src apps/web/src
+```
+
+Expected: no matches for removed procedure names. Matches are acceptable only for unrelated words outside tRPC procedure names.
+
+- [ ] **Step 4: Run type check**
+
+Run: `vp run -r check-types`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit cleanup**
+
+Run:
+
+```bash
+git add packages/api/src/routers/cash-transactions.ts apps/web/src
+git commit -m "refactor(api): align pagination helpers and query invalidation"
+```
+
+## Task 7: Full Verification
+
+**Files:**
+- No planned source edits unless verification exposes a defect.
+
+- [ ] **Step 1: Run API tests**
+
+Run: `vp run --filter @prive-admin-tanstack/api test`
+
+Expected: pagination helper tests pass.
+
+- [ ] **Step 2: Run workspace type checks**
+
+Run: `vp run -r check-types`
+
+Expected: all packages pass.
+
+- [ ] **Step 3: Run Vite+ check**
+
+Run: `vp check`
+
+Expected: formatting, linting, and type-related checks pass. If it formats files, inspect `git diff` and commit the formatting-only changes with the related task or a final cleanup commit.
+
+- [ ] **Step 4: Run builds**
+
+Run:
+
+```bash
+vp build apps/web
+vp build apps/server
+```
+
+Expected: both builds pass.
+
+- [ ] **Step 5: Runtime smoke test**
+
+Start the apps with the project’s normal dev command:
+
+```bash
+vp run -r --parallel dev
+```
+
+Smoke these workflows in the browser:
+
+- Customers page loads and renders rows from `customers.list(...).items`.
+- Customer detail loads customer, summary, appointments, notes, and hair assigned data.
+- Appointment detail loads transactions through `transactions.list({ appointmentId })`.
+- Existing create/update/delete workflows refresh the expected lists after mutation.
+
+- [ ] **Step 6: Commit final verification fixes**
+
+If verification required source changes, run:
+
+```bash
+git add packages/api apps/web
+git commit -m "fix: address trpc router standardization verification"
+```
+
+If no changes were required, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: The plan covers shared helpers, resource naming, paged list envelopes, missing-operation restraint, Hono non-changes, web call-site migration, invalidation audit, and verification.
+- Red-flag scan: The plan contains no deferred implementation step and no compatibility alias.
+- Type consistency: The plan consistently uses `list`, `get`, `create`, `update`, `delete`, `pageSchema`, `searchSchema`, `getOffset`, and `pagedResult`.

--- a/docs/superpowers/specs/2026-07-05-trpc-resource-router-standardization-design.md
+++ b/docs/superpowers/specs/2026-07-05-trpc-resource-router-standardization-design.md
@@ -1,0 +1,322 @@
+# tRPC Resource Router Standardization Design
+
+## Context
+
+The server app is a Hono Node server that mounts Better Auth under `/api/auth/*`, file-oriented REST endpoints under `/api/*`, and tRPC under `/trpc/*`.
+
+JSON business operations live in `packages/api/src/routers/*`. The routers were migrated from TanStack Start server functions and currently preserve several action-oriented names:
+
+- `customers.byId`
+- `appointments.byCustomerId`
+- `transactions.byAppointmentId`
+- `hairAssigned.byCustomer`
+- `hairAssigned.byAppointment`
+- `bankStatementAttachments.unassigned`
+
+Some routers already follow a stronger collection shape. `cashTransactions.list` accepts pagination and filters and returns `{ items, page, pageSize, totalCount }`. Other routers, such as `customers.list`, return all rows with no input.
+
+This design standardizes the existing tRPC surface so the API behaves like resource-oriented REST while keeping tRPC as the typed transport.
+
+## Goals
+
+- Keep tRPC routers and procedures as the JSON business API.
+- Standardize all existing tRPC procedures around resource-oriented naming and contracts.
+- Update all web call sites in the same PR.
+- Make collection reads consistently filterable and pageable where the resource can grow.
+- Use one page response envelope for paged collection responses.
+- Keep domain actions explicit when they do not map cleanly to CRUD.
+- Keep Hono REST endpoints for auth, multipart uploads, binary previews, and exports.
+
+## Non-Goals
+
+- Do not add missing operations just to complete a CRUD matrix.
+- Do not replace tRPC with HTTP JSON REST endpoints.
+- Do not redesign the database schema or domain model.
+- Do not redesign the web UI.
+- Do not migrate file upload, preview, or export flows into tRPC.
+- Do not add compatibility aliases for renamed tRPC procedures.
+
+## Recommended Approach
+
+Use resource-oriented tRPC routers with a small canonical procedure vocabulary:
+
+- `list`: collection reads.
+- `get`: single-resource reads by `{ id }`.
+- `create`: create an existing resource type when that operation already exists.
+- `update`: update an existing resource type when that operation already exists.
+- `delete`: delete an existing resource type when that operation already exists.
+
+Existing non-CRUD operations remain explicit domain procedures when they represent workflow commands, aggregate reads, imports, exports, or analytical views. Examples include `summary`, `stats`, `import`, `assign`, `unassign`, `ignore`, `undo`, and `recalculatePrices`.
+
+This is a breaking internal API refactor. Procedure names and inputs can change, and all affected web call sites must be updated in the same PR.
+
+## Procedure Naming Rules
+
+Single-resource reads should use `get`:
+
+- `customers.byId` becomes `customers.get`.
+- `appointments.byId` becomes `appointments.get`.
+- `legalEntities.byId` becomes `legalEntities.get`.
+- `salons.byId` becomes `salons.get`.
+- `bankAccounts.byId` becomes `bankAccounts.get`.
+
+Collection reads should use `list` with filters instead of relationship-specific procedure names:
+
+- `appointments.byCustomerId` becomes `appointments.list({ customerId })`.
+- `transactions.byAppointmentId` becomes `transactions.list({ appointmentId })`.
+- `hairAssigned.byCustomer` becomes `hairAssigned.list({ customerId })`.
+- `hairAssigned.byAppointment` becomes `hairAssigned.list({ appointmentId })`.
+- `bankStatementAttachments.unassigned` becomes `bankStatementAttachments.list({ assigned: false })`.
+
+Existing action procedures should keep verb names only when they are true domain actions:
+
+- `appointments.linkPersonnel` remains a domain action because there is no standalone appointment-personnel resource in the existing API.
+- `appointments.updateMaster` becomes `appointments.update` with the same effective capability: updating the appointment master. This standardizes the resource update name without adding unrelated appointment update fields.
+- `bankStatementEntries.importCsv` remains `importCsv` because the input format is part of the operation contract.
+- `bankStatementEntries.ignore` and `bankStatementEntries.undo` remain workflow actions.
+- `bankStatementAttachments.assign` and `bankStatementAttachments.unassign` remain workflow actions.
+- `hairOrders.recalculatePrices` remains a domain action.
+
+Analytical routers can use descriptive names, but they should be consistent within each router. Dashboard and reports procedures do not need to pretend to be CRUD resources.
+
+## List Contract
+
+Every collection procedure should accept an object input, even if it has no required filters today. This gives a stable place to add pagination, search, sort, and filters without changing procedure shape again.
+
+The common list input fields are:
+
+```ts
+{
+  page?: number
+  pageSize?: number
+  search?: string
+}
+```
+
+Resource-specific filters live beside those fields:
+
+```ts
+customers.list({
+  page,
+  pageSize,
+  search,
+  phoneNumber,
+})
+```
+
+```ts
+appointments.list({
+  page,
+  pageSize,
+  startDate,
+  endDate,
+  customerId,
+  salonId,
+})
+```
+
+```ts
+transactions.list({
+  page,
+  pageSize,
+  appointmentId,
+  customerId,
+  currency,
+})
+```
+
+Sort support should be added only where the UI needs it or where a stable non-default sort is required. Each sortable resource should validate sort fields with an enum instead of accepting arbitrary column names.
+
+## Paged Response Contract
+
+Paged collection responses use one envelope:
+
+```ts
+{
+  items: T[]
+  page: number
+  pageSize: number
+  totalCount: number
+}
+```
+
+Small bounded reference collections may remain unpaged only when the result set is intentionally small and operationally safe to load in full. These exceptions should still use `list` and should be obvious in the router implementation. Examples may include option lists used by forms, but only after checking the specific resource.
+
+## Shared API Helpers
+
+Add shared helpers in `packages/api` so routers do not copy pagination and response boilerplate:
+
+- `pageSchema`: validates `page` and `pageSize`, with defaults such as `page: 1` and `pageSize: 25`, and a max `pageSize` of `100`.
+- `searchSchema`: trims optional search strings and caps length.
+- `getOffset(input)`: returns `(page - 1) * pageSize`.
+- `pagedResult(items, input, totalCount)`: returns the standard page envelope.
+- Optional sort schema helpers when multiple routers need the same sort shape.
+
+Resource-specific filter schemas remain in their router files unless they are reused by multiple routers.
+
+## Router-Specific Direction
+
+### Customers
+
+Make `customers` the reference implementation:
+
+- Rename `byId` to `get`.
+- Change `list` to accept pagination and search.
+- Search should match customer name and phone number.
+- Return the standard page envelope.
+- Keep `summary` as an aggregate read for the customer detail page.
+- Keep existing `create` and `update`.
+- Do not add `delete`.
+
+### Appointments
+
+- Rename `byId` to `get`.
+- Keep `list` as the collection endpoint.
+- Fold customer-specific reads into `list({ customerId })`.
+- Preserve date range filters.
+- Use the standard page envelope for `list`. Calendar views can request a sufficiently large page size with date filters, but the collection contract remains paged.
+- Keep `create`.
+- Replace `updateMaster` with `update`, accepting only the existing master update capability.
+- Keep `linkPersonnel` as a domain action.
+
+### Transactions
+
+- Rename `byAppointmentId` to `list({ appointmentId })`.
+- Use the standard page envelope for `list`.
+- Keep existing `create`, `update`, and `delete`.
+- Keep appointment/customer validation behavior.
+
+### Cash Transactions
+
+- Preserve the current good pattern.
+- Align helper usage with the shared pagination and search helpers.
+- Keep existing `list`, `create`, `update`, and `delete`.
+
+### Hair Orders
+
+- Rename `byId` to `get`.
+- Make `list` accept an object input.
+- Use the standard page envelope for `list`.
+- Include filters for status, customer, placed date, and arrived date only when those fields are already present in the resource and useful to existing screens.
+- Keep `recalculatePrices` as a domain action.
+- Keep existing `create` and `update`.
+- Do not add `delete`.
+
+### Hair Assigned
+
+- Replace relationship-specific collection names with `list` filters.
+- Keep `availableOrders` as a bounded option-list procedure. It returns candidate hair orders for a form workflow, not hair-assigned rows.
+- Keep existing `create`, `update`, and `delete`.
+
+### Bank Accounts
+
+- Rename `byId` to `get`.
+- Keep existing `create` and `update`.
+- Do not add `list` or `delete` unless an existing endpoint already provides that capability.
+
+### Bank Statement Entries
+
+- Keep `list` as the collection endpoint.
+- Preserve existing filters.
+- Use the standard page envelope for `list`.
+- Rename `byId` to `get`.
+- Keep `importCsv`, `ignore`, and `undo` as workflow procedures.
+
+### Bank Statement Attachments
+
+- Keep attachment row collections under `list` with filters such as `entryId` and `assigned`.
+- Keep `counts` as an aggregate read.
+- Keep `assign`, `unassign`, and `delete` if they already exist.
+- File upload, preview, and export stay in Hono REST endpoints because they use multipart input or binary/streaming output.
+
+### Legal Entities, Salons, Notes, User Settings
+
+- Rename `byId` to `get` where present.
+- Keep existing create/update/delete capabilities only where they already exist.
+- Make collection endpoints accept object inputs where practical.
+- Do not add missing deletes or creates.
+- `userSettings.get` is acceptable because it reads the singleton settings resource for the current user.
+
+### Dashboard And Reports
+
+These routers expose analytical views rather than CRUD resources. Keep descriptive procedure names, but make names consistent within each router. Inputs should be object-shaped and validated with Zod. Outputs should remain domain-specific aggregates.
+
+## Hono Server Structure
+
+The JSON business API remains in tRPC. Hono continues to own:
+
+- `GET|POST /api/auth/*`
+- Multipart upload endpoints.
+- Binary preview endpoints.
+- Archive/export endpoints.
+- Health checks.
+- The `/trpc/*` mount.
+
+The Hono best-practices guide recommends keeping handlers close to route definitions instead of detached controller-style files, because route-local handlers preserve better type inference for params. For larger Hono apps, the guide recommends splitting route modules and mounting them with `app.route()`.
+
+Apply that guidance if `apps/server/src/index.ts` is split:
+
+- Use Hono route modules for REST endpoints, such as statement attachment files.
+- Mount modules with `app.route()`.
+- Avoid Rails-style controller files for Hono handlers.
+- Do not create dedicated `HEAD` handlers; Hono derives HEAD behavior from GET routes.
+
+This guidance does not require moving tRPC procedures into Hono route modules.
+
+Reference: https://hono.dev/docs/guides/best-practices
+
+## Error Handling
+
+Keep errors tRPC-native:
+
+- Missing auth returns `UNAUTHORIZED` from `protectedProcedure`.
+- Missing records return `NOT_FOUND` from `get`, `update`, `delete`, and domain actions targeting a missing row.
+- Invalid domain state returns `BAD_REQUEST`.
+- Malformed inputs are rejected by Zod.
+- Unexpected failures should not be broadly wrapped unless the handler can add useful, non-sensitive domain context.
+
+Mutations targeting existing records should consistently verify affected rows. If an update or delete touches no rows, throw `NOT_FOUND`.
+
+## Web Migration
+
+Update all web call sites in the same PR. No compatibility aliases should remain in the API package.
+
+Expected call-site changes include:
+
+- `trpc.customers.byId` to `trpc.customers.get`.
+- `trpc.customers.list.queryOptions()` to `trpc.customers.list.queryOptions({ page, pageSize, search })` or an explicit default input.
+- `trpc.appointments.byCustomerId` to `trpc.appointments.list` with `customerId`.
+- `trpc.transactions.byAppointmentId` to `trpc.transactions.list` with `appointmentId`.
+- `trpc.hairAssigned.byCustomer` and `byAppointment` to `trpc.hairAssigned.list` with the relevant filter.
+
+React Query invalidation should use the new query options or query keys. Where a mutation affects a paged list, invalidate the resource list broadly or use the tRPC query key helper for the resource rather than invalidating only one page unless that is intentional.
+
+## Verification
+
+Required checks after implementation:
+
+- `vp check`
+- `vp run -r check-types`
+- Relevant package tests, or `vp run -r test` if the workspace has tests available.
+- Build checks for affected apps/packages, such as `vp build apps/web` and `vp build apps/server` if configured.
+
+Contract checks should cover:
+
+- Shared pagination defaulting and max page size.
+- `customers.list` pagination, search, and response envelope.
+- Renamed `get` procedures returning `NOT_FOUND` when appropriate.
+- Filtered list behavior for appointment, transaction, hair assigned, and attachment relationship reads.
+- Mutation errors for update/delete of missing rows.
+
+Runtime smoke checks should cover:
+
+- Authenticated customer list loads with the new paged response.
+- Customer detail route loads with renamed `get` and filtered related-resource lists.
+- A create/update/delete workflow invalidates the expected standardized query keys.
+
+## Open Decisions Resolved
+
+- The refactor keeps tRPC and does not add HTTP JSON REST endpoints.
+- The refactor is breaking and updates call sites in the same PR.
+- Missing CRUD operations are not added.
+- Hono REST remains for auth and file/binary workflows.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,9 @@
     "./routers": "./src/routers/index.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vp test run",
+    "test:watch": "vp test"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1068.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./context": "./src/context.ts",
+    "./http": "./src/http/index.ts",
     "./r2": "./src/r2.ts",
     "./routers": "./src/routers/index.ts"
   },
@@ -15,10 +16,12 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1068.0",
+    "@paralleldrive/cuid2": "^3.3.0",
     "@prive-admin-tanstack/auth": "workspace:*",
     "@prive-admin-tanstack/db": "workspace:*",
     "@prive-admin-tanstack/env": "workspace:*",
     "@trpc/server": "catalog:",
+    "archiver": "^8.0.0",
     "csv-parse": "^6.2.1",
     "drizzle-orm": "^0.45.2",
     "hono": "catalog:",
@@ -26,6 +29,7 @@
   },
   "devDependencies": {
     "@prive-admin-tanstack/config": "workspace:*",
+    "@types/archiver": "^6.0.3",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/api/src/http/index.ts
+++ b/packages/api/src/http/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono"
+
+import { statementAttachmentRoutes } from "./statement-attachments"
+import { uploadRoutes } from "./uploads"
+
+export const apiRoutes = new Hono()
+
+apiRoutes.route("/", uploadRoutes)
+apiRoutes.route("/statement-attachments", statementAttachmentRoutes)
+
+export { statementAttachmentRoutes } from "./statement-attachments"
+export { uploadRoutes } from "./uploads"

--- a/packages/api/src/http/session.ts
+++ b/packages/api/src/http/session.ts
@@ -1,0 +1,7 @@
+import { auth } from "@prive-admin-tanstack/auth"
+
+export async function requireSession(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) return null
+  return session
+}

--- a/packages/api/src/http/statement-attachments.ts
+++ b/packages/api/src/http/statement-attachments.ts
@@ -1,0 +1,194 @@
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3"
+import { createId } from "@paralleldrive/cuid2"
+import { db } from "@prive-admin-tanstack/db"
+import { bankStatementAttachment } from "@prive-admin-tanstack/db/schema/bank-statement-attachment"
+import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
+import * as archiverPkg from "archiver"
+import { and, eq, gte, lte } from "drizzle-orm"
+import { Hono } from "hono"
+import { Readable } from "node:stream"
+
+import { bucketName, r2 } from "../r2"
+import { requireSession } from "./session"
+
+const ZipArchive = (
+  archiverPkg as unknown as {
+    ZipArchive: new (opts?: unknown) => Readable & {
+      append: (src: Readable | Buffer, opts: { name: string }) => void
+      finalize: () => void
+      on: (ev: string, cb: (err: Error) => void) => void
+    }
+  }
+).ZipArchive
+
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+function pad2(n: number) {
+  return String(n).padStart(2, "0")
+}
+
+function lastDay(year: number, month: number) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+function safeSegment(s: string | null | undefined) {
+  if (!s) return ""
+  return s.replace(/[^\w.-]+/g, "_").slice(0, 60)
+}
+
+export const statementAttachmentRoutes = new Hono()
+
+statementAttachmentRoutes.post("/upload", async (c) => {
+  const session = await requireSession(c.req.raw)
+  if (!session) return c.json({ error: "Unauthorized" }, 401)
+
+  const formData = await c.req.raw.formData()
+  const rawEntryId = formData.get("entryId")
+  const entryId = typeof rawEntryId === "string" && rawEntryId.length > 0 ? rawEntryId : null
+  const file = formData.get("file") as globalThis.File | null
+
+  if (!file) return c.json({ error: "No file provided" }, 400)
+  if (file.size > MAX_ATTACHMENT_BYTES) return c.json({ error: `File exceeds ${MAX_ATTACHMENT_BYTES} bytes` }, 413)
+
+  if (entryId) {
+    const entry = await db.query.bankStatementEntry.findFirst({
+      where: eq(bankStatementEntry.id, entryId),
+      columns: { id: true },
+    })
+    if (!entry) return c.json({ error: "Entry not found" }, 404)
+  }
+
+  const safeName = file.name.replace(/[^\w.-]+/g, "_")
+  const now = new Date()
+  const yyyy = now.getUTCFullYear()
+  const mm = pad2(now.getUTCMonth() + 1)
+  const attachmentId = createId()
+  const key = `statement_uploads/${yyyy}/${mm}/${attachmentId}-${safeName}`
+  const arrayBuffer = await file.arrayBuffer()
+
+  try {
+    await r2.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        Body: new Uint8Array(arrayBuffer),
+        ContentType: file.type || "application/octet-stream",
+      }),
+    )
+  } catch (error) {
+    console.error("[statement-attachment upload] R2", error)
+    return c.json({ error: "Upload failed" }, 500)
+  }
+
+  const [row] = await db
+    .insert(bankStatementAttachment)
+    .values({
+      id: attachmentId,
+      bankStatementEntryId: entryId,
+      r2Key: key,
+      originalName: file.name,
+      contentType: file.type || "application/octet-stream",
+      size: file.size,
+      uploadedById: session.user.id,
+    })
+    .returning()
+
+  return c.json(row)
+})
+
+statementAttachmentRoutes.get("/preview", async (c) => {
+  const session = await requireSession(c.req.raw)
+  if (!session) return c.json({ error: "Unauthorized" }, 401)
+
+  const id = c.req.query("id")
+  if (!id) return c.json({ error: "Missing id" }, 400)
+
+  const row = await db.query.bankStatementAttachment.findFirst({
+    where: eq(bankStatementAttachment.id, id),
+  })
+  if (!row) return c.json({ error: "Not found" }, 404)
+
+  let obj
+  try {
+    obj = await r2.send(new GetObjectCommand({ Bucket: bucketName, Key: row.r2Key }))
+  } catch (error) {
+    console.error("[statement-attachment preview] R2", error)
+    return c.json({ error: "Fetch failed" }, 500)
+  }
+  if (!obj.Body) return c.json({ error: "Empty body" }, 500)
+
+  const webStream = Readable.toWeb(obj.Body as Readable) as unknown as ReadableStream
+  const inlineSafeTypes = new Set([
+    "application/pdf",
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "text/plain",
+    "text/csv",
+  ])
+  const contentType = row.contentType || "application/octet-stream"
+  const disposition = inlineSafeTypes.has(contentType) ? "inline" : "attachment"
+  const filename = encodeURIComponent(row.originalName)
+
+  return new Response(webStream, {
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": `${disposition}; filename="${filename}"; filename*=UTF-8''${filename}`,
+      "Cache-Control": "private, max-age=60",
+      "X-Content-Type-Options": "nosniff",
+    },
+  })
+})
+
+statementAttachmentRoutes.get("/export", async (c) => {
+  const session = await requireSession(c.req.raw)
+  if (!session) return c.json({ error: "Unauthorized" }, 401)
+
+  const year = Number(c.req.query("year"))
+  const month = Number(c.req.query("month"))
+  const bankAccountId = c.req.query("bankAccountId") || undefined
+
+  if (!Number.isInteger(year) || year < 2000 || year > 9999) return c.json({ error: "Invalid year" }, 400)
+  if (!Number.isInteger(month) || month < 1 || month > 12) return c.json({ error: "Invalid month" }, 400)
+
+  const start = `${year}-${pad2(month)}-01`
+  const end = `${year}-${pad2(month)}-${pad2(lastDay(year, month))}`
+
+  const conditions = [gte(bankStatementEntry.date, start), lte(bankStatementEntry.date, end)]
+  if (bankAccountId) conditions.push(eq(bankStatementEntry.bankAccountId, bankAccountId))
+
+  const rows = await db
+    .select({
+      attachment: bankStatementAttachment,
+      entry: bankStatementEntry,
+    })
+    .from(bankStatementAttachment)
+    .innerJoin(bankStatementEntry, eq(bankStatementAttachment.bankStatementEntryId, bankStatementEntry.id))
+    .where(and(...conditions))
+
+  const archive = new ZipArchive({ zlib: { level: 9 } })
+  archive.on("warning", (err: Error) => console.warn("[zip warning]", err))
+  archive.on("error", (err: Error) => console.error("[zip error]", err))
+
+  for (const { attachment, entry } of rows) {
+    const obj = await r2.send(new GetObjectCommand({ Bucket: bucketName, Key: attachment.r2Key }))
+    const body = obj.Body
+    if (!body) continue
+    const counterparty = safeSegment(entry.counterpartyName) || "unknown"
+    const name = `${entry.date}_${counterparty}_${attachment.originalName}`
+    archive.append(body as Readable, { name })
+  }
+
+  archive.finalize()
+
+  const webStream = Readable.toWeb(archive) as unknown as ReadableStream
+  const filename = `bank-statements-${year}-${pad2(month)}.zip`
+
+  return new Response(webStream, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  })
+})

--- a/packages/api/src/http/uploads.ts
+++ b/packages/api/src/http/uploads.ts
@@ -1,0 +1,34 @@
+import { PutObjectCommand } from "@aws-sdk/client-s3"
+import { Hono } from "hono"
+
+import { bucketName, r2 } from "../r2"
+import { requireSession } from "./session"
+
+export const uploadRoutes = new Hono()
+
+uploadRoutes.post("/upload", async (c) => {
+  const session = await requireSession(c.req.raw)
+  if (!session) return c.json({ error: "Unauthorized" }, 401)
+
+  const formData = await c.req.raw.formData()
+  const file = formData.get("file") as globalThis.File | null
+  if (!file) return c.json({ error: "No file provided" }, 400)
+
+  try {
+    const safeName = file.name.replace(/[^\w.-]+/g, "_")
+    const key = `uploads/${Date.now()}-${safeName}`
+    const arrayBuffer = await file.arrayBuffer()
+    await r2.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        Body: new Uint8Array(arrayBuffer),
+        ContentType: file.type || "application/octet-stream",
+      }),
+    )
+    return c.json({ key })
+  } catch (error) {
+    console.error("[upload]", error)
+    return c.json({ error: "Upload failed" }, 500)
+  }
+})

--- a/packages/api/src/pagination.test.ts
+++ b/packages/api/src/pagination.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import { getOffset, pageSchema, pagedResult, searchSchema } from "./pagination"
+
+describe("pagination helpers", () => {
+  it("defaults page and pageSize", () => {
+    expect(pageSchema.parse({})).toEqual({ page: 1, pageSize: 25 })
+  })
+
+  it("rejects unsafe page sizes", () => {
+    expect(() => pageSchema.parse({ page: 1, pageSize: 101 })).toThrow()
+    expect(() => pageSchema.parse({ page: 0, pageSize: 25 })).toThrow()
+  })
+
+  it("trims blank search to undefined", () => {
+    expect(searchSchema.parse("  alice  ")).toBe("alice")
+    expect(searchSchema.parse("   ")).toBeUndefined()
+    expect(searchSchema.parse(undefined)).toBeUndefined()
+  })
+
+  it("calculates offsets", () => {
+    expect(getOffset({ page: 1, pageSize: 25 })).toBe(0)
+    expect(getOffset({ page: 3, pageSize: 25 })).toBe(50)
+  })
+
+  it("returns the standard page envelope", () => {
+    expect(pagedResult([{ id: "c1" }], { page: 2, pageSize: 10 }, 31)).toEqual({
+      items: [{ id: "c1" }],
+      page: 2,
+      pageSize: 10,
+      totalCount: 31,
+    })
+  })
+})

--- a/packages/api/src/pagination.ts
+++ b/packages/api/src/pagination.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const pageSchema = z.object({
+  page: z.number().int().min(1).max(1000).default(1),
+  pageSize: z.number().int().min(1).max(100).default(25),
+})
+
+export const searchSchema = z
+  .string()
+  .trim()
+  .max(120)
+  .optional()
+  .transform((value) => (value ? value : undefined))
+
+export type PageInput = z.infer<typeof pageSchema>
+
+export function getOffset(input: PageInput) {
+  return (input.page - 1) * input.pageSize
+}
+
+export function pagedResult<T>(items: T[], input: PageInput, totalCount: number) {
+  return {
+    items,
+    page: input.page,
+    pageSize: input.pageSize,
+    totalCount,
+  }
+}

--- a/packages/api/src/routers/appointments.ts
+++ b/packages/api/src/routers/appointments.ts
@@ -1,10 +1,11 @@
 import { db } from "@prive-admin-tanstack/db"
 import { appointment, personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
 import { TRPCError } from "@trpc/server"
-import { and, eq, gte, lte } from "drizzle-orm"
+import { and, count, eq, gte, lte } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const appointmentInputSchema = z.object({
   id: z.string().optional(),
@@ -15,27 +16,38 @@ const appointmentInputSchema = z.object({
   salonId: z.string().min(1, "Salon is required"),
 })
 
+const appointmentListSchema = pageSchema.extend({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  customerId: z.string().optional(),
+  salonId: z.string().optional(),
+})
+
 export const appointmentsRouter = router({
-  list: protectedProcedure
-    .input(
-      z.object({
-        startDate: z.string().optional(),
-        endDate: z.string().optional(),
-      }),
-    )
-    .query(({ input }) => {
-      const conditions = []
-      if (input.startDate) conditions.push(gte(appointment.startsAt, new Date(input.startDate)))
-      if (input.endDate) conditions.push(lte(appointment.startsAt, new Date(input.endDate)))
+  list: protectedProcedure.input(appointmentListSchema).query(async ({ input }) => {
+    const conditions = []
+    if (input.startDate) conditions.push(gte(appointment.startsAt, new Date(input.startDate)))
+    if (input.endDate) conditions.push(lte(appointment.startsAt, new Date(input.endDate)))
+    if (input.customerId) conditions.push(eq(appointment.clientId, input.customerId))
+    if (input.salonId) conditions.push(eq(appointment.salonId, input.salonId))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
 
-      return db.query.appointment.findMany({
-        where: conditions.length > 0 ? and(...conditions) : undefined,
-        with: { client: true, master: true, salon: true },
-        orderBy: (appointment, { asc }) => [asc(appointment.startsAt)],
-      })
-    }),
+    const items = await db.query.appointment.findMany({
+      where,
+      with: { client: true, master: true, salon: true },
+      orderBy: (appointment, { asc, desc }) => [
+        input.customerId ? desc(appointment.startsAt) : asc(appointment.startsAt),
+      ],
+      limit: input.pageSize,
+      offset: getOffset(input),
+    })
 
-  byId: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
+    const [countRow] = await db.select({ totalCount: count() }).from(appointment).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
+  }),
+
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
     const result = await db.query.appointment.findFirst({
       where: eq(appointment.id, input.id),
       with: {
@@ -78,25 +90,17 @@ export const appointmentsRouter = router({
       await db.insert(personnelOnAppointments).values(values)
     }),
 
-  updateMaster: protectedProcedure
-    .input(z.object({ appointmentId: z.string(), masterId: z.string().min(1) }))
+  update: protectedProcedure
+    .input(z.object({ id: z.string().min(1), masterId: z.string().min(1) }))
     .mutation(async ({ input }) => {
       const [result] = await db
         .update(appointment)
         .set({ masterId: input.masterId })
-        .where(eq(appointment.id, input.appointmentId))
+        .where(eq(appointment.id, input.id))
         .returning()
       if (!result) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" })
       }
       return result
     }),
-
-  byCustomerId: protectedProcedure.input(z.object({ customerId: z.string() })).query(({ input }) => {
-    return db.query.appointment.findMany({
-      where: eq(appointment.clientId, input.customerId),
-      with: { master: true, salon: true },
-      orderBy: (appointment, { desc }) => [desc(appointment.startsAt)],
-    })
-  }),
 })

--- a/packages/api/src/routers/bank-accounts.ts
+++ b/packages/api/src/routers/bank-accounts.ts
@@ -23,7 +23,7 @@ const bankAccountSchema = z.object({
 })
 
 export const bankAccountsRouter = router({
-  byId: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
     const row = await db.query.bankAccount.findFirst({
       where: eq(bankAccount.id, input.id),
       with: {

--- a/packages/api/src/routers/bank-accounts.ts
+++ b/packages/api/src/routers/bank-accounts.ts
@@ -28,9 +28,6 @@ export const bankAccountsRouter = router({
       where: eq(bankAccount.id, input.id),
       with: {
         legalEntity: true,
-        statementEntries: {
-          orderBy: (e, { desc }) => [desc(e.date), desc(e.importedAt)],
-        },
       },
     })
     if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "Bank account not found" })

--- a/packages/api/src/routers/bank-statement-attachments.ts
+++ b/packages/api/src/routers/bank-statement-attachments.ts
@@ -3,26 +3,31 @@ import { db } from "@prive-admin-tanstack/db"
 import { bankStatementAttachment } from "@prive-admin-tanstack/db/schema/bank-statement-attachment"
 import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
 import { TRPCError } from "@trpc/server"
-import { desc, eq, isNull } from "drizzle-orm"
+import { and, desc, eq, isNotNull, isNull } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
 import { bucketName, r2 } from "../r2"
 
 export const bankStatementAttachmentsRouter = router({
-  list: protectedProcedure.input(z.object({ entryId: z.string().min(1) })).query(({ input }) => {
-    return db.query.bankStatementAttachment.findMany({
-      where: eq(bankStatementAttachment.bankStatementEntryId, input.entryId),
-      orderBy: [desc(bankStatementAttachment.uploadedAt)],
-    })
-  }),
+  list: protectedProcedure
+    .input(
+      z.object({
+        entryId: z.string().min(1).optional(),
+        assigned: z.boolean().optional(),
+      }),
+    )
+    .query(({ input }) => {
+      const conditions = []
+      if (input.entryId) conditions.push(eq(bankStatementAttachment.bankStatementEntryId, input.entryId))
+      if (input.assigned === false) conditions.push(isNull(bankStatementAttachment.bankStatementEntryId))
+      if (input.assigned === true) conditions.push(isNotNull(bankStatementAttachment.bankStatementEntryId))
 
-  unassigned: protectedProcedure.query(() => {
-    return db.query.bankStatementAttachment.findMany({
-      where: isNull(bankStatementAttachment.bankStatementEntryId),
-      orderBy: [desc(bankStatementAttachment.uploadedAt)],
-    })
-  }),
+      return db.query.bankStatementAttachment.findMany({
+        where: conditions.length > 0 ? and(...conditions) : undefined,
+        orderBy: [desc(bankStatementAttachment.uploadedAt)],
+      })
+    }),
 
   counts: protectedProcedure.query(async () => {
     const rows = await db

--- a/packages/api/src/routers/bank-statement-entries.ts
+++ b/packages/api/src/routers/bank-statement-entries.ts
@@ -2,11 +2,17 @@ import { db } from "@prive-admin-tanstack/db"
 import { bankAccount } from "@prive-admin-tanstack/db/schema/bank-account"
 import { bankStatementEntry } from "@prive-admin-tanstack/db/schema/bank-statement-entry"
 import { TRPCError } from "@trpc/server"
-import { and, desc, eq } from "drizzle-orm"
+import { and, count, desc, eq } from "drizzle-orm"
 import { z } from "zod"
 
 import { parseBankCsv } from "../bank-csv"
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
+
+const bankStatementEntryListSchema = pageSchema.extend({
+  bankAccountId: z.string().optional(),
+  status: z.enum(["PENDING", "IGNORED"]).optional(),
+})
 
 export const bankStatementEntriesRouter = router({
   importCsv: protectedProcedure.input(z.object({ csv: z.string().min(1) })).mutation(async ({ input }) => {
@@ -59,29 +65,28 @@ export const bankStatementEntriesRouter = router({
     }
   }),
 
-  list: protectedProcedure
-    .input(
-      z.object({
-        bankAccountId: z.string().optional(),
-        status: z.enum(["PENDING", "IGNORED"]).optional(),
-      }),
-    )
-    .query(async ({ input }) => {
-      const conditions = []
-      if (input.bankAccountId) conditions.push(eq(bankStatementEntry.bankAccountId, input.bankAccountId))
-      if (input.status) conditions.push(eq(bankStatementEntry.status, input.status))
+  list: protectedProcedure.input(bankStatementEntryListSchema).query(async ({ input }) => {
+    const conditions = []
+    if (input.bankAccountId) conditions.push(eq(bankStatementEntry.bankAccountId, input.bankAccountId))
+    if (input.status) conditions.push(eq(bankStatementEntry.status, input.status))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
 
-      return db.query.bankStatementEntry.findMany({
-        where: conditions.length > 0 ? and(...conditions) : undefined,
-        with: {
-          bankAccount: { with: { legalEntity: true } },
-        },
-        orderBy: [desc(bankStatementEntry.date), desc(bankStatementEntry.importedAt)],
-        limit: 500,
-      })
-    }),
+    const items = await db.query.bankStatementEntry.findMany({
+      where,
+      with: {
+        bankAccount: { with: { legalEntity: true } },
+      },
+      orderBy: [desc(bankStatementEntry.date), desc(bankStatementEntry.importedAt)],
+      limit: input.pageSize,
+      offset: getOffset(input),
+    })
 
-  byId: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
+    const [countRow] = await db.select({ totalCount: count() }).from(bankStatementEntry).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
+  }),
+
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
     const row = await db.query.bankStatementEntry.findFirst({
       where: eq(bankStatementEntry.id, input.id),
       with: {

--- a/packages/api/src/routers/cash-transactions.ts
+++ b/packages/api/src/routers/cash-transactions.ts
@@ -7,14 +7,13 @@ import { and, count, desc, eq, gt, gte, ilike, lt, or, type SQL } from "drizzle-
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema, searchSchema } from "../pagination"
 
 const pgIntegerSchema = z.number().int().min(-2147483648).max(2147483647)
 const currencySchema = z.enum(["EUR", "GBP"])
 
-const listSchema = z.object({
-  page: z.number().int().min(1).max(1000).default(1),
-  pageSize: z.number().int().min(1).max(100).default(25),
-  search: z.string().trim().max(120).optional(),
+const listSchema = pageSchema.extend({
+  search: searchSchema,
   customerId: z.string().optional(),
   currency: currencySchema.optional(),
   direction: z.enum(["all", "received", "paid"]).default("all"),
@@ -74,7 +73,6 @@ function buildWhere(data: z.infer<typeof listSchema>) {
 export const cashTransactionsRouter = router({
   list: protectedProcedure.input(listSchema).query(async ({ input }) => {
     const where = buildWhere(input)
-    const offset = (input.page - 1) * input.pageSize
     const rows = await db
       .select({
         id: cashTransaction.id,
@@ -94,7 +92,7 @@ export const cashTransactionsRouter = router({
       .where(where)
       .orderBy(desc(cashTransaction.createdAt), desc(cashTransaction.id))
       .limit(input.pageSize)
-      .offset(offset)
+      .offset(getOffset(input))
 
     const [countRow] = await db
       .select({ totalCount: count() })
@@ -102,7 +100,7 @@ export const cashTransactionsRouter = router({
       .innerJoin(customer, eq(cashTransaction.customerId, customer.id))
       .where(where)
 
-    return { items: rows, page: input.page, pageSize: input.pageSize, totalCount: countRow?.totalCount ?? 0 }
+    return pagedResult(rows, input, countRow?.totalCount ?? 0)
   }),
 
   create: protectedProcedure.input(cashTransactionSchema).mutation(async ({ input, ctx }) => {

--- a/packages/api/src/routers/customers.ts
+++ b/packages/api/src/routers/customers.ts
@@ -1,10 +1,11 @@
 import { db } from "@prive-admin-tanstack/db"
 import { customer } from "@prive-admin-tanstack/db/schema/customer"
 import { TRPCError } from "@trpc/server"
-import { eq } from "drizzle-orm"
+import { asc, count, eq, ilike, or } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema, searchSchema } from "../pagination"
 
 const customerInputSchema = z.object({
   id: z.string().optional(),
@@ -19,14 +20,35 @@ const customerInputSchema = z.object({
 
 type Currency = "GBP" | "EUR"
 
+const customerListSchema = pageSchema.extend({ search: searchSchema })
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, "\\$&")
+}
+
 export const customersRouter = router({
-  list: protectedProcedure.query(() => {
-    return db.query.customer.findMany({
-      orderBy: (customer, { asc }) => [asc(customer.name)],
-    })
+  list: protectedProcedure.input(customerListSchema).query(async ({ input }) => {
+    const where = input.search
+      ? or(
+          ilike(customer.name, `%${escapeLikePattern(input.search)}%`),
+          ilike(customer.phoneNumber, `%${escapeLikePattern(input.search)}%`),
+        )
+      : undefined
+
+    const items = await db
+      .select()
+      .from(customer)
+      .where(where)
+      .orderBy(asc(customer.name))
+      .limit(input.pageSize)
+      .offset(getOffset(input))
+
+    const [countRow] = await db.select({ totalCount: count() }).from(customer).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
   }),
 
-  byId: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
     const result = await db.query.customer.findFirst({
       where: eq(customer.id, input.id),
     })

--- a/packages/api/src/routers/hair-assigned.ts
+++ b/packages/api/src/routers/hair-assigned.ts
@@ -1,25 +1,35 @@
 import { db } from "@prive-admin-tanstack/db"
 import { hairAssigned, hairOrder } from "@prive-admin-tanstack/db/schema/hair"
 import { TRPCError } from "@trpc/server"
-import { eq, gt, sql } from "drizzle-orm"
+import { and, count, eq, gt, sql } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
+
+const hairAssignedListSchema = pageSchema.extend({
+  appointmentId: z.string().optional(),
+  customerId: z.string().optional(),
+})
 
 export const hairAssignedRouter = router({
-  byAppointment: protectedProcedure.input(z.object({ appointmentId: z.string() })).query(({ input }) => {
-    return db.query.hairAssigned.findMany({
-      where: eq(hairAssigned.appointmentId, input.appointmentId),
-      with: { client: true, hairOrder: true },
-    })
-  }),
+  list: protectedProcedure.input(hairAssignedListSchema).query(async ({ input }) => {
+    const conditions = []
+    if (input.appointmentId) conditions.push(eq(hairAssigned.appointmentId, input.appointmentId))
+    if (input.customerId) conditions.push(eq(hairAssigned.clientId, input.customerId))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
 
-  byCustomer: protectedProcedure.input(z.object({ customerId: z.string() })).query(({ input }) => {
-    return db.query.hairAssigned.findMany({
-      where: eq(hairAssigned.clientId, input.customerId),
+    const items = await db.query.hairAssigned.findMany({
+      where,
       with: { client: true, hairOrder: true },
       orderBy: (ha, { desc }) => [desc(ha.createdAt)],
+      limit: input.pageSize,
+      offset: getOffset(input),
     })
+
+    const [countRow] = await db.select({ totalCount: count() }).from(hairAssigned).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
   }),
 
   availableOrders: protectedProcedure.query(() => {

--- a/packages/api/src/routers/hair-orders.ts
+++ b/packages/api/src/routers/hair-orders.ts
@@ -1,10 +1,11 @@
 import { db } from "@prive-admin-tanstack/db"
 import { hairAssigned, hairOrder } from "@prive-admin-tanstack/db/schema/hair"
 import { TRPCError } from "@trpc/server"
-import { eq, sql } from "drizzle-orm"
+import { and, count, eq, sql } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const hairOrderInputSchema = z.object({
   id: z.string().optional(),
@@ -15,6 +16,11 @@ const hairOrderInputSchema = z.object({
   weightReceived: z.number().int().min(0),
   weightUsed: z.number().int().min(0),
   total: z.number().int().min(0),
+})
+
+const hairOrderListSchema = pageSchema.extend({
+  customerId: z.string().optional(),
+  status: z.enum(["PENDING", "COMPLETED"]).optional(),
 })
 
 const dateValue = (value: string | Date | null) => (value ? String(value) : null)
@@ -29,14 +35,26 @@ const assertWeightUsedWithinReceived = (weightUsed: number, weightReceived: numb
 }
 
 export const hairOrdersRouter = router({
-  list: protectedProcedure.query(() => {
-    return db.query.hairOrder.findMany({
+  list: protectedProcedure.input(hairOrderListSchema).query(async ({ input }) => {
+    const conditions = []
+    if (input.customerId) conditions.push(eq(hairOrder.customerId, input.customerId))
+    if (input.status) conditions.push(eq(hairOrder.status, input.status))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+
+    const items = await db.query.hairOrder.findMany({
+      where,
       with: { createdBy: true, customer: true },
       orderBy: (hairOrder, { asc }) => [asc(hairOrder.uid)],
+      limit: input.pageSize,
+      offset: getOffset(input),
     })
+
+    const [countRow] = await db.select({ totalCount: count() }).from(hairOrder).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
   }),
 
-  byId: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
     const result = await db.query.hairOrder.findFirst({
       where: eq(hairOrder.id, input.id),
       with: {

--- a/packages/api/src/routers/legal-entities.ts
+++ b/packages/api/src/routers/legal-entities.ts
@@ -14,13 +14,13 @@ const legalEntityUpdateSchema = z.object({
 })
 
 export const legalEntitiesRouter = router({
-  list: protectedProcedure.query(() => {
+  list: protectedProcedure.input(z.object({}).optional().default({})).query(() => {
     return db.query.legalEntity.findMany({
       orderBy: (le, { asc }) => [asc(le.country), asc(le.name)],
     })
   }),
 
-  byId: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
     const result = await db.query.legalEntity.findFirst({
       where: eq(legalEntity.id, input.id),
       with: {

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -1,0 +1,102 @@
+import { TRPCError } from "@trpc/server"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { appointmentsRouter } from "./appointments"
+import { transactionsRouter } from "./transactions"
+
+const dbMock = vi.hoisted(() => ({
+  query: {
+    appointment: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    transaction: {
+      findMany: vi.fn(),
+    },
+  },
+  select: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock("@prive-admin-tanstack/db", () => ({ db: dbMock }))
+
+const ctx = { session: { user: { id: "user-1" } } } as never
+
+function countQuery(totalCount: number) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ totalCount }]),
+    }),
+  }
+}
+
+function updateQuery(result: unknown) {
+  return {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(result ? [result] : []),
+  }
+}
+
+describe("resource read routers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("lists appointments in the standard page envelope", async () => {
+    const caller = appointmentsRouter.createCaller(ctx)
+    const appointmentRows = [{ id: "appointment-1", name: "Cut", clientId: "customer-1" }]
+    dbMock.query.appointment.findMany.mockResolvedValue(appointmentRows)
+    dbMock.select.mockReturnValue(countQuery(42))
+
+    const result = await caller.list({ page: 2, pageSize: 10, customerId: "customer-1" })
+
+    expect(result).toEqual({ items: appointmentRows, page: 2, pageSize: 10, totalCount: 42 })
+    expect(dbMock.query.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 10,
+        with: { client: true, master: true, salon: true },
+      }),
+    )
+  })
+
+  it("gets an appointment by id and preserves not found behavior", async () => {
+    const caller = appointmentsRouter.createCaller(ctx)
+    const appointmentRow = { id: "appointment-1", name: "Cut" }
+    dbMock.query.appointment.findFirst.mockResolvedValueOnce(appointmentRow).mockResolvedValueOnce(undefined)
+
+    await expect(caller.get({ id: "appointment-1" })).resolves.toBe(appointmentRow)
+    await expect(caller.get({ id: "missing" })).rejects.toMatchObject(
+      new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" }),
+    )
+  })
+
+  it("updates an appointment master by id", async () => {
+    const caller = appointmentsRouter.createCaller(ctx)
+    const appointmentRow = { id: "appointment-1", masterId: "master-2" }
+    dbMock.update.mockReturnValue(updateQuery(appointmentRow))
+
+    await expect(caller.update({ id: "appointment-1", masterId: "master-2" })).resolves.toBe(appointmentRow)
+  })
+
+  it("lists transactions in the standard page envelope", async () => {
+    const caller = transactionsRouter.createCaller(ctx)
+    const transactionRows = [{ id: "transaction-1", appointmentId: "appointment-1", customerId: "customer-1" }]
+    dbMock.query.appointment.findFirst.mockResolvedValue({ id: "appointment-1" })
+    dbMock.query.transaction.findMany.mockResolvedValue(transactionRows)
+    dbMock.select.mockReturnValue(countQuery(3))
+
+    const result = await caller.list({ page: 1, pageSize: 25, appointmentId: "appointment-1" })
+
+    expect(result).toEqual({ items: transactionRows, page: 1, pageSize: 25, totalCount: 3 })
+    expect(dbMock.query.appointment.findFirst).toHaveBeenCalled()
+    expect(dbMock.query.transaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 25,
+        offset: 0,
+        with: { customer: { columns: { id: true, name: true } } },
+      }),
+    )
+  })
+})

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server"
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { appointmentsRouter } from "./appointments"
+import { bankAccountsRouter } from "./bank-accounts"
 import { transactionsRouter } from "./transactions"
 
 const dbMock = vi.hoisted(() => ({
@@ -12,6 +13,9 @@ const dbMock = vi.hoisted(() => ({
     },
     transaction: {
       findMany: vi.fn(),
+    },
+    bankAccount: {
+      findFirst: vi.fn(),
     },
   },
   select: vi.fn(),
@@ -69,6 +73,19 @@ describe("resource read routers", () => {
     await expect(caller.get({ id: "appointment-1" })).resolves.toBe(appointmentRow)
     await expect(caller.get({ id: "missing" })).rejects.toMatchObject(
       new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" }),
+    )
+  })
+
+  it("gets a bank account with legal entity only", async () => {
+    const caller = bankAccountsRouter.createCaller(ctx)
+    const bankAccountRow = { id: "bank-account-1", legalEntity: { id: "legal-entity-1" } }
+    dbMock.query.bankAccount.findFirst.mockResolvedValue(bankAccountRow)
+
+    await expect(caller.get({ id: "bank-account-1" })).resolves.toBe(bankAccountRow)
+    expect(dbMock.query.bankAccount.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        with: { legalEntity: true },
+      }),
     )
   })
 

--- a/packages/api/src/routers/salons.ts
+++ b/packages/api/src/routers/salons.ts
@@ -13,13 +13,13 @@ const salonSchema = z.object({
 })
 
 export const salonsRouter = router({
-  list: protectedProcedure.query(() => {
+  list: protectedProcedure.input(z.object({}).optional().default({})).query(() => {
     return db.query.salon.findMany({
       orderBy: (s, { asc }) => [asc(s.name)],
     })
   }),
 
-  byId: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
     const result = await db.query.salon.findFirst({ where: eq(salon.id, input.id) })
     if (!result) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Salon not found" })

--- a/packages/api/src/routers/transactions.ts
+++ b/packages/api/src/routers/transactions.ts
@@ -2,10 +2,11 @@ import { db } from "@prive-admin-tanstack/db"
 import { appointment, personnelOnAppointments } from "@prive-admin-tanstack/db/schema/appointment"
 import { transaction } from "@prive-admin-tanstack/db/schema/transaction"
 import { TRPCError } from "@trpc/server"
-import { eq } from "drizzle-orm"
+import { and, count, eq } from "drizzle-orm"
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const currencySchema = z.enum(["GBP", "EUR"])
 
@@ -16,23 +17,43 @@ const transactionFieldsSchema = z.object({
   currency: currencySchema,
 })
 
+const transactionListSchema = pageSchema.extend({
+  appointmentId: z.string().optional(),
+  customerId: z.string().optional(),
+  currency: currencySchema.optional(),
+})
+
 export const transactionsRouter = router({
-  byAppointmentId: protectedProcedure.input(z.object({ appointmentId: z.string() })).query(async ({ input }) => {
-    const appointmentRow = await db.query.appointment.findFirst({
-      where: eq(appointment.id, input.appointmentId),
-      columns: { id: true },
-    })
-    if (!appointmentRow) {
-      throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" })
+  list: protectedProcedure.input(transactionListSchema).query(async ({ input }) => {
+    if (input.appointmentId) {
+      const appointmentRow = await db.query.appointment.findFirst({
+        where: eq(appointment.id, input.appointmentId),
+        columns: { id: true },
+      })
+      if (!appointmentRow) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" })
+      }
     }
 
-    return db.query.transaction.findMany({
-      where: eq(transaction.appointmentId, input.appointmentId),
+    const conditions = []
+    if (input.appointmentId) conditions.push(eq(transaction.appointmentId, input.appointmentId))
+    if (input.customerId) conditions.push(eq(transaction.customerId, input.customerId))
+    if (input.currency) conditions.push(eq(transaction.currency, input.currency))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+
+    const items = await db.query.transaction.findMany({
+      where,
       with: {
         customer: { columns: { id: true, name: true } },
       },
       orderBy: (tx, { asc }) => [asc(tx.createdAt)],
+      limit: input.pageSize,
+      offset: getOffset(input),
     })
+
+    const [countRow] = await db.select({ totalCount: count() }).from(transaction).where(where)
+
+    return pagedResult(items, input, countRow?.totalCount ?? 0)
   }),
 
   create: protectedProcedure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,39 +288,24 @@ importers:
 
   apps/server:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.1068.0
-        version: 3.1079.0
       '@hono/node-server':
         specifier: 'catalog:'
         version: 1.19.14(hono@4.12.27)
       '@hono/trpc-server':
         specifier: 'catalog:'
         version: 0.4.2(@trpc/server@11.18.0(typescript@6.0.3))(hono@4.12.27)
-      '@paralleldrive/cuid2':
-        specifier: ^3.3.0
-        version: 3.3.0
       '@prive-admin-tanstack/api':
         specifier: workspace:*
         version: link:../../packages/api
       '@prive-admin-tanstack/auth':
         specifier: workspace:*
         version: link:../../packages/auth
-      '@prive-admin-tanstack/db':
-        specifier: workspace:*
-        version: link:../../packages/db
       '@prive-admin-tanstack/env':
         specifier: workspace:*
         version: link:../../packages/env
       '@trpc/server':
         specifier: 'catalog:'
         version: 11.18.0(typescript@6.0.3)
-      archiver:
-        specifier: ^8.0.0
-        version: 8.0.0
-      drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)
       hono:
         specifier: 'catalog:'
         version: 4.12.27
@@ -328,9 +313,6 @@ importers:
       '@prive-admin-tanstack/config':
         specifier: workspace:*
         version: link:../../packages/config
-      '@types/archiver':
-        specifier: ^6.0.3
-        version: 6.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.4
@@ -446,6 +428,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1068.0
         version: 3.1079.0
+      '@paralleldrive/cuid2':
+        specifier: ^3.3.0
+        version: 3.3.0
       '@prive-admin-tanstack/auth':
         specifier: workspace:*
         version: link:../auth
@@ -458,6 +443,9 @@ importers:
       '@trpc/server':
         specifier: 'catalog:'
         version: 11.18.0(typescript@6.0.3)
+      archiver:
+        specifier: ^8.0.0
+        version: 8.0.0
       csv-parse:
         specifier: ^6.2.1
         version: 6.2.1
@@ -474,6 +462,9 @@ importers:
       '@prive-admin-tanstack/config':
         specifier: workspace:*
         version: link:../config
+      '@types/archiver':
+        specifier: ^6.0.3
+        version: 6.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.4


### PR DESCRIPTION
## Summary
- Standardize tRPC routers around resource-style list/get/create/update/delete contracts without adding missing CRUD operations
- Add shared pagination helpers and update web call sites for paged envelopes, server-backed customer search, and visible pagination/overflow states
- Keep Hono REST file/auth endpoints unchanged and document the accepted design/plan

## Test Plan
- vp run -r check-types
- vp check
- vp test
- vp build apps/web
- vp run --filter server build
- rg -n "\.(byId|byCustomerId|byAppointmentId|byCustomer|byAppointment|updateMaster|unassigned)\b" packages/api/src apps/web/src