### PR TITLE
fix: customer paging

### DIFF
--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -12,7 +12,7 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
-const PAGE_SIZE = 25
+const PAGE_SIZE = 10
 const searchSchema = z.object({
   page: z.number().int().min(1).optional(),
   search: z.string().optional(),

--- a/packages/api/src/routers/customers.ts
+++ b/packages/api/src/routers/customers.ts
@@ -9,7 +9,7 @@ import { z } from "zod"
 
 import { toTrpcError } from "../errors"
 import { protectedProcedure, router } from "../index"
-import { pagedResult, pageSchema, searchSchema } from "../pagination"
+import { getOffset, pagedResult, pageSchema, searchSchema } from "../pagination"
 
 const customerInputSchema = z.object({
   id: z.string().optional(),
@@ -26,7 +26,11 @@ const customerListSchema = pageSchema.extend({ search: searchSchema })
 
 export const customersRouter = router({
   list: protectedProcedure.input(customerListSchema).query(async ({ input }) => {
-    const { items, totalCount } = await listCustomers(input.search ?? undefined)
+    const { items, totalCount } = await listCustomers({
+      pageSize: input.pageSize,
+      offset: getOffset(input),
+      search: input.search,
+    })
     return pagedResult(items, input, totalCount)
   }),
 

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { appointmentsRouter } from "./appointments"
 import { bankAccountsRouter } from "./bank-accounts"
+import { customersRouter } from "./customers"
 import { transactionsRouter } from "./transactions"
 
 const servicesMock = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const servicesMock = vi.hoisted(() => ({
   createBankAccount: vi.fn(),
   getBankAccount: vi.fn(),
   updateBankAccount: vi.fn(),
+  listCustomers: vi.fn(),
   createTransaction: vi.fn(),
   deleteTransaction: vi.fn(),
   listTransactions: vi.fn(),
@@ -84,6 +86,23 @@ describe("resource read routers", () => {
         pageSize: 25,
         offset: 0,
         appointmentId: "appointment-1",
+      }),
+    )
+  })
+
+  it("lists customers with page offset applied", async () => {
+    const caller = customersRouter.createCaller(ctx)
+    const customerRows = [{ id: "customer-1", name: "Anna" }]
+    servicesMock.listCustomers.mockResolvedValue({ items: customerRows, totalCount: 31 })
+
+    const result = await caller.list({ page: 2, pageSize: 10, search: "ann" })
+
+    expect(result).toEqual({ items: customerRows, page: 2, pageSize: 10, totalCount: 31 })
+    expect(servicesMock.listCustomers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageSize: 10,
+        offset: 10,
+        search: "ann",
       }),
     )
   })

--- a/packages/application/src/services/customers.test.ts
+++ b/packages/application/src/services/customers.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { listCustomers } from "./customers"
+
+const dbMock = vi.hoisted(() => ({
+  createCustomer: vi.fn(),
+  getCustomer: vi.fn(),
+  getCustomerSummary: vi.fn(),
+  listCustomers: vi.fn(),
+  updateCustomer: vi.fn(),
+}))
+
+vi.mock("@prive-admin-tanstack/db", () => dbMock)
+
+describe("customer service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("forwards paging and search to the database layer", async () => {
+    dbMock.listCustomers.mockResolvedValue({ items: [], totalCount: 0 })
+
+    await listCustomers({ offset: 50, pageSize: 25, search: "ann" })
+
+    expect(dbMock.listCustomers).toHaveBeenCalledWith(undefined, {
+      offset: 50,
+      pageSize: 25,
+      search: "ann",
+    })
+  })
+})

--- a/packages/application/src/services/customers.ts
+++ b/packages/application/src/services/customers.ts
@@ -18,8 +18,8 @@ type CustomerSummaryRow = {
   notes: Array<{ id: string }>
 }
 
-export async function listCustomers(search?: string) {
-  return fetchCustomers(undefined, { search })
+export async function listCustomers(input: { pageSize: number; offset: number; search?: string }) {
+  return fetchCustomers(undefined, input)
 }
 
 export async function getCustomer(id: string) {

--- a/packages/db/src/repositories/customers.ts
+++ b/packages/db/src/repositories/customers.ts
@@ -1,9 +1,11 @@
 import { asc, count, eq, ilike, or } from "drizzle-orm"
 
 import { db, type Db } from "../index"
-import { customer } from "../schema/customer"
+import { customer } from "../schema"
 
 export type CustomerListFilter = {
+  pageSize: number
+  offset: number
   search?: string
 }
 
@@ -17,7 +19,7 @@ function escapeLikePattern(value: string) {
   return value.replace(/[\\%_]/g, "\\$&")
 }
 
-export async function listCustomers(database: Db = db, filter: CustomerListFilter = {}) {
+export async function listCustomers(database: Db = db, filter: CustomerListFilter) {
   const where = filter.search
     ? or(
         ilike(customer.name, `%${escapeLikePattern(filter.search)}%`),
@@ -25,7 +27,13 @@ export async function listCustomers(database: Db = db, filter: CustomerListFilte
       )
     : undefined
 
-  const items = await database.select().from(customer).where(where).orderBy(asc(customer.name))
+  const items = await database
+    .select()
+    .from(customer)
+    .where(where)
+    .orderBy(asc(customer.name))
+    .limit(filter.pageSize)
+    .offset(filter.offset)
 
   const [countRow] = await database.select({ totalCount: count() }).from(customer).where(where)
   return { items, totalCount: countRow?.totalCount ?? 0 }


### PR DESCRIPTION
## Summary
- Fix customers list pagination by forwarding page, pageSize, and search through the API and service layers.
- Apply limit and offset in the customer repository query.

## Verification
- `vp test run src/routers/resource-reads.test.ts` in `packages/api`
- `vp test run src/services/customers.test.ts` in `packages/application`
- `vp run check-types` in `packages/api`, `packages/application`, and `packages/db`
- `vp check`

Closes #231
