### PR TITLE
feat: improve legal entities navigation

### DIFF
--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -12,8 +12,8 @@ export function PageHeader({
   actions?: ReactNode
 }) {
   return (
-    <Group justify="space-between" align="flex-start" wrap="nowrap" mb="lg">
-      <Stack gap={4} miw={0}>
+    <Group justify="space-between" align="flex-start" wrap="wrap" mb="lg">
+      <Stack gap={4} miw={0} flex={1}>
         <Title order={2} fw={600} lh={1.2}>
           {title}
         </Title>
@@ -24,7 +24,7 @@ export function PageHeader({
         ) : null}
       </Stack>
       {actions ? (
-        <Group gap="xs" wrap="nowrap">
+        <Group gap="xs" wrap="wrap" w={{ base: "100%", sm: "auto" }}>
           {actions}
         </Group>
       ) : null}

--- a/apps/web/src/lib/legal-entity-navigation.test.ts
+++ b/apps/web/src/lib/legal-entity-navigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import { getLegalEntitySectionFromPath, getLegalEntitySectionPath } from "./legal-entity-navigation"
+
+describe("legal entity navigation", () => {
+  it("detects the active legal entity section from a pathname", () => {
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1")).toBe("overview")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/overview")).toBe("overview")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/documents")).toBe("documents")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/bank-accounts")).toBe("bank-accounts")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/bank-accounts/account-1")).toBe("bank-accounts")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/salons")).toBe("salons")
+    expect(getLegalEntitySectionFromPath("/dashboard")).toBe("overview")
+  })
+
+  it("builds legal entity section paths", () => {
+    expect(getLegalEntitySectionPath("entity-1", "overview")).toBe("/legal-entities/entity-1/overview")
+    expect(getLegalEntitySectionPath("entity-1", "documents")).toBe("/legal-entities/entity-1/documents")
+    expect(getLegalEntitySectionPath("entity-1", "bank-accounts")).toBe("/legal-entities/entity-1/bank-accounts")
+    expect(getLegalEntitySectionPath("entity-1", "salons")).toBe("/legal-entities/entity-1/salons")
+  })
+})

--- a/apps/web/src/lib/legal-entity-navigation.ts
+++ b/apps/web/src/lib/legal-entity-navigation.ts
@@ -1,0 +1,29 @@
+export type LegalEntitySectionValue = "overview" | "documents" | "bank-accounts" | "salons"
+
+export type LegalEntitySection = {
+  value: LegalEntitySectionValue
+  label: string
+}
+
+export const LEGAL_ENTITY_SECTIONS = [
+  { value: "overview", label: "Overview" },
+  { value: "documents", label: "Documents" },
+  { value: "bank-accounts", label: "Bank accounts" },
+  { value: "salons", label: "Salons" },
+] as const satisfies readonly LegalEntitySection[]
+
+const SECTION_VALUES = new Set<LegalEntitySectionValue>(LEGAL_ENTITY_SECTIONS.map((section) => section.value))
+
+export function getLegalEntitySectionFromPath(pathname: string): LegalEntitySectionValue {
+  const match = pathname.match(/^\/legal-entities\/[^/]+(?:\/([^/]+))?/)
+  const section = match?.[1] as LegalEntitySectionValue | undefined
+
+  return section && SECTION_VALUES.has(section) ? section : "overview"
+}
+
+export function getLegalEntitySectionPath(
+  legalEntityId: string,
+  section: LegalEntitySectionValue,
+): `/legal-entities/${string}/${LegalEntitySectionValue}` {
+  return `/legal-entities/${legalEntityId}/${section}`
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -29,7 +29,8 @@ function LegalEntityLayout() {
   const activeSection = getLegalEntitySectionFromPath(location.pathname)
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
 
-  const { data: legalEntity } = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
+  const legalEntityQuery = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
+  const legalEntity = legalEntityQuery.data
   const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
   const { data: unassignedAttachments = [] } = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
@@ -57,7 +58,7 @@ function LegalEntityLayout() {
     })
   }
 
-  if (legalEntity === null) {
+  if (legalEntityQuery.isError || legalEntity === null) {
     return (
       <Container size="xl">
         <Stack gap="md">
@@ -94,7 +95,7 @@ function LegalEntityLayout() {
               disabled={legalEntities.length <= 1}
               searchable={legalEntities.length > 5}
               size="sm"
-              w={220}
+              w={{ base: "100%", sm: 220 }}
             />
             <Button variant="default" leftSection={<IconPencil size={14} />} onClick={openEdit} disabled={!legalEntity}>
               Edit

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -5,6 +5,7 @@ import { notifications } from "@mantine/notifications"
 import { IconArrowLeft, IconPencil } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, Outlet, createFileRoute, useLocation } from "@tanstack/react-router"
+import { TRPCClientError } from "@trpc/client"
 import { zodResolver } from "mantine-form-zod-resolver"
 
 import { PageHeader } from "@/components/page-header"
@@ -29,7 +30,10 @@ function LegalEntityLayout() {
   const activeSection = getLegalEntitySectionFromPath(location.pathname)
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
 
-  const legalEntityQuery = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
+  const legalEntityQuery = useQuery({
+    ...trpc.legalEntities.get.queryOptions({ id: legalEntityId }),
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  })
   const legalEntity = legalEntityQuery.data
   const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
   const { data: unassignedAttachments = [] } = useQuery(
@@ -58,7 +62,7 @@ function LegalEntityLayout() {
     })
   }
 
-  if (legalEntityQuery.isError || legalEntity === null) {
+  if (legalEntityQuery.isError && isNotFoundError(legalEntityQuery.error)) {
     return (
       <Container size="xl">
         <Stack gap="md">
@@ -69,6 +73,27 @@ function LegalEntityLayout() {
             </Group>
           </Anchor>
           <Text c="dimmed">Legal entity not found.</Text>
+        </Stack>
+      </Container>
+    )
+  }
+
+  if (legalEntityQuery.isError) {
+    return (
+      <Container size="xl">
+        <Stack gap="md">
+          <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed">
+            <Group gap={4}>
+              <IconArrowLeft size={12} />
+              Back to legal entities
+            </Group>
+          </Anchor>
+          <Stack gap={4}>
+            <Text fw={600}>Unable to load legal entity</Text>
+            <Text c="dimmed" size="sm">
+              Refresh the page to try again.
+            </Text>
+          </Stack>
         </Stack>
       </Container>
     )
@@ -143,6 +168,10 @@ function LegalEntityLayout() {
       />
     </Container>
   )
+}
+
+function isNotFoundError(error: unknown) {
+  return error instanceof TRPCClientError && error.data?.code === "NOT_FOUND"
 }
 
 type EditValues = {

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -1,13 +1,20 @@
-import { Button, Container, Group, Modal, Stack, TextInput } from "@mantine/core"
+import { Anchor, Badge, Button, Container, Group, Modal, Select, Stack, Tabs, Text, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { useDisclosure } from "@mantine/hooks"
 import { notifications } from "@mantine/notifications"
+import { IconArrowLeft, IconPencil } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Outlet, createFileRoute } from "@tanstack/react-router"
+import { Link, Outlet, createFileRoute, useLocation } from "@tanstack/react-router"
 import { zodResolver } from "mantine-form-zod-resolver"
 
 import { PageHeader } from "@/components/page-header"
 import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
+import {
+  LEGAL_ENTITY_SECTIONS,
+  type LegalEntitySectionValue,
+  getLegalEntitySectionFromPath,
+  getLegalEntitySectionPath,
+} from "@/lib/legal-entity-navigation"
 import { legalEntityUpdateSchema } from "@/lib/schemas"
 import { trpc } from "@/utils/trpc"
 
@@ -17,27 +24,105 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
 
 function LegalEntityLayout() {
   const { legalEntityId } = Route.useParams()
+  const navigate = Route.useNavigate()
+  const location = useLocation()
+  const activeSection = getLegalEntitySectionFromPath(location.pathname)
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
 
   const { data: legalEntity } = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
+  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: unassignedAttachments = [] } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  )
+  const unassignedCount = unassignedAttachments.length
 
   const country = legalEntity?.country as Country | undefined
   const description = legalEntity
     ? `${legalEntity.type}${country ? ` · ${COUNTRY_FLAGS[country]} ${COUNTRY_LABELS[country]}` : ""} · ${legalEntity.defaultCurrency}`
     : undefined
 
+  const handleSectionChange = (value: string | null) => {
+    if (!value || value === activeSection) return
+    navigate({
+      to: getLegalEntitySectionPath(legalEntityId, value as LegalEntitySectionValue),
+      params: { legalEntityId },
+    })
+  }
+
+  const handleEntityChange = (nextLegalEntityId: string | null) => {
+    if (!nextLegalEntityId || nextLegalEntityId === legalEntityId) return
+    navigate({
+      to: getLegalEntitySectionPath(nextLegalEntityId, activeSection),
+      params: { legalEntityId: nextLegalEntityId },
+    })
+  }
+
+  if (legalEntity === null) {
+    return (
+      <Container size="xl">
+        <Stack gap="md">
+          <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed">
+            <Group gap={4}>
+              <IconArrowLeft size={12} />
+              Back to legal entities
+            </Group>
+          </Anchor>
+          <Text c="dimmed">Legal entity not found.</Text>
+        </Stack>
+      </Container>
+    )
+  }
+
   return (
     <Container size="xl">
+      <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed" mb="xs" display="inline-block">
+        <Group gap={4}>
+          <IconArrowLeft size={12} />
+          Back to legal entities
+        </Group>
+      </Anchor>
       <PageHeader
         title={legalEntity?.name ?? "Legal entity"}
         description={description}
         actions={
-          <Button variant="default" onClick={openEdit} disabled={!legalEntity}>
-            Edit
-          </Button>
+          <>
+            <Select
+              aria-label="Switch legal entity"
+              data={legalEntities.map((entity) => ({ value: entity.id, label: entity.name }))}
+              value={legalEntityId}
+              onChange={handleEntityChange}
+              disabled={legalEntities.length <= 1}
+              searchable={legalEntities.length > 5}
+              size="sm"
+              w={220}
+            />
+            <Button variant="default" leftSection={<IconPencil size={14} />} onClick={openEdit} disabled={!legalEntity}>
+              Edit
+            </Button>
+          </>
         }
       />
       <Stack>
+        <Tabs value={activeSection} onChange={handleSectionChange}>
+          <Tabs.List>
+            {LEGAL_ENTITY_SECTIONS.map((section) => (
+              <Tabs.Tab
+                key={section.value}
+                value={section.value}
+                rightSection={
+                  section.value === "documents" && unassignedCount > 0 ? (
+                    <Badge size="xs" variant="filled" color="orange" circle>
+                      {unassignedCount}
+                    </Badge>
+                  ) : null
+                }
+              >
+                {section.label}
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs>
+
         <Outlet />
       </Stack>
 

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -21,6 +21,16 @@ function LegalEntitiesIndex() {
   return (
     <Container size="xl">
       <PageHeader title="Legal entities" description="Companies and sole-trader registrations." />
+      {unassignedCount > 0 ? (
+        <Group gap="xs" mb="md">
+          <Text size="sm" c="dimmed">
+            Unassigned documents
+          </Text>
+          <Badge size="sm" variant="filled" color="orange">
+            {unassignedCount}
+          </Badge>
+        </Group>
+      ) : null}
       {legalEntities.length === 0 ? (
         <Card withBorder padding="lg">
           <Stack gap={4}>
@@ -62,8 +72,6 @@ function LegalEntitiesIndex() {
 
                   <Group gap="xs">
                     {LEGAL_ENTITY_SECTIONS.map((section) => {
-                      const showBadge = section.value === "documents" && unassignedCount > 0
-
                       return (
                         <Button
                           key={section.value}
@@ -76,13 +84,6 @@ function LegalEntitiesIndex() {
                               {...props}
                             />
                           )}
-                          rightSection={
-                            showBadge ? (
-                              <Badge size="xs" variant="filled" color="orange" circle>
-                                {unassignedCount}
-                              </Badge>
-                            ) : null
-                          }
                         >
                           {section.label}
                         </Button>

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -1,10 +1,10 @@
-import { Anchor, Container, Stack, Table } from "@mantine/core"
+import { Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
 import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 
 import { PageHeader } from "@/components/page-header"
-import { Section } from "@/components/section"
 import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
+import { LEGAL_ENTITY_SECTIONS, getLegalEntitySectionPath } from "@/lib/legal-entity-navigation"
 import { trpc } from "@/utils/trpc"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/")({
@@ -13,44 +13,88 @@ export const Route = createFileRoute("/_authenticated/legal-entities/")({
 
 function LegalEntitiesIndex() {
   const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: unassignedAttachments = [] } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  )
+  const unassignedCount = unassignedAttachments.length
 
   return (
     <Container size="xl">
       <PageHeader title="Legal entities" description="Companies and sole-trader registrations." />
-      <Stack>
-        <Section padding={0}>
-          <Table>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Name</Table.Th>
-                <Table.Th>Type</Table.Th>
-                <Table.Th>Country</Table.Th>
-                <Table.Th>Default currency</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {legalEntities.map((le) => (
-                <Table.Tr key={le.id}>
-                  <Table.Td>
-                    <Anchor
+      {legalEntities.length === 0 ? (
+        <Card withBorder padding="lg">
+          <Stack gap={4}>
+            <Title order={4} fw={600}>
+              No legal entities
+            </Title>
+            <Text size="sm" c="dimmed">
+              Legal entities will appear here once they have been added.
+            </Text>
+          </Stack>
+        </Card>
+      ) : (
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+          {legalEntities.map((legalEntity) => {
+            const country = legalEntity.country as Country
+
+            return (
+              <Card key={legalEntity.id} withBorder padding="lg">
+                <Stack gap="md">
+                  <Stack gap={4}>
+                    <Title
+                      order={3}
+                      fw={600}
                       renderRoot={(props) => (
-                        <Link to="/legal-entities/$legalEntityId" params={{ legalEntityId: le.id }} {...props} />
+                        <Link
+                          to="/legal-entities/$legalEntityId/overview"
+                          params={{ legalEntityId: legalEntity.id }}
+                          {...props}
+                        />
                       )}
                     >
-                      {le.name}
-                    </Anchor>
-                  </Table.Td>
-                  <Table.Td>{le.type}</Table.Td>
-                  <Table.Td>
-                    {COUNTRY_FLAGS[le.country as Country]} {COUNTRY_LABELS[le.country as Country]}
-                  </Table.Td>
-                  <Table.Td>{le.defaultCurrency}</Table.Td>
-                </Table.Tr>
-              ))}
-            </Table.Tbody>
-          </Table>
-        </Section>
-      </Stack>
+                      {legalEntity.name}
+                    </Title>
+                    <Text size="sm" c="dimmed">
+                      {legalEntity.type} · {COUNTRY_FLAGS[country]} {COUNTRY_LABELS[country]} ·{" "}
+                      {legalEntity.defaultCurrency}
+                    </Text>
+                  </Stack>
+
+                  <Group gap="xs">
+                    {LEGAL_ENTITY_SECTIONS.map((section) => {
+                      const showBadge = section.value === "documents" && unassignedCount > 0
+
+                      return (
+                        <Button
+                          key={section.value}
+                          size="xs"
+                          variant={section.value === "overview" ? "filled" : "default"}
+                          renderRoot={(props) => (
+                            <Link
+                              to={getLegalEntitySectionPath(legalEntity.id, section.value)}
+                              params={{ legalEntityId: legalEntity.id }}
+                              {...props}
+                            />
+                          )}
+                          rightSection={
+                            showBadge ? (
+                              <Badge size="xs" variant="filled" color="orange" circle>
+                                {unassignedCount}
+                              </Badge>
+                            ) : null
+                          }
+                        >
+                          {section.label}
+                        </Button>
+                      )
+                    })}
+                  </Group>
+                </Stack>
+              </Card>
+            )
+          })}
+        </SimpleGrid>
+      )}
     </Container>
   )
 }

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -12,7 +12,8 @@ export const Route = createFileRoute("/_authenticated/legal-entities/")({
 })
 
 function LegalEntitiesIndex() {
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const legalEntities = legalEntitiesQuery.data ?? []
   const { data: unassignedAttachments = [] } = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
   )
@@ -31,7 +32,24 @@ function LegalEntitiesIndex() {
           </Badge>
         </Group>
       ) : null}
-      {legalEntities.length === 0 ? (
+      {legalEntitiesQuery.isPending ? (
+        <Card withBorder padding="lg">
+          <Text size="sm" c="dimmed">
+            Loading legal entities...
+          </Text>
+        </Card>
+      ) : legalEntitiesQuery.isError ? (
+        <Card withBorder padding="lg">
+          <Stack gap={4}>
+            <Title order={4} fw={600}>
+              Unable to load legal entities
+            </Title>
+            <Text size="sm" c="dimmed">
+              Refresh the page to try again.
+            </Text>
+          </Stack>
+        </Card>
+      ) : legalEntities.length === 0 ? (
         <Card withBorder padding="lg">
           <Stack gap={4}>
             <Title order={4} fw={600}>

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -77,18 +77,6 @@
   font-size: 11px;
 }
 
-.entitySubNav {
-  margin-left: 16px;
-  padding-left: 10px;
-  border-left: 1px solid var(--prive-border);
-}
-
-.subNavLink {
-  border-radius: var(--mantine-radius-lg);
-  padding: 6px 10px;
-  font-size: var(--mantine-font-size-sm);
-}
-
 .user {
   color: var(--mantine-color-text);
   padding: 6px 8px;

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -11,7 +11,6 @@ import {
   Card,
   Group,
   Menu,
-  NavLink as MantineNavLink,
   ScrollArea,
   Stack,
   Text,
@@ -28,7 +27,6 @@ import {
   IconCash,
   IconChevronDown,
   IconDeviceDesktop,
-  IconFileText,
   IconLayoutDashboard,
   IconLogout,
   IconMoon,
@@ -39,7 +37,6 @@ import {
   IconSun,
   IconUserCircle,
   IconUsers,
-  IconWallet,
 } from "@tabler/icons-react"
 import { useQuery, useQueryErrorResetBoundary } from "@tanstack/react-query"
 import { Link, Outlet, createFileRoute, redirect, useLocation, useNavigate, useRouter } from "@tanstack/react-router"
@@ -71,13 +68,6 @@ const manageNav: NavItem[] = [
 ]
 
 const footerNav: NavItem[] = [{ to: "/settings", label: "Settings", icon: IconSettings }]
-
-const LEGAL_ENTITY_TABS = [
-  { value: "overview", label: "Overview", icon: IconLayoutDashboard },
-  { value: "documents", label: "Documents", icon: IconFileText, badgeKey: "unassigned" as const },
-  { value: "bank-accounts", label: "Bank accounts", icon: IconWallet },
-  { value: "salons", label: "Salons", icon: IconScissors },
-]
 
 export const Route = createFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
@@ -159,16 +149,6 @@ function AuthenticatedLayout() {
 }
 
 function SidebarNav({ badges, onNavigate }: { badges: { unassigned: number }; onNavigate: () => void }) {
-  const location = useLocation()
-  const entityMatch = location.pathname.match(/^\/legal-entities\/([^/]+)(?:\/([^/]+))?/)
-  const entityId = entityMatch?.[1]
-  const entityTab = entityMatch?.[2] ?? "overview"
-
-  const { data: entity } = useQuery({
-    ...trpc.legalEntities.get.queryOptions({ id: entityId ?? "" }),
-    enabled: !!entityId,
-  })
-
   return (
     <Stack gap="md">
       <Box>
@@ -197,45 +177,6 @@ function SidebarNav({ badges, onNavigate }: { badges: { unassigned: number }; on
             />
           ))}
         </Stack>
-
-        {entityId && (
-          <Box mt={6} className={classes.entitySubNav}>
-            <Text size="xs" fw={600} c="dimmed" px="sm" py={4} truncate>
-              {entity?.name ?? "…"}
-            </Text>
-            <Stack gap={2}>
-              {LEGAL_ENTITY_TABS.map((t) => {
-                const Icon = t.icon
-                const active = entityTab === t.value
-                const badge = t.badgeKey ? badges[t.badgeKey] : 0
-                return (
-                  <MantineNavLink
-                    key={t.value}
-                    renderRoot={(props) => (
-                      <Link
-                        to={`/legal-entities/$legalEntityId/${t.value}`}
-                        params={{ legalEntityId: entityId }}
-                        {...props}
-                      />
-                    )}
-                    label={t.label}
-                    leftSection={<Icon size={16} stroke={1.6} />}
-                    rightSection={
-                      badge > 0 ? (
-                        <Badge size="xs" variant="filled" color="orange" circle>
-                          {badge}
-                        </Badge>
-                      ) : null
-                    }
-                    active={active}
-                    onClick={onNavigate}
-                    className={classes.subNavLink}
-                  />
-                )
-              })}
-            </Stack>
-          </Box>
-        )}
       </Box>
     </Stack>
   )

--- a/docs/superpowers/plans/2026-07-19-legal-entities-ui-access.md
+++ b/docs/superpowers/plans/2026-07-19-legal-entities-ui-access.md
@@ -1,0 +1,723 @@
+# Legal Entities UI Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve access to the legal entities route by adding a clear entity hub, local entity tabs, entity switching, and visible document work indicators.
+
+**Architecture:** Add a small legal-entity navigation helper for shared tab/action metadata and switch-target path logic. Use that helper from the legal entities hub and detail layout. Keep server APIs unchanged and use existing TRPC queries for entity data and unassigned document counts.
+
+**Tech Stack:** React, TypeScript, Mantine, Tabler icons, TanStack Router, TanStack Query, TRPC, Vite+, Vitest.
+
+## Global Constraints
+
+- The current branch must not be `main` when committing.
+- Use the existing Mantine and TanStack Router patterns.
+- Expected legal entity count is small, usually one to five entities.
+- Do not add legal entity creation unless an existing flow already supports it.
+- Do not add heavy search, filtering, or sorting for large legal entity sets.
+- Do not redesign unrelated workspace navigation.
+- Do not change backend document scoping unless existing APIs already support it.
+- Preserve current global unassigned document behavior and label it clearly as `Unassigned documents` where appropriate.
+- Run `vp check`.
+- Run `vp test`; if it fails because required env vars are missing for `packages/env/src/server.test.ts`, record that as the known baseline environment issue.
+
+---
+
+## File Structure
+
+- Create `apps/web/src/lib/legal-entity-navigation.ts`
+  - Owns legal-entity section metadata and URL helpers.
+  - Exports `LEGAL_ENTITY_SECTIONS`, `LegalEntitySectionValue`, `getLegalEntitySectionFromPath`, and `getLegalEntitySectionPath`.
+
+- Create `apps/web/src/lib/legal-entity-navigation.test.ts`
+  - Verifies path-to-section detection and section-to-path generation.
+
+- Modify `apps/web/src/routes/_authenticated/legal-entities/index.tsx`
+  - Replaces the plain table with a compact hub.
+  - Uses shared navigation metadata for direct actions.
+  - Shows pending document count on the Documents action.
+
+- Modify `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`
+  - Adds a back link, local tabs, entity switcher, missing-entity state, and document tab badge.
+  - Uses shared navigation helpers to preserve section on entity switch.
+
+- Modify `apps/web/src/routes/_authenticated/route.tsx`
+  - Removes the nested legal-entity subnav from the global sidebar after local tabs exist.
+  - Keeps `Legal entities` as the global entry point with the existing unassigned document badge.
+
+- Generated route files
+  - `apps/web/src/routeTree.gen.ts` may change after running Vite+ checks or the router generator. Only include it if tooling updates it.
+
+---
+
+### Task 1: Add Legal Entity Navigation Helper
+
+**Files:**
+- Create: `apps/web/src/lib/legal-entity-navigation.ts`
+- Create: `apps/web/src/lib/legal-entity-navigation.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type LegalEntitySectionValue = "overview" | "documents" | "bank-accounts" | "salons"`
+  - `const LEGAL_ENTITY_SECTIONS: readonly LegalEntitySection[]`
+  - `function getLegalEntitySectionFromPath(pathname: string): LegalEntitySectionValue`
+  - `function getLegalEntitySectionPath(legalEntityId: string, section: LegalEntitySectionValue): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/lib/legal-entity-navigation.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { getLegalEntitySectionFromPath, getLegalEntitySectionPath } from "./legal-entity-navigation"
+
+describe("legal entity navigation", () => {
+  it("detects the active legal entity section from a pathname", () => {
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1")).toBe("overview")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/overview")).toBe("overview")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/documents")).toBe("documents")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/bank-accounts")).toBe("bank-accounts")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/bank-accounts/account-1")).toBe("bank-accounts")
+    expect(getLegalEntitySectionFromPath("/legal-entities/entity-1/salons")).toBe("salons")
+    expect(getLegalEntitySectionFromPath("/dashboard")).toBe("overview")
+  })
+
+  it("builds legal entity section paths", () => {
+    expect(getLegalEntitySectionPath("entity-1", "overview")).toBe("/legal-entities/entity-1/overview")
+    expect(getLegalEntitySectionPath("entity-1", "documents")).toBe("/legal-entities/entity-1/documents")
+    expect(getLegalEntitySectionPath("entity-1", "bank-accounts")).toBe("/legal-entities/entity-1/bank-accounts")
+    expect(getLegalEntitySectionPath("entity-1", "salons")).toBe("/legal-entities/entity-1/salons")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+vp test apps/web/src/lib/legal-entity-navigation.test.ts
+```
+
+Expected: FAIL because `apps/web/src/lib/legal-entity-navigation.ts` does not exist.
+
+- [ ] **Step 3: Add the helper implementation**
+
+Create `apps/web/src/lib/legal-entity-navigation.ts`:
+
+```ts
+export type LegalEntitySectionValue = "overview" | "documents" | "bank-accounts" | "salons"
+
+export type LegalEntitySection = {
+  value: LegalEntitySectionValue
+  label: string
+}
+
+export const LEGAL_ENTITY_SECTIONS = [
+  { value: "overview", label: "Overview" },
+  { value: "documents", label: "Documents" },
+  { value: "bank-accounts", label: "Bank accounts" },
+  { value: "salons", label: "Salons" },
+] as const satisfies readonly LegalEntitySection[]
+
+const SECTION_VALUES = new Set<LegalEntitySectionValue>(LEGAL_ENTITY_SECTIONS.map((section) => section.value))
+
+export function getLegalEntitySectionFromPath(pathname: string): LegalEntitySectionValue {
+  const match = pathname.match(/^\/legal-entities\/[^/]+(?:\/([^/]+))?/)
+  const section = match?.[1] as LegalEntitySectionValue | undefined
+
+  return section && SECTION_VALUES.has(section) ? section : "overview"
+}
+
+export function getLegalEntitySectionPath(
+  legalEntityId: string,
+  section: LegalEntitySectionValue,
+): `/legal-entities/${string}/${LegalEntitySectionValue}` {
+  return `/legal-entities/${legalEntityId}/${section}`
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run:
+
+```bash
+vp test apps/web/src/lib/legal-entity-navigation.test.ts
+```
+
+Expected: PASS for `apps/web/src/lib/legal-entity-navigation.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add apps/web/src/lib/legal-entity-navigation.ts apps/web/src/lib/legal-entity-navigation.test.ts
+git commit -m "feat: add legal entity navigation helpers"
+```
+
+---
+
+### Task 2: Build The Legal Entities Hub
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/legal-entities/index.tsx`
+
+**Interfaces:**
+- Consumes:
+  - `LEGAL_ENTITY_SECTIONS`
+  - `getLegalEntitySectionPath(legalEntityId, section)`
+
+- [ ] **Step 1: Replace the plain table with a compact hub**
+
+Modify `apps/web/src/routes/_authenticated/legal-entities/index.tsx` to this structure:
+
+```tsx
+import { Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
+import { useQuery } from "@tanstack/react-query"
+import { Link, createFileRoute } from "@tanstack/react-router"
+
+import { PageHeader } from "@/components/page-header"
+import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
+import { LEGAL_ENTITY_SECTIONS, getLegalEntitySectionPath } from "@/lib/legal-entity-navigation"
+import { trpc } from "@/utils/trpc"
+
+export const Route = createFileRoute("/_authenticated/legal-entities/")({
+  component: LegalEntitiesIndex,
+})
+
+function LegalEntitiesIndex() {
+  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: unassignedAttachments = [] } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  )
+  const unassignedCount = unassignedAttachments.length
+
+  return (
+    <Container size="xl">
+      <PageHeader title="Legal entities" description="Companies and sole-trader registrations." />
+      {legalEntities.length === 0 ? (
+        <Card withBorder padding="lg">
+          <Stack gap={4}>
+            <Title order={4} fw={600}>
+              No legal entities
+            </Title>
+            <Text size="sm" c="dimmed">
+              Legal entities will appear here once they have been added.
+            </Text>
+          </Stack>
+        </Card>
+      ) : (
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+          {legalEntities.map((legalEntity) => {
+            const country = legalEntity.country as Country
+
+            return (
+              <Card key={legalEntity.id} withBorder padding="lg">
+                <Stack gap="md">
+                  <Stack gap={4}>
+                    <Title
+                      order={3}
+                      fw={600}
+                      renderRoot={(props) => (
+                        <Link
+                          to="/legal-entities/$legalEntityId/overview"
+                          params={{ legalEntityId: legalEntity.id }}
+                          {...props}
+                        />
+                      )}
+                    >
+                      {legalEntity.name}
+                    </Title>
+                    <Text size="sm" c="dimmed">
+                      {legalEntity.type} · {COUNTRY_FLAGS[country]} {COUNTRY_LABELS[country]} ·{" "}
+                      {legalEntity.defaultCurrency}
+                    </Text>
+                  </Stack>
+
+                  <Group gap="xs">
+                    {LEGAL_ENTITY_SECTIONS.map((section) => {
+                      const showBadge = section.value === "documents" && unassignedCount > 0
+
+                      return (
+                        <Button
+                          key={section.value}
+                          size="xs"
+                          variant={section.value === "overview" ? "filled" : "default"}
+                          renderRoot={(props) => (
+                            <Link
+                              to={getLegalEntitySectionPath(legalEntity.id, section.value)}
+                              params={{ legalEntityId: legalEntity.id }}
+                              {...props}
+                            />
+                          )}
+                          rightSection={
+                            showBadge ? (
+                              <Badge size="xs" variant="filled" color="orange" circle>
+                                {unassignedCount}
+                              </Badge>
+                            ) : null
+                          }
+                        >
+                          {section.label}
+                        </Button>
+                      )
+                    })}
+                  </Group>
+                </Stack>
+              </Card>
+            )
+          })}
+        </SimpleGrid>
+      )}
+    </Container>
+  )
+}
+```
+
+- [ ] **Step 2: Run focused checks**
+
+Run:
+
+```bash
+vp check
+```
+
+Expected: PASS with no format or lint errors.
+
+Run:
+
+```bash
+vp run --filter web check-types
+```
+
+Expected: PASS with no TypeScript errors. If TanStack Router rejects `to={getLegalEntitySectionPath(...)}`, replace those generated path links with explicit conditional `Link` targets:
+
+```tsx
+const linkProps =
+  section.value === "overview"
+    ? { to: "/legal-entities/$legalEntityId/overview" as const, params: { legalEntityId: legalEntity.id } }
+    : section.value === "documents"
+      ? { to: "/legal-entities/$legalEntityId/documents" as const, params: { legalEntityId: legalEntity.id } }
+      : section.value === "bank-accounts"
+        ? { to: "/legal-entities/$legalEntityId/bank-accounts" as const, params: { legalEntityId: legalEntity.id } }
+        : { to: "/legal-entities/$legalEntityId/salons" as const, params: { legalEntityId: legalEntity.id } }
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add apps/web/src/routes/_authenticated/legal-entities/index.tsx
+git commit -m "feat: add legal entities hub"
+```
+
+---
+
+### Task 3: Add Local Detail Navigation And Entity Switching
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`
+
+**Interfaces:**
+- Consumes:
+  - `LEGAL_ENTITY_SECTIONS`
+  - `LegalEntitySectionValue`
+  - `getLegalEntitySectionFromPath(pathname)`
+  - `getLegalEntitySectionPath(legalEntityId, section)`
+
+- [ ] **Step 1: Update imports**
+
+In `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`, update imports to include the navigation controls and icons:
+
+```tsx
+import { Anchor, Badge, Button, Container, Group, Modal, Select, Stack, Tabs, Text, TextInput } from "@mantine/core"
+import { IconArrowLeft, IconPencil } from "@tabler/icons-react"
+import { Link, Outlet, createFileRoute, useLocation } from "@tanstack/react-router"
+```
+
+Add the helper import:
+
+```tsx
+import {
+  LEGAL_ENTITY_SECTIONS,
+  type LegalEntitySectionValue,
+  getLegalEntitySectionFromPath,
+  getLegalEntitySectionPath,
+} from "@/lib/legal-entity-navigation"
+```
+
+- [ ] **Step 2: Add detail navigation behavior**
+
+Inside `LegalEntityLayout`, add these values after `const { legalEntityId } = Route.useParams()`:
+
+```tsx
+const navigate = Route.useNavigate()
+const location = useLocation()
+const activeSection = getLegalEntitySectionFromPath(location.pathname)
+```
+
+Add these queries near the existing current-entity query:
+
+```tsx
+const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+const { data: unassignedAttachments = [] } = useQuery(
+  trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+)
+const unassignedCount = unassignedAttachments.length
+```
+
+Add these handlers before the `return`:
+
+```tsx
+const handleSectionChange = (value: string | null) => {
+  if (!value || value === activeSection) return
+  navigate({
+    to: getLegalEntitySectionPath(legalEntityId, value as LegalEntitySectionValue),
+    params: { legalEntityId },
+  })
+}
+
+const handleEntityChange = (nextLegalEntityId: string | null) => {
+  if (!nextLegalEntityId || nextLegalEntityId === legalEntityId) return
+  navigate({
+    to: getLegalEntitySectionPath(nextLegalEntityId, activeSection),
+    params: { legalEntityId: nextLegalEntityId },
+  })
+}
+```
+
+- [ ] **Step 3: Add a missing-entity state**
+
+Before the main `return`, add:
+
+```tsx
+if (legalEntity === null) {
+  return (
+    <Container size="xl">
+      <Stack gap="md">
+        <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed">
+          <Group gap={4}>
+            <IconArrowLeft size={12} />
+            Back to legal entities
+          </Group>
+        </Anchor>
+        <Text c="dimmed">Legal entity not found.</Text>
+      </Stack>
+    </Container>
+  )
+}
+```
+
+If the query returns `undefined` during loading and never returns `null` for missing records, keep the layout loading label as `Legal entity` and rely on existing error behavior.
+
+- [ ] **Step 4: Render back link, switcher, edit button, and tabs**
+
+Replace the existing top-level return header area with this structure:
+
+```tsx
+return (
+  <Container size="xl">
+    <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed" mb="xs" display="inline-block">
+      <Group gap={4}>
+        <IconArrowLeft size={12} />
+        Back to legal entities
+      </Group>
+    </Anchor>
+    <PageHeader
+      title={legalEntity?.name ?? "Legal entity"}
+      description={description}
+      actions={
+        <>
+          <Select
+            aria-label="Switch legal entity"
+            data={legalEntities.map((entity) => ({ value: entity.id, label: entity.name }))}
+            value={legalEntityId}
+            onChange={handleEntityChange}
+            disabled={legalEntities.length <= 1}
+            searchable={legalEntities.length > 5}
+            size="sm"
+            w={220}
+          />
+          <Button variant="default" leftSection={<IconPencil size={14} />} onClick={openEdit} disabled={!legalEntity}>
+            Edit
+          </Button>
+        </>
+      }
+    />
+    <Stack>
+      <Tabs value={activeSection} onChange={handleSectionChange}>
+        <Tabs.List>
+          {LEGAL_ENTITY_SECTIONS.map((section) => (
+            <Tabs.Tab
+              key={section.value}
+              value={section.value}
+              rightSection={
+                section.value === "documents" && unassignedCount > 0 ? (
+                  <Badge size="xs" variant="filled" color="orange" circle>
+                    {unassignedCount}
+                  </Badge>
+                ) : null
+              }
+            >
+              {section.label}
+            </Tabs.Tab>
+          ))}
+        </Tabs.List>
+      </Tabs>
+
+      <Outlet />
+    </Stack>
+
+    <EditLegalEntityModal
+      opened={editOpened}
+      onClose={closeEdit}
+      legalEntityId={legalEntityId}
+      initial={
+        legalEntity
+          ? {
+              name: legalEntity.name,
+              registrationNumber: legalEntity.registrationNumber ?? "",
+              vatNumber: legalEntity.vatNumber ?? "",
+            }
+          : null
+      }
+    />
+  </Container>
+)
+```
+
+- [ ] **Step 5: Run focused checks**
+
+Run:
+
+```bash
+vp check
+```
+
+Expected: PASS with no format or lint errors.
+
+Run:
+
+```bash
+vp run --filter web check-types
+```
+
+Expected: PASS with no TypeScript errors. If TanStack Router rejects helper-built `to` paths in `navigate`, replace the two `navigate` calls with explicit conditionals for each section using the same path strings shown in Task 2.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add 'apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx'
+git commit -m "feat: add legal entity detail navigation"
+```
+
+---
+
+### Task 4: Simplify Global Sidebar Legal Entity Navigation
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/route.tsx`
+- Modify: `apps/web/src/routes/_authenticated/route.module.css`
+
+**Interfaces:**
+- Consumes: local tabs introduced in Task 3.
+- Produces: global sidebar with only the `Legal entities` entry for this area.
+
+- [ ] **Step 1: Remove nested legal entity tab metadata and query**
+
+In `apps/web/src/routes/_authenticated/route.tsx`, remove these icon imports if no longer used:
+
+```tsx
+IconFileText,
+IconWallet,
+```
+
+Remove the `LEGAL_ENTITY_TABS` constant.
+
+Inside `SidebarNav`, remove:
+
+```tsx
+const entityMatch = location.pathname.match(/^\/legal-entities\/([^/]+)(?:\/([^/]+))?/)
+const entityId = entityMatch?.[1]
+const entityTab = entityMatch?.[2] ?? "overview"
+
+const { data: entity } = useQuery({
+  ...trpc.legalEntities.get.queryOptions({ id: entityId ?? "" }),
+  enabled: !!entityId,
+})
+```
+
+Keep `const location = useLocation()` because `TopLink` still uses active route behavior separately.
+
+- [ ] **Step 2: Remove nested sidebar rendering**
+
+Delete the conditional block that starts with:
+
+```tsx
+{entityId && (
+  <Box mt={6} className={classes.entitySubNav}>
+```
+
+and ends after the nested `LEGAL_ENTITY_TABS.map(...)` stack.
+
+- [ ] **Step 3: Remove unused CSS**
+
+In `apps/web/src/routes/_authenticated/route.module.css`, remove:
+
+```css
+.entitySubNav {
+  margin-left: 16px;
+  padding-left: 10px;
+  border-left: 1px solid var(--prive-border);
+}
+
+.subNavLink {
+  border-radius: var(--mantine-radius-lg);
+  padding: 6px 10px;
+  font-size: var(--mantine-font-size-sm);
+}
+```
+
+- [ ] **Step 4: Run focused checks**
+
+Run:
+
+```bash
+vp check
+```
+
+Expected: PASS with no format or lint errors.
+
+Run:
+
+```bash
+vp run --filter web check-types
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add apps/web/src/routes/_authenticated/route.tsx apps/web/src/routes/_authenticated/route.module.css
+git commit -m "refactor: simplify legal entity sidebar navigation"
+```
+
+---
+
+### Task 5: Final Validation And Responsive Inspection
+
+**Files:**
+- Inspect: `apps/web/src/routes/_authenticated/legal-entities/index.tsx`
+- Inspect: `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`
+- Inspect: `apps/web/src/routes/_authenticated/route.tsx`
+- Inspect: `apps/web/src/routeTree.gen.ts`
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: validated implementation branch ready for review.
+
+- [ ] **Step 1: Check route tree status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: either clean or only intentional files changed. If `apps/web/src/routeTree.gen.ts` changed because tooling regenerated it, inspect it:
+
+```bash
+git diff -- apps/web/src/routeTree.gen.ts
+```
+
+Expected: generated route tree changes only.
+
+- [ ] **Step 2: Run full checks**
+
+Run:
+
+```bash
+vp check
+```
+
+Expected: PASS with no format or lint errors.
+
+Run:
+
+```bash
+vp test
+```
+
+Expected: PASS when required env vars are present. If it fails with the known missing env vars in `packages/env/src/server.test.ts`, record the exact missing variables and run the focused helper test:
+
+```bash
+vp test apps/web/src/lib/legal-entity-navigation.test.ts
+```
+
+Expected: PASS for the helper test.
+
+- [ ] **Step 3: Run the web app for manual inspection**
+
+Run:
+
+```bash
+vp run dev:web
+```
+
+Expected: the dev server prints a local URL.
+
+Open the printed URL and inspect these paths at desktop and mobile widths:
+
+```text
+/legal-entities
+/legal-entities/<existing-legal-entity-id>/overview
+/legal-entities/<existing-legal-entity-id>/documents
+/legal-entities/<existing-legal-entity-id>/bank-accounts
+/legal-entities/<existing-legal-entity-id>/salons
+```
+
+Confirm:
+
+- Hub entries show direct actions without relying on the sidebar.
+- Detail pages show `Back to legal entities`.
+- Detail pages show local tabs.
+- The Documents action/tab shows the unassigned document count when present.
+- The entity switcher changes entities and preserves the active section.
+- Mobile access to subpages works without opening the sidebar.
+
+- [ ] **Step 4: Commit generated changes if needed**
+
+If `apps/web/src/routeTree.gen.ts` changed and the diff is generated-only, run:
+
+```bash
+git add apps/web/src/routeTree.gen.ts
+git commit -m "chore: update route tree"
+```
+
+If no generated changes exist, skip this commit.
+
+- [ ] **Step 5: Summarize final state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: clean status and recent commits for the helper, hub, detail navigation, and sidebar simplification.
+
+Report:
+
+- Current branch name.
+- Commits created.
+- Verification commands and results.
+- Any known baseline environment failure that remains.

--- a/docs/superpowers/specs/2026-07-19-legal-entities-ui-access-design.md
+++ b/docs/superpowers/specs/2026-07-19-legal-entities-ui-access-design.md
@@ -1,0 +1,117 @@
+# Legal Entities UI Access Design
+
+## Context
+
+The legal entities area currently has a plain list at `/legal-entities` and entity-specific navigation that appears in the global sidebar only after an entity is selected. This makes several common paths feel hidden:
+
+- Finding a specific legal entity.
+- Discovering entity subpages: Overview, Documents, Bank accounts, and Salons.
+- Moving from one legal entity to another.
+- Finding where document upload and assignment work happens.
+
+The route serves both frequent operators, such as admins and bookkeepers, and occasional users, such as owners or managers. The expected legal entity count is small, usually one to five entities, so the design should favor direct access and clarity over heavy filtering.
+
+## Goals
+
+- Make `/legal-entities` a clear hub for all legal entities and their primary actions.
+- Make entity subpage access visible inside each legal entity page without requiring the global sidebar.
+- Allow switching between legal entities while staying in the same task area when possible.
+- Surface pending document work at decision points.
+- Keep the implementation aligned with existing Mantine and TanStack Router patterns.
+
+## Non-Goals
+
+- Add legal entity creation unless an existing flow already supports it.
+- Add heavy search, filtering, or sorting for large legal entity sets.
+- Redesign unrelated workspace navigation.
+- Change backend document scoping unless existing APIs already support it.
+
+## User Experience
+
+### Legal Entities Hub
+
+`/legal-entities` should become a compact hub rather than a plain table. Each entity should be shown as a scannable card or enhanced row with:
+
+- Entity name as the primary entry point.
+- Type, country, and default currency as secondary identity details.
+- Direct actions for Overview, Documents, Bank accounts, and Salons.
+- A pending document badge on the Documents action when there are unassigned documents.
+
+Because the expected entity count is small, all entities should be visible without requiring search. The layout should remain compact on desktop and readable on mobile, with direct actions still reachable without opening the global sidebar.
+
+### Entity Detail Navigation
+
+`/legal-entities/$legalEntityId` should own local navigation for entity-level tasks:
+
+- Add a subtle `Back to legal entities` link above the page header.
+- Keep the existing page header with legal entity name, type, country, and currency.
+- Add local tabs below the header for Overview, Documents, Bank accounts, and Salons.
+- Add a pending document badge to the Documents tab when unassigned documents exist.
+- Keep the existing Edit action.
+- Add an entity switcher in the header actions.
+
+The local tabs should follow the customer detail route precedent, where users can move between related subpages from the page itself. After this is added, the legal-entity subnav in the global sidebar should be removed or de-emphasized. The sidebar should keep `Legal entities` as the global entry point, with its existing pending document badge if still useful.
+
+### Entity Switching
+
+The entity switcher should list the small set of legal entities by name. When the user selects another legal entity, navigation should preserve the current section when possible:
+
+- From Overview to the selected entity's Overview.
+- From Documents to the selected entity's Documents.
+- From Bank accounts to the selected entity's Bank accounts.
+- From Salons to the selected entity's Salons.
+
+If the current path cannot map cleanly, fall back to the selected entity's Overview.
+
+### Document Access
+
+The current documents page works with unassigned documents globally. The UI should preserve this behavior unless backend support for entity-specific document scoping already exists.
+
+To avoid misleading users, document labels should continue to say `Unassigned documents` where appropriate. Pending document counts should appear at access points, but should not imply the pending files belong only to the selected legal entity.
+
+## Components And Data
+
+### Routes
+
+- `apps/web/src/routes/_authenticated/legal-entities/index.tsx`
+  - Render the entity hub.
+  - Query `trpc.legalEntities.list`.
+  - Query `trpc.bankStatementAttachments.list({ assigned: false })` for the pending document count.
+
+- `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`
+  - Render the back link, page header, edit modal, entity switcher, local tabs, and outlet.
+  - Query `trpc.legalEntities.get` for the current entity.
+  - Query `trpc.legalEntities.list` for the entity switcher.
+  - Query `trpc.bankStatementAttachments.list({ assigned: false })` for the Documents tab badge.
+
+- `apps/web/src/routes/_authenticated/route.tsx`
+  - Keep `Legal entities` as a global navigation item.
+  - Remove or reduce the nested legal entity sidebar subnav once local tabs exist.
+
+### Shared Helpers
+
+If the hub and detail layout duplicate action or tab metadata, introduce a small local helper near the legal-entity routes. The helper should define tab labels, icons, path values, and badge behavior. Avoid broader abstractions unless duplication becomes meaningful.
+
+## Edge Cases
+
+- No legal entities: show a clear empty state on the hub. Do not add creation unless an existing route or mutation already supports it.
+- Missing legal entity: show a concise not-found state with a link back to `/legal-entities`.
+- Loading state: keep labels stable and avoid layout shifts where possible.
+- Mobile: local tabs and hub actions must remain reachable without relying on the collapsed sidebar.
+
+## Acceptance Criteria
+
+- A user can land on `/legal-entities` and immediately see each entity plus direct paths to Overview, Documents, Bank accounts, and Salons.
+- A user inside an entity can switch subpages without opening the global sidebar.
+- A user inside an entity can switch to another legal entity and stay on the equivalent subpage when possible.
+- Pending unassigned document work is visible on the hub and detail Documents tab.
+- Mobile access to legal entity subpages does not depend on opening the sidebar.
+- The global sidebar remains a stable entry point to legal entities without being the only place entity subpages are discoverable.
+
+## Verification
+
+- Run `vp check`.
+- Run `vp test`.
+- If responsive layout changes are implemented, run the web app locally and inspect desktop and mobile behavior.
+
+The current baseline `vp test` fails before this design work when required environment variables for `packages/env/src/server.test.ts` are missing. That should be treated as an environment setup issue unless it persists with the expected env file or variables present.


### PR DESCRIPTION
## Summary
- Add a legal entities hub with direct Overview, Documents, Bank accounts, and Salons actions
- Add local entity detail tabs, back navigation, entity switching, and clearer document indicators
- Simplify the global sidebar by removing the context-only legal entity subnav
- Add responsive header behavior and clearer loading/not-found/error states

## Validation
- vp check: passed
- vp run --filter web check-types: passed
- vp test apps/web/src/lib/legal-entity-navigation.test.ts: passed
- Browser validation: desktop/mobile legal-entity hub and detail routes, document count badge, and entity switching preserving Documents route

## Known issue
- Full vp test currently fails because test discovery includes ignored .worktrees/* and packages/*/dist test files. This was reproduced before/after and is not caused by this branch.