### PR TITLE
fix: repair dependency update workflow

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -39,16 +39,15 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            set -o pipefail
+            set -eo pipefail
             log=$(mktemp)
-            pnpm dlx taze major -r -w --maturity-period 7 --concurrency 3 2>&1 | tee "$log"
+            vp dlx taze major -r -w --maturity-period 7 --concurrency 3 2>&1 | tee "$log"
             if grep -q 'Timeout requesting' "$log"; then
-              echo "::warning::taze hit registry timeouts; failing step to trigger retry"
-              exit 1
+              echo "::warning::taze hit registry timeouts for one or more packages; continuing with resolved updates"
             fi
 
       - name: Update Lockfile
-        run: vp install
+        run: vp install --no-frozen-lockfile
 
       - name: Create or Update Pull Request
         uses: peter-evans/create-pull-request@v8
@@ -59,7 +58,7 @@ jobs:
           commit-message: "fix(deps): bump dependencies via taze major"
           title: "fix(deps): nightly dependency updates"
           body: |
-            Automated nightly run of `pnpm dlx taze major -r -w` followed by `vp install`.
+            Automated nightly run of `vp dlx taze major -r -w` followed by `vp install`.
 
             This PR is updated each night with any newly outdated packages until merged or closed.
           labels: dependencies


### PR DESCRIPTION
## Summary
- run taze through Vite+ with `vp dlx` so CI has the package executor available
- keep real command failures fatal with `set -eo pipefail`
- treat taze registry metadata timeouts as warnings so resolved updates can still continue
- allow `vp install` to update the lockfile after taze changes manifests/catalogs

## Verification
- `vp check`
- workflow dispatched from temp branch and completed successfully: https://github.com/moreorover/prive-admin/actions/runs/29752506206
- dependency update PR was created by the fixed workflow: https://github.com/moreorover/prive-admin/pull/243