### PR TITLE
chore: align config with TypeScript 7

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,11 +15,9 @@
 
     /* Linting */
     "skipLibCheck": true,
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     "paths": {
       "@/*": ["./src/*"],
       "@prive-admin-tanstack/ui/*": ["../../packages/ui/src/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,4 +44,8 @@ export default defineConfig({
       },
     ],
   },
+  test: {
+    include: ["{apps,packages}/**/src/**/*.test.{ts,tsx}"],
+    exclude: ["**/dist/**", "**/node_modules/**", ".worktrees/**"],
+  },
 })


### PR DESCRIPTION
## Summary
- remove web tsconfig options that are now TypeScript 7 defaults
- scope root Vite+ test discovery to source tests under apps and packages
- exclude dist, node_modules, and local .worktrees from root test discovery

## Validation
- vp install
- vp check
- vp test
- vp run check-types
- vp run build

## Notes
- Vite+ still warns that local pnpm 11.11.0 differs from devEngines.packageManager 11.9.0.
- tsdown still warns that TypeScript 7.0 has no stable compiler API yet, but builds complete.