### PR TITLE
feat: add hair sales navigation

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -17,14 +17,17 @@ import { Route as AuthenticatedProfileRouteImport } from './routes/_authenticate
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
 import { Route as AuthenticatedCashRouteImport } from './routes/_authenticated/cash'
 import { Route as AuthenticatedCalendarRouteImport } from './routes/_authenticated/calendar'
+import { Route as AuthenticatedHairSalesRouteRouteImport } from './routes/_authenticated/hair-sales/route'
 import { Route as AuthenticatedHairOrdersRouteRouteImport } from './routes/_authenticated/hair-orders/route'
 import { Route as AuthenticatedCustomersRouteRouteImport } from './routes/_authenticated/customers/route'
 import { Route as AuthenticatedAppointmentsRouteRouteImport } from './routes/_authenticated/appointments/route'
 import { Route as AuthenticatedSalonsIndexRouteImport } from './routes/_authenticated/salons/index'
 import { Route as AuthenticatedLegalEntitiesIndexRouteImport } from './routes/_authenticated/legal-entities/index'
+import { Route as AuthenticatedHairSalesIndexRouteImport } from './routes/_authenticated/hair-sales/index'
 import { Route as AuthenticatedHairOrdersIndexRouteImport } from './routes/_authenticated/hair-orders/index'
 import { Route as AuthenticatedCustomersIndexRouteImport } from './routes/_authenticated/customers/index'
 import { Route as AuthenticatedSalonsSalonIdRouteImport } from './routes/_authenticated/salons/$salonId'
+import { Route as AuthenticatedHairSalesHairSaleIdRouteImport } from './routes/_authenticated/hair-sales/$hairSaleId'
 import { Route as AuthenticatedHairOrdersHairOrderIdRouteImport } from './routes/_authenticated/hair-orders/$hairOrderId'
 import { Route as AuthenticatedAppointmentsAppointmentIdRouteImport } from './routes/_authenticated/appointments/$appointmentId'
 import { Route as AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/route'
@@ -80,6 +83,12 @@ const AuthenticatedCalendarRoute = AuthenticatedCalendarRouteImport.update({
   path: '/calendar',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedHairSalesRouteRoute =
+  AuthenticatedHairSalesRouteRouteImport.update({
+    id: '/hair-sales',
+    path: '/hair-sales',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedHairOrdersRouteRoute =
   AuthenticatedHairOrdersRouteRouteImport.update({
     id: '/hair-orders',
@@ -110,6 +119,12 @@ const AuthenticatedLegalEntitiesIndexRoute =
     path: '/legal-entities/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedHairSalesIndexRoute =
+  AuthenticatedHairSalesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
+  } as any)
 const AuthenticatedHairOrdersIndexRoute =
   AuthenticatedHairOrdersIndexRouteImport.update({
     id: '/',
@@ -127,6 +142,12 @@ const AuthenticatedSalonsSalonIdRoute =
     id: '/salons/$salonId',
     path: '/salons/$salonId',
     getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedHairSalesHairSaleIdRoute =
+  AuthenticatedHairSalesHairSaleIdRouteImport.update({
+    id: '/$hairSaleId',
+    path: '/$hairSaleId',
+    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
   } as any)
 const AuthenticatedHairOrdersHairOrderIdRoute =
   AuthenticatedHairOrdersHairOrderIdRouteImport.update({
@@ -227,6 +248,7 @@ export interface FileRoutesByFullPath {
   '/appointments': typeof AuthenticatedAppointmentsRouteRouteWithChildren
   '/customers': typeof AuthenticatedCustomersRouteRouteWithChildren
   '/hair-orders': typeof AuthenticatedHairOrdersRouteRouteWithChildren
+  '/hair-sales': typeof AuthenticatedHairSalesRouteRouteWithChildren
   '/calendar': typeof AuthenticatedCalendarRoute
   '/cash': typeof AuthenticatedCashRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
@@ -236,9 +258,11 @@ export interface FileRoutesByFullPath {
   '/legal-entities/$legalEntityId': typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRouteWithChildren
   '/appointments/$appointmentId': typeof AuthenticatedAppointmentsAppointmentIdRoute
   '/hair-orders/$hairOrderId': typeof AuthenticatedHairOrdersHairOrderIdRoute
+  '/hair-sales/$hairSaleId': typeof AuthenticatedHairSalesHairSaleIdRoute
   '/salons/$salonId': typeof AuthenticatedSalonsSalonIdRoute
   '/customers/': typeof AuthenticatedCustomersIndexRoute
   '/hair-orders/': typeof AuthenticatedHairOrdersIndexRoute
+  '/hair-sales/': typeof AuthenticatedHairSalesIndexRoute
   '/legal-entities/': typeof AuthenticatedLegalEntitiesIndexRoute
   '/salons/': typeof AuthenticatedSalonsIndexRoute
   '/customers/$customerId/appointments': typeof AuthenticatedCustomersCustomerIdAppointmentsRoute
@@ -264,9 +288,11 @@ export interface FileRoutesByTo {
   '/settings': typeof AuthenticatedSettingsRoute
   '/appointments/$appointmentId': typeof AuthenticatedAppointmentsAppointmentIdRoute
   '/hair-orders/$hairOrderId': typeof AuthenticatedHairOrdersHairOrderIdRoute
+  '/hair-sales/$hairSaleId': typeof AuthenticatedHairSalesHairSaleIdRoute
   '/salons/$salonId': typeof AuthenticatedSalonsSalonIdRoute
   '/customers': typeof AuthenticatedCustomersIndexRoute
   '/hair-orders': typeof AuthenticatedHairOrdersIndexRoute
+  '/hair-sales': typeof AuthenticatedHairSalesIndexRoute
   '/legal-entities': typeof AuthenticatedLegalEntitiesIndexRoute
   '/salons': typeof AuthenticatedSalonsIndexRoute
   '/customers/$customerId/appointments': typeof AuthenticatedCustomersCustomerIdAppointmentsRoute
@@ -289,6 +315,7 @@ export interface FileRoutesById {
   '/_authenticated/appointments': typeof AuthenticatedAppointmentsRouteRouteWithChildren
   '/_authenticated/customers': typeof AuthenticatedCustomersRouteRouteWithChildren
   '/_authenticated/hair-orders': typeof AuthenticatedHairOrdersRouteRouteWithChildren
+  '/_authenticated/hair-sales': typeof AuthenticatedHairSalesRouteRouteWithChildren
   '/_authenticated/calendar': typeof AuthenticatedCalendarRoute
   '/_authenticated/cash': typeof AuthenticatedCashRoute
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
@@ -298,9 +325,11 @@ export interface FileRoutesById {
   '/_authenticated/legal-entities/$legalEntityId': typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRouteWithChildren
   '/_authenticated/appointments/$appointmentId': typeof AuthenticatedAppointmentsAppointmentIdRoute
   '/_authenticated/hair-orders/$hairOrderId': typeof AuthenticatedHairOrdersHairOrderIdRoute
+  '/_authenticated/hair-sales/$hairSaleId': typeof AuthenticatedHairSalesHairSaleIdRoute
   '/_authenticated/salons/$salonId': typeof AuthenticatedSalonsSalonIdRoute
   '/_authenticated/customers/': typeof AuthenticatedCustomersIndexRoute
   '/_authenticated/hair-orders/': typeof AuthenticatedHairOrdersIndexRoute
+  '/_authenticated/hair-sales/': typeof AuthenticatedHairSalesIndexRoute
   '/_authenticated/legal-entities/': typeof AuthenticatedLegalEntitiesIndexRoute
   '/_authenticated/salons/': typeof AuthenticatedSalonsIndexRoute
   '/_authenticated/customers/$customerId/appointments': typeof AuthenticatedCustomersCustomerIdAppointmentsRoute
@@ -323,6 +352,7 @@ export interface FileRouteTypes {
     | '/appointments'
     | '/customers'
     | '/hair-orders'
+    | '/hair-sales'
     | '/calendar'
     | '/cash'
     | '/dashboard'
@@ -332,9 +362,11 @@ export interface FileRouteTypes {
     | '/legal-entities/$legalEntityId'
     | '/appointments/$appointmentId'
     | '/hair-orders/$hairOrderId'
+    | '/hair-sales/$hairSaleId'
     | '/salons/$salonId'
     | '/customers/'
     | '/hair-orders/'
+    | '/hair-sales/'
     | '/legal-entities/'
     | '/salons/'
     | '/customers/$customerId/appointments'
@@ -360,9 +392,11 @@ export interface FileRouteTypes {
     | '/settings'
     | '/appointments/$appointmentId'
     | '/hair-orders/$hairOrderId'
+    | '/hair-sales/$hairSaleId'
     | '/salons/$salonId'
     | '/customers'
     | '/hair-orders'
+    | '/hair-sales'
     | '/legal-entities'
     | '/salons'
     | '/customers/$customerId/appointments'
@@ -384,6 +418,7 @@ export interface FileRouteTypes {
     | '/_authenticated/appointments'
     | '/_authenticated/customers'
     | '/_authenticated/hair-orders'
+    | '/_authenticated/hair-sales'
     | '/_authenticated/calendar'
     | '/_authenticated/cash'
     | '/_authenticated/dashboard'
@@ -393,9 +428,11 @@ export interface FileRouteTypes {
     | '/_authenticated/legal-entities/$legalEntityId'
     | '/_authenticated/appointments/$appointmentId'
     | '/_authenticated/hair-orders/$hairOrderId'
+    | '/_authenticated/hair-sales/$hairSaleId'
     | '/_authenticated/salons/$salonId'
     | '/_authenticated/customers/'
     | '/_authenticated/hair-orders/'
+    | '/_authenticated/hair-sales/'
     | '/_authenticated/legal-entities/'
     | '/_authenticated/salons/'
     | '/_authenticated/customers/$customerId/appointments'
@@ -475,6 +512,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCalendarRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/hair-sales': {
+      id: '/_authenticated/hair-sales'
+      path: '/hair-sales'
+      fullPath: '/hair-sales'
+      preLoaderRoute: typeof AuthenticatedHairSalesRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/hair-orders': {
       id: '/_authenticated/hair-orders'
       path: '/hair-orders'
@@ -510,6 +554,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedLegalEntitiesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/hair-sales/': {
+      id: '/_authenticated/hair-sales/'
+      path: '/'
+      fullPath: '/hair-sales/'
+      preLoaderRoute: typeof AuthenticatedHairSalesIndexRouteImport
+      parentRoute: typeof AuthenticatedHairSalesRouteRoute
+    }
     '/_authenticated/hair-orders/': {
       id: '/_authenticated/hair-orders/'
       path: '/'
@@ -530,6 +581,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/salons/$salonId'
       preLoaderRoute: typeof AuthenticatedSalonsSalonIdRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/hair-sales/$hairSaleId': {
+      id: '/_authenticated/hair-sales/$hairSaleId'
+      path: '/$hairSaleId'
+      fullPath: '/hair-sales/$hairSaleId'
+      preLoaderRoute: typeof AuthenticatedHairSalesHairSaleIdRouteImport
+      parentRoute: typeof AuthenticatedHairSalesRouteRoute
     }
     '/_authenticated/hair-orders/$hairOrderId': {
       id: '/_authenticated/hair-orders/$hairOrderId'
@@ -712,6 +770,23 @@ const AuthenticatedHairOrdersRouteRouteWithChildren =
     AuthenticatedHairOrdersRouteRouteChildren,
   )
 
+interface AuthenticatedHairSalesRouteRouteChildren {
+  AuthenticatedHairSalesHairSaleIdRoute: typeof AuthenticatedHairSalesHairSaleIdRoute
+  AuthenticatedHairSalesIndexRoute: typeof AuthenticatedHairSalesIndexRoute
+}
+
+const AuthenticatedHairSalesRouteRouteChildren: AuthenticatedHairSalesRouteRouteChildren =
+  {
+    AuthenticatedHairSalesHairSaleIdRoute:
+      AuthenticatedHairSalesHairSaleIdRoute,
+    AuthenticatedHairSalesIndexRoute: AuthenticatedHairSalesIndexRoute,
+  }
+
+const AuthenticatedHairSalesRouteRouteWithChildren =
+  AuthenticatedHairSalesRouteRoute._addFileChildren(
+    AuthenticatedHairSalesRouteRouteChildren,
+  )
+
 interface AuthenticatedLegalEntitiesLegalEntityIdRouteRouteChildren {
   AuthenticatedLegalEntitiesLegalEntityIdDocumentsRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdDocumentsRoute
   AuthenticatedLegalEntitiesLegalEntityIdOverviewRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdOverviewRoute
@@ -749,6 +824,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedAppointmentsRouteRoute: typeof AuthenticatedAppointmentsRouteRouteWithChildren
   AuthenticatedCustomersRouteRoute: typeof AuthenticatedCustomersRouteRouteWithChildren
   AuthenticatedHairOrdersRouteRoute: typeof AuthenticatedHairOrdersRouteRouteWithChildren
+  AuthenticatedHairSalesRouteRoute: typeof AuthenticatedHairSalesRouteRouteWithChildren
   AuthenticatedCalendarRoute: typeof AuthenticatedCalendarRoute
   AuthenticatedCashRoute: typeof AuthenticatedCashRoute
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
@@ -767,6 +843,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
     AuthenticatedCustomersRouteRouteWithChildren,
   AuthenticatedHairOrdersRouteRoute:
     AuthenticatedHairOrdersRouteRouteWithChildren,
+  AuthenticatedHairSalesRouteRoute:
+    AuthenticatedHairSalesRouteRouteWithChildren,
   AuthenticatedCalendarRoute: AuthenticatedCalendarRoute,
   AuthenticatedCashRoute: AuthenticatedCashRoute,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -1,8 +1,8 @@
-import { ActionIcon, Badge, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
+import { ActionIcon, Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
 import { MonthPickerInput } from "@mantine/dates"
-import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react"
+import { IconChevronLeft, IconChevronRight, IconEye } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
 import { PageHeader } from "@/components/page-header"
@@ -131,16 +131,20 @@ function DashboardPage() {
           selected={selected}
         />
         <HairStatsSection
-          title="Hair assigned during appointments"
+          title="Appointment hair sales"
           currentYearData={appointmentsData}
           previousYearData={previousAppointmentsData}
           selected={selected}
+          source="appointment"
+          selectedMonthKey={selectedMonthKey}
         />
         <HairStatsSection
-          title="Hair assigned during sale"
+          title="Individual hair sales"
           currentYearData={salesData}
           previousYearData={previousSalesData}
           selected={selected}
+          source="individual"
+          selectedMonthKey={selectedMonthKey}
         />
       </Stack>
     </Container>
@@ -200,16 +204,32 @@ function HairStatsSection({
   currentYearData,
   previousYearData,
   selected,
+  source,
+  selectedMonthKey,
 }: {
   title: string
   currentYearData: HairMonthlyBreakdown | undefined
   previousYearData: HairMonthlyBreakdown | undefined
   selected: { year: number; month: number }
+  source: "appointment" | "individual"
+  selectedMonthKey: string
 }) {
   const { current, previous } = selectedMonthData(currentYearData, previousYearData, selected)
 
   return (
-    <Section title={title}>
+    <Section
+      title={title}
+      actions={
+        <Button
+          renderRoot={(props) => <Link to="/hair-sales" search={{ source, month: selectedMonthKey }} {...props} />}
+          variant="default"
+          size="sm"
+          leftSection={<IconEye size={14} />}
+        >
+          View sales
+        </Button>
+      }
+    >
       <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }}>
         <MetricCard
           label="Weight"

--- a/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
@@ -1,0 +1,140 @@
+import { Anchor, Badge, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
+import { IconArrowLeft, IconCalendar, IconScissors, IconUser } from "@tabler/icons-react"
+import { useQuery } from "@tanstack/react-query"
+import { Link, createFileRoute } from "@tanstack/react-router"
+
+import { ClientDate } from "@/components/client-date"
+import { PageHeader } from "@/components/page-header"
+import { Section } from "@/components/section"
+import { trpc } from "@/utils/trpc"
+
+export const Route = createFileRoute("/_authenticated/hair-sales/$hairSaleId")({
+  component: HairSaleDetailPage,
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData(trpc.hairAssigned.get.queryOptions({ id: params.hairSaleId }))
+  },
+})
+
+const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
+
+function HairSaleDetailPage() {
+  const { hairSaleId } = Route.useParams()
+  const { data: sale } = useQuery(trpc.hairAssigned.get.queryOptions({ id: hairSaleId }))
+
+  if (!sale) {
+    return (
+      <Container size="xl">
+        <Text c="dimmed">Hair sale not found.</Text>
+      </Container>
+    )
+  }
+
+  return (
+    <Container size="xl">
+      <Anchor component={Link} to="/hair-sales" size="xs" c="dimmed" mb="xs" display="inline-block">
+        <Group gap={4}>
+          <IconArrowLeft size={12} />
+          Back to hair sales
+        </Group>
+      </Anchor>
+      <PageHeader
+        title={
+          <Group gap="sm">
+            <span>Hair sale</span>
+            <Badge variant="light" color={sale.appointmentId ? "blue" : "grape"}>
+              {sale.appointmentId ? "Appointment" : "Individual"}
+            </Badge>
+          </Group>
+        }
+        description={
+          <Group gap="sm">
+            <Group gap={4}>
+              <IconUser size={12} />
+              <Anchor
+                renderRoot={(props) => (
+                  <Link to="/customers/$customerId" params={{ customerId: sale.client.id }} {...props} />
+                )}
+                size="sm"
+              >
+                {sale.client.name}
+              </Anchor>
+            </Group>
+            <Text size="sm" c="dimmed">
+              Created by {sale.createdBy?.name ?? "Unknown"}
+            </Text>
+          </Group>
+        }
+      />
+
+      <Stack>
+        <SimpleGrid cols={{ base: 2, md: 4 }}>
+          <Card padding="md">
+            <Text size="xs" c="dimmed">
+              Weight
+            </Text>
+            <Title order={4}>{sale.weightInGrams}g</Title>
+          </Card>
+          <Card padding="md">
+            <Text size="xs" c="dimmed">
+              Sold for
+            </Text>
+            <Title order={4}>{formatCents(sale.soldFor)}</Title>
+          </Card>
+          <Card padding="md">
+            <Text size="xs" c="dimmed">
+              Profit
+            </Text>
+            <Title order={4}>{formatCents(sale.profit)}</Title>
+          </Card>
+          <Card padding="md">
+            <Text size="xs" c="dimmed">
+              Price/gram
+            </Text>
+            <Title order={4}>{formatCents(sale.pricePerGram)}</Title>
+          </Card>
+        </SimpleGrid>
+
+        <Section title="Sale links">
+          <Stack gap="sm">
+            <Group gap="xs">
+              <IconScissors size={16} />
+              <Text size="sm" c="dimmed">
+                Hair order
+              </Text>
+              <Anchor
+                renderRoot={(props) => (
+                  <Link to="/hair-orders/$hairOrderId" params={{ hairOrderId: sale.hairOrder.id }} {...props} />
+                )}
+              >
+                #{sale.hairOrder.uid}
+              </Anchor>
+            </Group>
+            {sale.appointmentId ? (
+              <Group gap="xs">
+                <IconCalendar size={16} />
+                <Text size="sm" c="dimmed">
+                  Appointment
+                </Text>
+                <Anchor
+                  renderRoot={(props) => (
+                    <Link
+                      to="/appointments/$appointmentId"
+                      params={{ appointmentId: sale.appointmentId! }}
+                      {...props}
+                    />
+                  )}
+                >
+                  <ClientDate date={sale.appointment?.startsAt ?? sale.createdAt} />
+                </Anchor>
+              </Group>
+            ) : (
+              <Text size="sm" c="dimmed">
+                Direct sale created <ClientDate date={sale.createdAt} />.
+              </Text>
+            )}
+          </Stack>
+        </Section>
+      </Stack>
+    </Container>
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/index.tsx
@@ -1,0 +1,252 @@
+import {
+  Anchor,
+  Badge,
+  Button,
+  Container,
+  Group,
+  Pagination,
+  SegmentedControl,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+} from "@mantine/core"
+import { MonthPickerInput } from "@mantine/dates"
+import { IconEye, IconSearch } from "@tabler/icons-react"
+import { useQuery } from "@tanstack/react-query"
+import { Link, createFileRoute, redirect } from "@tanstack/react-router"
+import { z } from "zod"
+
+import { ClientDate } from "@/components/client-date"
+import { PageHeader } from "@/components/page-header"
+import { Section } from "@/components/section"
+import { dateFromMonthKey, monthKeyFromDate } from "@/lib/dashboard-monthly-stats"
+import { trpc } from "@/utils/trpc"
+
+const PAGE_SIZE = 25
+const sourceSchema = z.enum(["all", "appointment", "individual"])
+const monthSearchSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/)
+const searchSchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  search: z.string().optional(),
+  source: sourceSchema.optional(),
+  month: monthSearchSchema.optional(),
+})
+
+function monthRange(month: string | undefined) {
+  if (!month) return {}
+  const [year, monthNumber] = month.split("-").map(Number)
+  const from = new Date(Date.UTC(year, monthNumber - 1, 1))
+  const to = new Date(Date.UTC(year, monthNumber, 1))
+  return { from, to }
+}
+
+function hairSalesQueryOptions(input: {
+  page: number
+  search: string
+  source: z.infer<typeof sourceSchema>
+  month?: string
+}) {
+  const range = monthRange(input.month)
+  return trpc.hairAssigned.list.queryOptions({
+    page: input.page,
+    pageSize: PAGE_SIZE,
+    search: input.search.trim() || undefined,
+    source: input.source === "all" ? undefined : input.source,
+    ...range,
+  })
+}
+
+export const Route = createFileRoute("/_authenticated/hair-sales/")({
+  component: HairSalesPage,
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({
+    page: search.page ?? 1,
+    search: search.search ?? "",
+    source: search.source ?? "all",
+    month: search.month,
+  }),
+  loader: async ({ context, deps }) => {
+    const data = await context.queryClient.ensureQueryData(hairSalesQueryOptions(deps))
+    const totalPages = Math.max(1, Math.ceil(data.totalCount / PAGE_SIZE))
+    if (deps.page > totalPages) {
+      throw redirect({
+        to: "/hair-sales",
+        search: { page: totalPages, search: deps.search, source: deps.source, month: deps.month },
+      })
+    }
+  },
+})
+
+type HairSale = {
+  id: string
+  appointmentId?: string | null
+  createdAt: string | Date
+  weightInGrams: number
+  soldFor: number
+  profit: number
+  pricePerGram: number
+  appointment?: { startsAt: string | Date } | null
+  client?: { id: string; name: string } | null
+  hairOrder?: { id: string; uid: number } | null
+}
+
+const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
+
+function HairSalesPage() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const source = search.source ?? "all"
+  const month = search.month
+  const monthDate = month ? dateFromMonthKey(month) : null
+  const queryOptions = hairSalesQueryOptions({ page, search: searchValue, source, month })
+  const { data, isLoading } = useQuery(queryOptions)
+  const hairSales = (data?.items ?? []) as HairSale[]
+  const totalCount = data?.totalCount ?? 0
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
+  const clampedPage = Math.min(page, totalPages)
+
+  const setSearch = (
+    next: Partial<{ page: number; search: string; source: z.infer<typeof sourceSchema>; month?: string }>,
+  ) =>
+    navigate({
+      search: {
+        page,
+        search: searchValue,
+        source,
+        month,
+        ...next,
+      },
+      replace: true,
+    })
+
+  return (
+    <Container size="xl">
+      <PageHeader
+        title="Hair sales"
+        description={month ? `Sales for ${month}.` : "Appointment and individual hair sales in one place."}
+      />
+      <Section padding={0}>
+        <Stack gap={0}>
+          <Group p="md" gap="sm" wrap="wrap">
+            <SegmentedControl
+              value={source}
+              onChange={(value) => setSearch({ page: 1, source: value as z.infer<typeof sourceSchema> })}
+              data={[
+                { value: "all", label: "All" },
+                { value: "appointment", label: "Appointment" },
+                { value: "individual", label: "Individual" },
+              ]}
+            />
+            <MonthPickerInput
+              aria-label="Filter hair sales by month"
+              placeholder="All months"
+              value={monthDate}
+              onChange={(value) => setSearch({ page: 1, month: value ? monthKeyFromDate(new Date(value)) : undefined })}
+              valueFormat="MMMM YYYY"
+              clearable
+              popoverProps={{ withinPortal: false }}
+              w={190}
+            />
+            <TextInput
+              aria-label="Search hair sales"
+              placeholder="Search client or order"
+              leftSection={<IconSearch size={16} />}
+              value={searchValue}
+              onChange={(event) => setSearch({ page: 1, search: event.currentTarget.value })}
+              w={260}
+            />
+          </Group>
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Client</Table.Th>
+                <Table.Th>Source</Table.Th>
+                <Table.Th>Hair order</Table.Th>
+                <Table.Th>Weight</Table.Th>
+                <Table.Th>Sold for</Table.Th>
+                <Table.Th>Profit</Table.Th>
+                <Table.Th>Date</Table.Th>
+                <Table.Th />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {hairSales.map((sale) => (
+                <Table.Tr key={sale.id}>
+                  <Table.Td>
+                    {sale.client ? (
+                      <Anchor
+                        renderRoot={(props) => (
+                          <Link to="/customers/$customerId" params={{ customerId: sale.client!.id }} {...props} />
+                        )}
+                      >
+                        {sale.client.name}
+                      </Anchor>
+                    ) : (
+                      "—"
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge variant="light" color={sale.appointmentId ? "blue" : "grape"}>
+                      {sale.appointmentId ? "Appointment" : "Individual"}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    {sale.hairOrder ? (
+                      <Anchor
+                        renderRoot={(props) => (
+                          <Link
+                            to="/hair-orders/$hairOrderId"
+                            params={{ hairOrderId: sale.hairOrder!.id }}
+                            {...props}
+                          />
+                        )}
+                      >
+                        #{sale.hairOrder.uid}
+                      </Anchor>
+                    ) : (
+                      "—"
+                    )}
+                  </Table.Td>
+                  <Table.Td>{sale.weightInGrams}g</Table.Td>
+                  <Table.Td>{formatCents(sale.soldFor)}</Table.Td>
+                  <Table.Td>{formatCents(sale.profit)}</Table.Td>
+                  <Table.Td>
+                    <ClientDate date={sale.appointment?.startsAt ?? sale.createdAt} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Button
+                      renderRoot={(props) => (
+                        <Link to="/hair-sales/$hairSaleId" params={{ hairSaleId: sale.id }} {...props} />
+                      )}
+                      variant="subtle"
+                      size="xs"
+                      leftSection={<IconEye size={14} />}
+                    >
+                      View
+                    </Button>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+              {!isLoading && hairSales.length === 0 && (
+                <Table.Tr>
+                  <Table.Td colSpan={8} ta="center" c="dimmed" py="xl">
+                    No hair sales match these filters.
+                  </Table.Td>
+                </Table.Tr>
+              )}
+            </Table.Tbody>
+          </Table>
+          <Group justify="space-between" p="md">
+            <Text size="sm" c="dimmed">
+              {totalCount} hair sale{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
+            </Text>
+            <Pagination value={clampedPage} total={totalPages} onChange={(nextPage) => setSearch({ page: nextPage })} />
+          </Group>
+        </Stack>
+      </Section>
+    </Container>
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/route.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/route.tsx
@@ -1,0 +1,5 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/_authenticated/hair-sales")({
+  component: () => <Outlet />,
+})

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -32,6 +32,7 @@ import {
   IconLayoutDashboard,
   IconLogout,
   IconMoon,
+  IconReceipt,
   IconRefresh,
   IconScissors,
   IconSettings,
@@ -61,6 +62,7 @@ const workspaceNav: NavItem[] = [
   { to: "/customers", label: "Customers", icon: IconUsers },
   { to: "/calendar", label: "Calendar", icon: IconCalendar },
   { to: "/hair-orders", label: "Hair orders", icon: IconScissors },
+  { to: "/hair-sales", label: "Hair sales", icon: IconReceipt },
   { to: "/cash", label: "Cash", icon: IconCash },
 ]
 

--- a/packages/api/src/routers/hair-assigned.ts
+++ b/packages/api/src/routers/hair-assigned.ts
@@ -2,6 +2,7 @@ import {
   availableHairOrders,
   createHairAssigned,
   deleteHairAssigned,
+  getHairAssigned,
   listHairAssigned,
   updateHairAssigned,
 } from "@prive-admin-tanstack/application/services"
@@ -14,6 +15,10 @@ import { getOffset, pagedResult, pageSchema } from "../pagination"
 const hairAssignedListSchema = pageSchema.extend({
   appointmentId: z.string().optional(),
   customerId: z.string().optional(),
+  source: z.enum(["appointment", "individual"]).optional(),
+  search: z.string().trim().min(1).optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
 })
 
 export const hairAssignedRouter = router({
@@ -24,8 +29,20 @@ export const hairAssignedRouter = router({
         offset: getOffset(input),
         appointmentId: input.appointmentId,
         customerId: input.customerId,
+        source: input.source,
+        search: input.search,
+        from: input.from,
+        to: input.to,
       })
       return pagedResult(result.items, input, result.totalCount)
+    } catch (error) {
+      throw toTrpcError(error)
+    }
+  }),
+
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
+    try {
+      return await getHairAssigned(input.id)
     } catch (error) {
       throw toTrpcError(error)
     }

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { appointmentsRouter } from "./appointments"
 import { bankAccountsRouter } from "./bank-accounts"
 import { customersRouter } from "./customers"
+import { hairAssignedRouter } from "./hair-assigned"
 import { transactionsRouter } from "./transactions"
 
 const servicesMock = vi.hoisted(() => ({
@@ -13,7 +14,9 @@ const servicesMock = vi.hoisted(() => ({
   updateAppointment: vi.fn(),
   createBankAccount: vi.fn(),
   getBankAccount: vi.fn(),
+  getHairAssigned: vi.fn(),
   updateBankAccount: vi.fn(),
+  listHairAssigned: vi.fn(),
   listCustomers: vi.fn(),
   listCustomerAppointments: vi.fn(),
   listCustomerHairAssigned: vi.fn(),
@@ -91,6 +94,44 @@ describe("resource read routers", () => {
         appointmentId: "appointment-1",
       }),
     )
+  })
+
+  it("lists hair sales with source, search, and date filters", async () => {
+    const caller = hairAssignedRouter.createCaller(ctx)
+    const hairRows = [{ id: "hair-sale-1", clientId: "customer-1" }]
+    servicesMock.listHairAssigned.mockResolvedValue({ items: hairRows, totalCount: 4 })
+    const from = new Date("2026-07-01T00:00:00.000Z")
+    const to = new Date("2026-08-01T00:00:00.000Z")
+
+    const result = await caller.list({
+      page: 2,
+      pageSize: 3,
+      source: "individual",
+      search: "42",
+      from,
+      to,
+    })
+
+    expect(result).toEqual({ items: hairRows, page: 2, pageSize: 3, totalCount: 4 })
+    expect(servicesMock.listHairAssigned).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageSize: 3,
+        offset: 3,
+        source: "individual",
+        search: "42",
+        from,
+        to,
+      }),
+    )
+  })
+
+  it("gets a hair sale by id", async () => {
+    const caller = hairAssignedRouter.createCaller(ctx)
+    const hairSale = { id: "hair-sale-1", clientId: "customer-1" }
+    servicesMock.getHairAssigned.mockResolvedValue(hairSale)
+
+    await expect(caller.get({ id: "hair-sale-1" })).resolves.toBe(hairSale)
+    expect(servicesMock.getHairAssigned).toHaveBeenCalledWith("hair-sale-1")
   })
 
   it("lists customers with page offset applied", async () => {

--- a/packages/application/src/services/hair.ts
+++ b/packages/application/src/services/hair.ts
@@ -2,6 +2,7 @@ import {
   createHairAssigned as insertHairAssigned,
   createHairOrder as insertHairOrder,
   deleteHairAssigned as removeHairAssigned,
+  getHairAssigned as findHairAssigned,
   getHairOrder as findHairOrder,
   listHairAssigned as fetchHairAssigned,
   listHairOrders as fetchHairOrders,
@@ -33,8 +34,18 @@ export async function listHairAssigned(input: {
   offset: number
   appointmentId?: string
   customerId?: string
+  source?: "appointment" | "individual"
+  search?: string
+  from?: Date
+  to?: Date
 }) {
   return fetchHairAssigned(undefined, input)
+}
+
+export async function getHairAssigned(id: string) {
+  const result = await findHairAssigned(undefined, id)
+  if (!result) throw notFound("Hair sale not found")
+  return result
 }
 
 export async function availableHairOrders() {

--- a/packages/db/src/repositories/hair.ts
+++ b/packages/db/src/repositories/hair.ts
@@ -1,27 +1,117 @@
-import { and, count, eq, gt, sql } from "drizzle-orm"
+import { and, count, desc, eq, gt, gte, isNotNull, isNull, lt, or, sql } from "drizzle-orm"
 
 import { db, type Db } from "../index"
+import { appointment } from "../schema/appointment"
+import { customer } from "../schema/customer"
 import { hairAssigned, hairOrder } from "../schema/hair"
 
-export async function listHairAssigned(
-  database: Db = db,
-  filter: { pageSize: number; offset: number; appointmentId?: string; customerId?: string },
-) {
+type HairAssignedFilter = {
+  pageSize: number
+  offset: number
+  appointmentId?: string
+  customerId?: string
+  source?: "appointment" | "individual"
+  search?: string
+  from?: Date
+  to?: Date
+}
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, "\\$&")
+}
+
+function hairAssignedDateCondition(filter: Pick<HairAssignedFilter, "source" | "from" | "to">) {
+  if (!filter.from && !filter.to) return undefined
+
+  const appointmentDateChecks = [isNotNull(hairAssigned.appointmentId)]
+  const individualDateChecks = [isNull(hairAssigned.appointmentId)]
+  if (filter.from) {
+    appointmentDateChecks.push(gte(appointment.startsAt, filter.from))
+    individualDateChecks.push(gte(hairAssigned.createdAt, filter.from))
+  }
+  if (filter.to) {
+    appointmentDateChecks.push(lt(appointment.startsAt, filter.to))
+    individualDateChecks.push(lt(hairAssigned.createdAt, filter.to))
+  }
+
+  const appointmentDateCondition = and(...appointmentDateChecks)
+  const individualDateCondition = and(...individualDateChecks)
+
+  if (filter.source === "appointment") return appointmentDateCondition
+  if (filter.source === "individual") return individualDateCondition
+  return or(appointmentDateCondition, individualDateCondition)
+}
+
+export async function listHairAssigned(database: Db = db, filter: HairAssignedFilter) {
   const conditions = []
   if (filter.appointmentId) conditions.push(eq(hairAssigned.appointmentId, filter.appointmentId))
   if (filter.customerId) conditions.push(eq(hairAssigned.clientId, filter.customerId))
+  if (filter.source === "appointment") conditions.push(isNotNull(hairAssigned.appointmentId))
+  if (filter.source === "individual") conditions.push(isNull(hairAssigned.appointmentId))
+  if (filter.search) {
+    const searchPattern = `%${escapeLikePattern(filter.search)}%`
+    conditions.push(
+      or(
+        sql<boolean>`${hairOrder.uid}::text ilike ${searchPattern}`,
+        sql<boolean>`${customer.name} ilike ${searchPattern}`,
+      ),
+    )
+  }
+  const dateCondition = hairAssignedDateCondition(filter)
+  if (dateCondition) conditions.push(dateCondition)
   const where = conditions.length > 0 ? and(...conditions) : undefined
 
-  const items = await database.query.hairAssigned.findMany({
-    where,
-    with: { client: true, hairOrder: true },
-    orderBy: (ha, { desc }) => [desc(ha.createdAt)],
-    limit: filter.pageSize,
-    offset: filter.offset,
-  })
+  const items = await database
+    .select({
+      id: hairAssigned.id,
+      appointmentId: hairAssigned.appointmentId,
+      hairOrderId: hairAssigned.hairOrderId,
+      weightInGrams: hairAssigned.weightInGrams,
+      soldFor: hairAssigned.soldFor,
+      profit: hairAssigned.profit,
+      pricePerGram: hairAssigned.pricePerGram,
+      clientId: hairAssigned.clientId,
+      createdById: hairAssigned.createdById,
+      createdAt: hairAssigned.createdAt,
+      updatedAt: hairAssigned.updatedAt,
+      appointment: {
+        id: appointment.id,
+        name: appointment.name,
+        startsAt: appointment.startsAt,
+      },
+      client: {
+        id: customer.id,
+        name: customer.name,
+      },
+      hairOrder: {
+        id: hairOrder.id,
+        uid: hairOrder.uid,
+      },
+    })
+    .from(hairAssigned)
+    .leftJoin(appointment, eq(hairAssigned.appointmentId, appointment.id))
+    .leftJoin(customer, eq(hairAssigned.clientId, customer.id))
+    .leftJoin(hairOrder, eq(hairAssigned.hairOrderId, hairOrder.id))
+    .where(where)
+    .orderBy(desc(hairAssigned.createdAt), desc(hairAssigned.id))
+    .limit(filter.pageSize)
+    .offset(filter.offset)
 
-  const [countRow] = await database.select({ totalCount: count() }).from(hairAssigned).where(where)
+  const [countRow] = await database
+    .select({ totalCount: count() })
+    .from(hairAssigned)
+    .leftJoin(appointment, eq(hairAssigned.appointmentId, appointment.id))
+    .leftJoin(customer, eq(hairAssigned.clientId, customer.id))
+    .leftJoin(hairOrder, eq(hairAssigned.hairOrderId, hairOrder.id))
+    .where(where)
   return { items, totalCount: countRow?.totalCount ?? 0 }
+}
+
+export async function getHairAssigned(database: Db = db, id: string) {
+  return database.query.hairAssigned.findFirst({
+    where: eq(hairAssigned.id, id),
+    with: { appointment: true, client: true, createdBy: true, hairOrder: { with: { customer: true } } },
+  })
 }
 
 export async function availableHairOrders(database: Db = db) {


### PR DESCRIPTION
## Summary
- add a top-level Hair sales navigation item with list and detail pages
- link dashboard hair sales cards to filtered month/source records
- add API/service/repository support for filtered hair sales list and detail reads

## Validation
- vp check
- vp run check-types
- vp test run src/routers/resource-reads.test.ts from packages/api
- vp run --filter web build

Note: web build reports existing Mantine/rrule default import and chunk-size warnings.