### PR TITLE
fix: restore monthly dashboard cards

### DIFF
--- a/apps/web/src/lib/dashboard-monthly-stats.test.ts
+++ b/apps/web/src/lib/dashboard-monthly-stats.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import {
+  calculateMonthlyMetric,
+  monthKeyFromDate,
+  previousMonth,
+  selectedMonthData,
+  selectedYearInputs,
+} from "./dashboard-monthly-stats"
+
+describe("dashboard monthly stats helpers", () => {
+  it("formats dates as stable URL month keys", () => {
+    expect(monthKeyFromDate(new Date(2026, 0, 15))).toBe("2026-01")
+    expect(monthKeyFromDate(new Date(2026, 10, 1))).toBe("2026-11")
+  })
+
+  it("calculates the previous month across a year boundary", () => {
+    expect(previousMonth({ year: 2026, month: 1 })).toEqual({ year: 2025, month: 12 })
+    expect(previousMonth({ year: 2026, month: 7 })).toEqual({ year: 2026, month: 6 })
+  })
+
+  it("requests the previous year only when January needs a December comparison", () => {
+    expect(selectedYearInputs({ year: 2026, month: 1 })).toEqual({ currentYear: 2026, previousYear: 2025 })
+    expect(selectedYearInputs({ year: 2026, month: 7 })).toEqual({ currentYear: 2026, previousYear: undefined })
+  })
+
+  it("selects current and previous buckets for the chosen month", () => {
+    const currentYear = {
+      months: [
+        { month: 1, weight: 120, soldFor: 24000, profit: 9000, pricePerGram: 200 },
+        { month: 2, weight: 80, soldFor: 20000, profit: 7000, pricePerGram: 250 },
+      ],
+      totals: { weight: 200, soldFor: 44000, profit: 16000, pricePerGramAvg: 220 },
+    }
+
+    expect(selectedMonthData(currentYear, undefined, { year: 2026, month: 2 })).toEqual({
+      current: { month: 2, weight: 80, soldFor: 20000, profit: 7000, pricePerGram: 250 },
+      previous: { month: 1, weight: 120, soldFor: 24000, profit: 9000, pricePerGram: 200 },
+    })
+  })
+
+  it("uses the previous year bucket for January comparisons", () => {
+    const currentYear = {
+      months: [{ month: 1, weight: 50, soldFor: 10000, profit: 4000, pricePerGram: 200 }],
+      totals: { weight: 50, soldFor: 10000, profit: 4000, pricePerGramAvg: 200 },
+    }
+    const previousYear = {
+      months: [{ month: 12, weight: 70, soldFor: 14000, profit: 5000, pricePerGram: 200 }],
+      totals: { weight: 70, soldFor: 14000, profit: 5000, pricePerGramAvg: 200 },
+    }
+
+    expect(selectedMonthData(currentYear, previousYear, { year: 2026, month: 1 })).toEqual({
+      current: { month: 1, weight: 50, soldFor: 10000, profit: 4000, pricePerGram: 200 },
+      previous: { month: 12, weight: 70, soldFor: 14000, profit: 5000, pricePerGram: 200 },
+    })
+  })
+
+  it("calculates monthly metric deltas without dividing by zero", () => {
+    expect(calculateMonthlyMetric(150, 100)).toEqual({
+      current: 150,
+      previous: 100,
+      difference: 50,
+      percentage: 50,
+    })
+    expect(calculateMonthlyMetric(25, 0)).toEqual({
+      current: 25,
+      previous: 0,
+      difference: 25,
+      percentage: 100,
+    })
+  })
+})

--- a/apps/web/src/lib/dashboard-monthly-stats.ts
+++ b/apps/web/src/lib/dashboard-monthly-stats.ts
@@ -1,0 +1,97 @@
+export type DashboardMonth = {
+  year: number
+  month: number
+}
+
+export type HairMonthBucket = {
+  month: number
+  weight: number
+  soldFor: number
+  profit: number
+  pricePerGram: number
+}
+
+export type HairMonthlyBreakdown = {
+  months: HairMonthBucket[]
+  totals: {
+    weight: number
+    soldFor: number
+    profit: number
+    pricePerGramAvg: number
+  }
+}
+
+export type MonthlyMetric = {
+  current: number
+  previous: number
+  difference: number
+  percentage: number
+}
+
+const EMPTY_HAIR_MONTH_BUCKET: HairMonthBucket = {
+  month: 0,
+  weight: 0,
+  soldFor: 0,
+  profit: 0,
+  pricePerGram: 0,
+}
+
+export function monthKeyFromDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  return `${year}-${month}`
+}
+
+export function dateFromMonthKey(monthKey: string): Date {
+  const [year, month] = monthKey.split("-").map(Number)
+  return new Date(year, month - 1, 1)
+}
+
+export function parseMonthKey(monthKey: string): DashboardMonth {
+  const [year, month] = monthKey.split("-").map(Number)
+  return { year, month }
+}
+
+export function previousMonth(selected: DashboardMonth): DashboardMonth {
+  if (selected.month === 1) return { year: selected.year - 1, month: 12 }
+  return { year: selected.year, month: selected.month - 1 }
+}
+
+export function selectedYearInputs(selected: DashboardMonth): { currentYear: number; previousYear?: number } {
+  return {
+    currentYear: selected.year,
+    previousYear: selected.month === 1 ? selected.year - 1 : undefined,
+  }
+}
+
+export function selectedMonthData(
+  currentYearData: HairMonthlyBreakdown | undefined,
+  previousYearData: HairMonthlyBreakdown | undefined,
+  selected: DashboardMonth,
+): { current: HairMonthBucket; previous: HairMonthBucket } {
+  const prior = previousMonth(selected)
+  const previousSource = prior.year === selected.year ? currentYearData : previousYearData
+
+  return {
+    current: currentYearData?.months.find((month) => month.month === selected.month) ?? {
+      ...EMPTY_HAIR_MONTH_BUCKET,
+      month: selected.month,
+    },
+    previous: previousSource?.months.find((month) => month.month === prior.month) ?? {
+      ...EMPTY_HAIR_MONTH_BUCKET,
+      month: prior.month,
+    },
+  }
+}
+
+export function calculateMonthlyMetric(current: number, previous: number): MonthlyMetric {
+  const difference = current - previous
+  const percentage = previous !== 0 ? (difference / Math.abs(previous)) * 100 : current > 0 ? 100 : 0
+
+  return {
+    current,
+    previous,
+    difference,
+    percentage: Math.round(percentage * 100) / 100,
+  }
+}

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -1,154 +1,270 @@
-import { Group, NumberInput, Paper, Stack, Table, Text, Title } from "@mantine/core"
+import { ActionIcon, Badge, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
+import { MonthPickerInput } from "@mantine/dates"
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
-import { formatMinor } from "@/lib/currency"
+import { PageHeader } from "@/components/page-header"
+import { Section } from "@/components/section"
+import { formatMinor, type Currency } from "@/lib/currency"
+import {
+  calculateMonthlyMetric,
+  dateFromMonthKey,
+  monthKeyFromDate,
+  parseMonthKey,
+  previousMonth,
+  selectedMonthData,
+  selectedYearInputs,
+  type HairMonthlyBreakdown,
+  type MonthlyMetric,
+} from "@/lib/dashboard-monthly-stats"
 import { trpc } from "@/utils/trpc"
 
-const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-
+const monthSearchSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/)
 const searchSchema = z.object({
-  year: z.number().int().min(2000).max(3000).optional(),
+  month: monthSearchSchema.optional(),
 })
+
+type TransactionStatsByCurrency = {
+  currency: string
+  months: { month: number; total: number }[]
+  total: number
+}
 
 export const Route = createFileRoute("/_authenticated/dashboard")({
   component: DashboardPage,
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => ({
-    year: search.year ?? new Date().getFullYear(),
-  }),
+  loaderDeps: ({ search }) => {
+    const selected = parseMonthKey(search.month ?? monthKeyFromDate(new Date()))
+    return selectedYearInputs(selected)
+  },
   loader: async ({ context, deps }) => {
-    await Promise.all([
-      context.queryClient.ensureQueryData(trpc.dashboard.hairAssignedStats.queryOptions({ year: deps.year })),
+    const queries = [
+      context.queryClient.ensureQueryData(trpc.dashboard.transactionStats.queryOptions({ year: deps.currentYear })),
+      context.queryClient.ensureQueryData(trpc.dashboard.hairAssignedStats.queryOptions({ year: deps.currentYear })),
       context.queryClient.ensureQueryData(
-        trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: deps.year }),
+        trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: deps.currentYear }),
       ),
-    ])
+    ]
+
+    if (deps.previousYear) {
+      queries.push(
+        context.queryClient.ensureQueryData(trpc.dashboard.transactionStats.queryOptions({ year: deps.previousYear })),
+        context.queryClient.ensureQueryData(trpc.dashboard.hairAssignedStats.queryOptions({ year: deps.previousYear })),
+        context.queryClient.ensureQueryData(
+          trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: deps.previousYear }),
+        ),
+      )
+    }
+
+    await Promise.all(queries)
   },
 })
 
 function DashboardPage() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
-  const currentYear = new Date().getFullYear()
-  const year = search.year ?? currentYear
+  const selectedMonthKey = search.month ?? monthKeyFromDate(new Date())
+  const selected = parseMonthKey(selectedMonthKey)
+  const { currentYear, previousYear } = selectedYearInputs(selected)
+  const monthDate = dateFromMonthKey(selectedMonthKey)
 
-  const { data: appointmentsData } = useQuery(trpc.dashboard.hairAssignedStats.queryOptions({ year }))
-  const { data: salesData } = useQuery(trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year }))
+  const { data: transactionData } = useQuery(trpc.dashboard.transactionStats.queryOptions({ year: currentYear }))
+  const { data: previousTransactionData } = useQuery({
+    ...trpc.dashboard.transactionStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  })
+  const { data: appointmentsData } = useQuery(trpc.dashboard.hairAssignedStats.queryOptions({ year: currentYear }))
+  const { data: previousAppointmentsData } = useQuery({
+    ...trpc.dashboard.hairAssignedStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  })
+  const { data: salesData } = useQuery(trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: currentYear }))
+  const { data: previousSalesData } = useQuery({
+    ...trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  })
 
-  const setYear = (next: number) => navigate({ search: { year: next } })
+  const goToMonth = (date: Date | null) => {
+    if (!date) return
+    navigate({ search: { month: monthKeyFromDate(date) } })
+  }
+
+  const changeMonth = (offset: number) => {
+    navigate({
+      search: {
+        month: monthKeyFromDate(new Date(selected.year, selected.month - 1 + offset, 1)),
+      },
+    })
+  }
 
   return (
-    <Stack gap="lg">
-      <Group justify="space-between" align="flex-end">
-        <Stack gap={2}>
-          <Title order={3} fw={600} lh={1.3}>
-            Dashboard
-          </Title>
-          <Text size="sm" c="dimmed">
-            Hair assignment reports for the selected year.
-          </Text>
-        </Stack>
-        <NumberInput
-          value={year}
-          onChange={(v) => setYear(typeof v === "number" ? v : Number(v) || currentYear)}
-          min={2000}
-          max={3000}
-          allowDecimal={false}
-          w={110}
-          size="sm"
-          aria-label="Year"
-        />
-      </Group>
+    <Container size="xl">
+      <PageHeader
+        title="Dashboard"
+        description="Monthly performance against the previous month."
+        actions={
+          <Group gap="xs" wrap="nowrap">
+            <ActionIcon variant="default" aria-label="Previous month" onClick={() => changeMonth(-1)}>
+              <IconChevronLeft size={16} />
+            </ActionIcon>
+            <MonthPickerInput
+              aria-label="Dashboard month"
+              value={monthDate}
+              onChange={(value) => goToMonth(value ? new Date(value) : null)}
+              valueFormat="MMMM YYYY"
+              popoverProps={{ withinPortal: false }}
+              w={190}
+            />
+            <ActionIcon variant="default" aria-label="Next month" onClick={() => changeMonth(1)}>
+              <IconChevronRight size={16} />
+            </ActionIcon>
+          </Group>
+        }
+      />
 
-      <HairReportTable
-        title="Hair assigned during appointments"
-        description="Hair assigned through appointments, grouped by appointment month."
-        data={appointmentsData}
-      />
-      <HairReportTable
-        title="Hair assigned during sale"
-        description="Hair assigned without an appointment, grouped by sale month."
-        data={salesData}
-      />
-    </Stack>
+      <Stack gap="lg">
+        <TransactionStatsSection
+          currentYearData={transactionData}
+          previousYearData={previousTransactionData}
+          selected={selected}
+        />
+        <HairStatsSection
+          title="Hair assigned during appointments"
+          currentYearData={appointmentsData}
+          previousYearData={previousAppointmentsData}
+          selected={selected}
+        />
+        <HairStatsSection
+          title="Hair assigned during sale"
+          currentYearData={salesData}
+          previousYearData={previousSalesData}
+          selected={selected}
+        />
+      </Stack>
+    </Container>
   )
 }
 
-function HairReportTable({
+function TransactionStatsSection({
+  currentYearData,
+  previousYearData,
+  selected,
+}: {
+  currentYearData: TransactionStatsByCurrency[] | undefined
+  previousYearData: TransactionStatsByCurrency[] | undefined
+  selected: { year: number; month: number }
+}) {
+  const prior = previousMonth(selected)
+  const previousSource = prior.year === selected.year ? currentYearData : previousYearData
+  const currencies = Array.from(
+    new Set([
+      ...(currentYearData ?? []).map((item) => item.currency),
+      ...(previousSource ?? []).map((item) => item.currency),
+    ]),
+  ).sort()
+
+  return (
+    <Section title="Transactions" description="Appointment transaction movement for the selected month.">
+      {currencies.length > 0 ? (
+        <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }}>
+          {currencies.map((currency) => {
+            const current = currentYearData
+              ?.find((item) => item.currency === currency)
+              ?.months.find((m) => m.month === selected.month)
+            const previous = previousSource
+              ?.find((item) => item.currency === currency)
+              ?.months.find((m) => m.month === prior.month)
+            return (
+              <MetricCard
+                key={currency}
+                label={`Transactions ${currency}`}
+                metric={calculateMonthlyMetric(current?.total ?? 0, previous?.total ?? 0)}
+                formatValue={(value) => formatMinor(value, currency as Currency)}
+              />
+            )
+          })}
+        </SimpleGrid>
+      ) : (
+        <Text size="sm" c="dimmed">
+          No transaction data for this month.
+        </Text>
+      )}
+    </Section>
+  )
+}
+
+function HairStatsSection({
   title,
-  description,
-  data,
+  currentYearData,
+  previousYearData,
+  selected,
 }: {
   title: string
-  description: string
-  data:
-    | {
-        months: { month: number; weight: number; soldFor: number; profit: number; pricePerGram: number }[]
-        totals: { weight: number; soldFor: number; profit: number; pricePerGramAvg: number }
-      }
-    | undefined
+  currentYearData: HairMonthlyBreakdown | undefined
+  previousYearData: HairMonthlyBreakdown | undefined
+  selected: { year: number; month: number }
 }) {
+  const { current, previous } = selectedMonthData(currentYearData, previousYearData, selected)
+
   return (
-    <Paper withBorder radius="sm" p="md">
-      <Stack gap="md">
-        <Stack gap={2}>
-          <Title order={4} fw={600} lh={1.3}>
-            {title}
-          </Title>
-          <Text size="sm" c="dimmed">
-            {description}
+    <Section title={title}>
+      <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }}>
+        <MetricCard
+          label="Weight"
+          metric={calculateMonthlyMetric(current.weight, previous.weight)}
+          formatValue={(value) => `${value}g`}
+        />
+        <MetricCard
+          label="Sold for"
+          metric={calculateMonthlyMetric(current.soldFor, previous.soldFor)}
+          formatValue={(value) => formatMinor(value, "EUR")}
+        />
+        <MetricCard
+          label="Profit"
+          metric={calculateMonthlyMetric(current.profit, previous.profit)}
+          formatValue={(value) => formatMinor(value, "EUR")}
+        />
+        <MetricCard
+          label="Avg price/gram"
+          metric={calculateMonthlyMetric(current.pricePerGram, previous.pricePerGram)}
+          formatValue={(value) => formatMinor(value, "EUR")}
+        />
+      </SimpleGrid>
+    </Section>
+  )
+}
+
+function MetricCard({
+  label,
+  metric,
+  formatValue,
+}: {
+  label: string
+  metric: MonthlyMetric
+  formatValue: (value: number) => string
+}) {
+  const positive = metric.difference >= 0
+
+  return (
+    <Card padding="md">
+      <Stack gap="xs">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Text size="xs" c="dimmed">
+            {label}
           </Text>
-        </Stack>
-        {data ? (
-          <Table.ScrollContainer minWidth={640}>
-            <Table striped highlightOnHover verticalSpacing="xs">
-              <Table.Thead>
-                <Table.Tr>
-                  <Table.Th>Month</Table.Th>
-                  <Table.Th ta="right">Weight</Table.Th>
-                  <Table.Th ta="right">Sold for</Table.Th>
-                  <Table.Th ta="right">Profit</Table.Th>
-                  <Table.Th ta="right">Avg €/g</Table.Th>
-                </Table.Tr>
-              </Table.Thead>
-              <Table.Tbody>
-                {data.months.map((month) => (
-                  <Table.Tr key={month.month}>
-                    <Table.Td>{MONTH_NAMES[month.month - 1]}</Table.Td>
-                    <Table.Td ta="right">{month.weight}g</Table.Td>
-                    <Table.Td ta="right">{formatMinor(month.soldFor, "EUR")}</Table.Td>
-                    <Table.Td ta="right" c={month.profit >= 0 ? "teal" : "red"} fw={500}>
-                      {formatMinor(month.profit, "EUR")}
-                    </Table.Td>
-                    <Table.Td ta="right">{formatMinor(month.pricePerGram, "EUR")}</Table.Td>
-                  </Table.Tr>
-                ))}
-                <Table.Tr>
-                  <Table.Td fw={600}>Total</Table.Td>
-                  <Table.Td ta="right" fw={600}>
-                    {data.totals.weight}g
-                  </Table.Td>
-                  <Table.Td ta="right" fw={600}>
-                    {formatMinor(data.totals.soldFor, "EUR")}
-                  </Table.Td>
-                  <Table.Td ta="right" fw={700} c={data.totals.profit >= 0 ? "teal" : "red"}>
-                    {formatMinor(data.totals.profit, "EUR")}
-                  </Table.Td>
-                  <Table.Td ta="right" fw={600}>
-                    {formatMinor(data.totals.pricePerGramAvg, "EUR")}
-                  </Table.Td>
-                </Table.Tr>
-              </Table.Tbody>
-            </Table>
-          </Table.ScrollContainer>
-        ) : (
-          <Text c="dimmed" size="sm">
-            No report data.
-          </Text>
-        )}
+          <Badge color={positive ? "teal" : "red"} variant="light">
+            {positive ? "+" : ""}
+            {metric.percentage}%
+          </Badge>
+        </Group>
+        <Title order={4}>{formatValue(metric.current)}</Title>
+        <Text size="xs" c="dimmed">
+          Previous {formatValue(metric.previous)} · {positive ? "+" : ""}
+          {formatValue(metric.difference)}
+        </Text>
       </Stack>
-    </Paper>
+    </Card>
   )
 }

--- a/packages/db/src/repositories/dashboard.test.ts
+++ b/packages/db/src/repositories/dashboard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vite-plus/test"
+
+import { appointment } from "../schema/appointment"
+import { transaction } from "../schema/transaction"
+import { transactionMonthlyRows } from "./dashboard"
+
+vi.mock("../index", () => ({ db: {} }))
+
+describe("dashboard repository", () => {
+  it("builds transaction dashboard stats from appointment-linked transaction rows", async () => {
+    const calls: { from?: unknown; innerJoin?: { table: unknown; condition: unknown } } = {}
+    const builder = {
+      from: vi.fn((table: unknown) => {
+        calls.from = table
+        return builder
+      }),
+      groupBy: vi.fn(async () => []),
+      innerJoin: vi.fn((table: unknown, condition: unknown) => {
+        calls.innerJoin = { table, condition }
+        return builder
+      }),
+      where: vi.fn(() => builder),
+    }
+    const database = {
+      select: vi.fn(() => builder),
+    }
+
+    await transactionMonthlyRows(database as never, { year: 2026 })
+
+    expect(calls.from).toBe(transaction)
+    expect(calls.innerJoin?.table).toBe(appointment)
+  })
+})

--- a/packages/db/src/repositories/dashboard.ts
+++ b/packages/db/src/repositories/dashboard.ts
@@ -1,36 +1,29 @@
-import { and, eq, gte, isNull, lt, sql } from "drizzle-orm"
+import { and, eq, gte, isNotNull, isNull, lt, sql } from "drizzle-orm"
 
 import { db, type Db } from "../index"
 import { appointment } from "../schema/appointment"
-import { bankAccount } from "../schema/bank-account"
-import { bankStatementEntry } from "../schema/bank-statement-entry"
 import { hairAssigned } from "../schema/hair"
+import { transaction } from "../schema/transaction"
 
 export async function transactionMonthlyRows(database: Db = db, input: { year: number; legalEntityId?: string }) {
-  const yearStart = `${input.year}-01-01`
-  const yearEnd = `${input.year + 1}-01-01`
+  const yearStart = new Date(Date.UTC(input.year, 0, 1))
+  const yearEnd = new Date(Date.UTC(input.year + 1, 0, 1))
   return database
     .select({
-      currency: bankStatementEntry.currency,
-      month: sql<number>`extract(month from ${bankStatementEntry.date})::int`,
-      sum: sql<number>`coalesce(sum(
-        case
-          when ${bankStatementEntry.direction} = 'C' then ${bankStatementEntry.amount}
-          when ${bankStatementEntry.direction} = 'D' then -${bankStatementEntry.amount}
-          else 0
-        end
-      ), 0)::int`,
+      currency: transaction.currency,
+      month: sql<number>`extract(month from ${appointment.startsAt})::int`,
+      sum: sql<number>`coalesce(sum(${transaction.amount}), 0)::int`,
     })
-    .from(bankStatementEntry)
-    .innerJoin(bankAccount, eq(bankStatementEntry.bankAccountId, bankAccount.id))
+    .from(transaction)
+    .innerJoin(appointment, eq(transaction.appointmentId, appointment.id))
     .where(
       and(
-        gte(bankStatementEntry.date, yearStart),
-        lt(bankStatementEntry.date, yearEnd),
-        input.legalEntityId ? eq(bankAccount.legalEntityId, input.legalEntityId) : undefined,
+        gte(appointment.startsAt, yearStart),
+        lt(appointment.startsAt, yearEnd),
+        isNotNull(transaction.appointmentId),
       ),
     )
-    .groupBy(bankStatementEntry.currency, sql`extract(month from ${bankStatementEntry.date})`)
+    .groupBy(transaction.currency, sql`extract(month from ${appointment.startsAt})`)
 }
 
 export async function hairAssignedMonthlyRows(database: Db = db, input: { year: number }) {


### PR DESCRIPTION
## Summary
- Replace dashboard annual hair tables with month picker navigation and monthly stat cards
- Restore Transactions dashboard stats to appointment-linked transactions grouped by appointment month
- Add helper and repository tests for month selection/comparison and transaction query source

## Verification
- vp test run src/repositories/dashboard.test.ts
- vp test run src/lib/dashboard-monthly-stats.test.ts
- vp run --filter @prive-admin-tanstack/db check-types
- vp run --filter web check-types
- vp check
- vp run --filter web build

Note: full vp test still discovers unrelated .worktrees/dist tests and fails outside this change.