### PR TITLE
feat: redesign admin header navigation

### DIFF
--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -12,8 +12,8 @@ export function PageHeader({
   actions?: ReactNode
 }) {
   return (
-    <Group justify="space-between" align="flex-start" wrap="wrap" mb="lg">
-      <Stack gap={4} miw={0} flex={1}>
+    <Group justify="space-between" align="flex-start" wrap="wrap" mb="lg" gap="md">
+      <Stack gap={4} miw={0} flex="1 1 22rem">
         <Title order={2} fw={600} lh={1.2}>
           {title}
         </Title>
@@ -24,7 +24,7 @@ export function PageHeader({
         ) : null}
       </Stack>
       {actions ? (
-        <Group gap="xs" wrap="wrap" w={{ base: "100%", sm: "auto" }}>
+        <Group gap="xs" wrap="wrap" className="prive-page-header-actions" w={{ base: "100%", sm: "auto" }}>
           {actions}
         </Group>
       ) : null}

--- a/apps/web/src/components/section.tsx
+++ b/apps/web/src/components/section.tsx
@@ -18,11 +18,11 @@ export function Section({
   const hasHeader = title || description || actions
 
   return (
-    <Card padding={0}>
+    <Card padding={0} className="prive-section">
       {hasHeader ? (
         <>
-          <Group justify="space-between" align="flex-start" wrap="nowrap" p="lg" pb="md">
-            <Stack gap={2} miw={0}>
+          <Group justify="space-between" align="flex-start" wrap="wrap" p="lg" pb="md" gap="md">
+            <Stack gap={2} miw={0} flex="1 1 18rem">
               {title ? (
                 <Title order={4} fw={600} lh={1.3}>
                   {title}
@@ -35,7 +35,7 @@ export function Section({
               ) : null}
             </Stack>
             {actions ? (
-              <Group gap="xs" wrap="nowrap">
+              <Group gap="xs" wrap="wrap" className="prive-section-actions">
                 {actions}
               </Group>
             ) : null}
@@ -43,7 +43,9 @@ export function Section({
           <Divider />
         </>
       ) : null}
-      <Box p={padding}>{children}</Box>
+      <Box p={padding} className="prive-section-body">
+        {children}
+      </Box>
     </Card>
   )
 }

--- a/apps/web/src/lib/app-navigation.test.ts
+++ b/apps/web/src/lib/app-navigation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import { appNavGroups, flatAppNavItems, getActiveAppNavItem } from "./app-navigation"
+
+describe("app navigation", () => {
+  it("keeps settings as a visible account navigation item", () => {
+    expect(appNavGroups.find((group) => group.label === "Account")?.items.map((item) => item.to)).toContain("/settings")
+  })
+
+  it("marks nested routes by their parent navigation item", () => {
+    expect(getActiveAppNavItem("/customers/123")?.to).toBe("/customers")
+    expect(getActiveAppNavItem("/legal-entities/entity-1/documents")?.to).toBe("/legal-entities")
+    expect(getActiveAppNavItem("/hair-orders/order-1")?.to).toBe("/hair-orders")
+  })
+
+  it("keeps the unassigned badge on legal entities", () => {
+    expect(flatAppNavItems.find((item) => item.to === "/legal-entities")?.badgeKey).toBe("unassigned")
+  })
+})

--- a/apps/web/src/lib/app-navigation.ts
+++ b/apps/web/src/lib/app-navigation.ts
@@ -9,7 +9,7 @@ import {
   IconUsers,
 } from "@tabler/icons-react"
 
-export type AppNavBadgeKey = "unassigned"
+type AppNavBadgeKey = "unassigned"
 
 export type AppNavItem = {
   to: string

--- a/apps/web/src/lib/app-navigation.ts
+++ b/apps/web/src/lib/app-navigation.ts
@@ -1,0 +1,61 @@
+import {
+  IconBuildingBank,
+  IconCalendar,
+  IconCash,
+  IconLayoutDashboard,
+  IconReceipt,
+  IconScissors,
+  IconSettings,
+  IconUsers,
+} from "@tabler/icons-react"
+
+export type AppNavBadgeKey = "unassigned"
+
+export type AppNavItem = {
+  to: string
+  label: string
+  shortLabel?: string
+  icon: typeof IconUsers
+  badgeKey?: AppNavBadgeKey
+}
+
+export type AppNavGroup = {
+  label: "Workspace" | "Manage" | "Account"
+  items: AppNavItem[]
+}
+
+export const appNavGroups: AppNavGroup[] = [
+  {
+    label: "Workspace",
+    items: [
+      { to: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
+      { to: "/customers", label: "Customers", icon: IconUsers },
+      { to: "/calendar", label: "Calendar", icon: IconCalendar },
+      { to: "/hair-orders", label: "Hair orders", shortLabel: "Orders", icon: IconScissors },
+      { to: "/hair-sales", label: "Hair sales", shortLabel: "Sales", icon: IconReceipt },
+      { to: "/cash", label: "Cash", icon: IconCash },
+    ],
+  },
+  {
+    label: "Manage",
+    items: [
+      {
+        to: "/legal-entities",
+        label: "Legal entities",
+        shortLabel: "Entities",
+        icon: IconBuildingBank,
+        badgeKey: "unassigned",
+      },
+    ],
+  },
+  {
+    label: "Account",
+    items: [{ to: "/settings", label: "Settings", icon: IconSettings }],
+  },
+]
+
+export const flatAppNavItems = appNavGroups.flatMap((group) => group.items)
+
+export function getActiveAppNavItem(pathname: string) {
+  return flatAppNavItems.find((item) => pathname === item.to || pathname.startsWith(`${item.to}/`))
+}

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -7,6 +7,7 @@ import {
   NativeSelect,
   Pagination,
   Select,
+  Table,
   TextInput,
 } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
@@ -108,7 +109,7 @@ function CashPage() {
       />
 
       <Section padding="lg">
-        <Group align="flex-end" mb="md">
+        <Group align="flex-end" mb="md" gap="sm" wrap="wrap">
           <TextInput
             label="Search"
             placeholder="Description, notes, or customer"
@@ -117,8 +118,7 @@ function CashPage() {
             onChange={(event) => {
               updateFilters({ search: event.currentTarget.value })
             }}
-            miw={260}
-            flex={1}
+            flex="1 1 18rem"
           />
           <Select
             label="Customer"
@@ -134,6 +134,7 @@ function CashPage() {
               const option = customerOptions.find((candidate) => candidate.value === value)
               setSelectedCustomerOption(option ?? null)
             }}
+            w={{ base: "100%", xs: 180 }}
           />
           <NativeSelect
             label="Currency"
@@ -146,6 +147,7 @@ function CashPage() {
             onChange={(event) => {
               updateFilters({ currency: event.currentTarget.value as CashTransactionCurrencyFilter })
             }}
+            w={{ base: "100%", xs: 180 }}
           />
           <NativeSelect
             label="Direction"
@@ -158,6 +160,7 @@ function CashPage() {
             onChange={(event) => {
               updateFilters({ direction: event.currentTarget.value as CashTransactionDirection })
             }}
+            w={{ base: "100%", xs: 180 }}
           />
           <DateInput
             label="From"
@@ -167,6 +170,7 @@ function CashPage() {
             onChange={(value) => {
               updateFilters({ dateFrom: value ?? "" })
             }}
+            w={{ base: "100%", xs: 180 }}
           />
           <DateInput
             label="To"
@@ -176,12 +180,15 @@ function CashPage() {
             onChange={(value) => {
               updateFilters({ dateTo: value ?? "" })
             }}
+            w={{ base: "100%", xs: 180 }}
           />
         </Group>
 
         <Box pos="relative">
           <LoadingOverlay visible={isFetching} />
-          <CashTransactionsTable items={result?.items ?? []} onEdit={setEditing} onDelete={setDeleting} />
+          <Table.ScrollContainer minWidth={760}>
+            <CashTransactionsTable items={result?.items ?? []} onEdit={setEditing} onDelete={setDeleting} />
+          </Table.ScrollContainer>
         </Box>
 
         <Group justify="flex-end" mt="md">

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -116,43 +116,47 @@ function CustomersPage() {
             {totalCount} customer{totalCount === 1 ? "" : "s"}
           </Text>
         </Group>
-        <Table>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>Name</Table.Th>
-              <Table.Th>Phone</Table.Th>
-              <Table.Th>Created</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {customers.map((c) => (
-              <Table.Tr key={c.id}>
-                <Table.Td>
-                  <Text
-                    renderRoot={(props) => (
-                      <Link to="/customers/$customerId" params={{ customerId: c.id }} {...props} />
-                    )}
-                    c="blue"
-                    fw={500}
-                  >
-                    {c.name}
-                  </Text>
-                </Table.Td>
-                <Table.Td c="dimmed">{c.phoneNumber ?? "—"}</Table.Td>
-                <Table.Td c="dimmed">
-                  <ClientDate date={c.createdAt} />
-                </Table.Td>
-              </Table.Tr>
-            ))}
-            {customers.length === 0 && (
+        <Table.ScrollContainer minWidth={640}>
+          <Table>
+            <Table.Thead>
               <Table.Tr>
-                <Table.Td colSpan={3} ta="center" c="dimmed">
-                  {searchValue.trim() ? "No customers match your search." : "No customers yet. Create your first one."}
-                </Table.Td>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Phone</Table.Th>
+                <Table.Th>Created</Table.Th>
               </Table.Tr>
-            )}
-          </Table.Tbody>
-        </Table>
+            </Table.Thead>
+            <Table.Tbody>
+              {customers.map((c) => (
+                <Table.Tr key={c.id}>
+                  <Table.Td>
+                    <Text
+                      renderRoot={(props) => (
+                        <Link to="/customers/$customerId" params={{ customerId: c.id }} {...props} />
+                      )}
+                      c="blue"
+                      fw={500}
+                    >
+                      {c.name}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td c="dimmed">{c.phoneNumber ?? "—"}</Table.Td>
+                  <Table.Td c="dimmed">
+                    <ClientDate date={c.createdAt} />
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+              {customers.length === 0 && (
+                <Table.Tr>
+                  <Table.Td colSpan={3} ta="center" c="dimmed">
+                    {searchValue.trim()
+                      ? "No customers match your search."
+                      : "No customers yet. Create your first one."}
+                  </Table.Td>
+                </Table.Tr>
+              )}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
         <Group justify="space-between" p="md">
           <Text size="sm" c="dimmed">
             Page {Math.min(page, totalPages)} of {totalPages}

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -105,7 +105,7 @@ function DashboardPage() {
         title="Dashboard"
         description="Monthly performance against the previous month."
         actions={
-          <Group gap="xs" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap" w={{ base: "100%", sm: "auto" }}>
             <ActionIcon variant="default" aria-label="Previous month" onClick={() => changeMonth(-1)}>
               <IconChevronLeft size={16} />
             </ActionIcon>
@@ -115,7 +115,8 @@ function DashboardPage() {
               onChange={(value) => goToMonth(value ? new Date(value) : null)}
               valueFormat="MMMM YYYY"
               popoverProps={{ withinPortal: false }}
-              w={190}
+              flex={{ base: 1, sm: "unset" }}
+              miw={170}
             />
             <ActionIcon variant="default" aria-label="Next month" onClick={() => changeMonth(1)}>
               <IconChevronRight size={16} />

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, Group, Modal, NumberInput, Select, Stack, Text } from "@mantine/core"
+import { Button, Container, Group, Modal, NumberInput, Select, Stack, Table, Text } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
@@ -125,7 +125,9 @@ function HairOrdersPage() {
         }
       />
       <Section padding="lg">
-        <HairOrdersTable hairOrders={hairOrders} isLoading={isLoading} />
+        <Table.ScrollContainer minWidth={760}>
+          <HairOrdersTable hairOrders={hairOrders} isLoading={isLoading} />
+        </Table.ScrollContainer>
         {showPagination && (
           <Group justify="space-between" mt="md">
             <Text size="sm" c="dimmed">

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -144,7 +144,7 @@ function LegalEntityLayout() {
       <Stack>
         <Tabs value={activeSection} onChange={handleSectionChange}>
           <Box style={{ overflowX: "auto" }}>
-            <Tabs.List>
+            <Tabs.List style={{ flexWrap: "nowrap", minWidth: "max-content" }}>
               {LEGAL_ENTITY_SECTIONS.map((section) => (
                 <Tabs.Tab
                   key={section.value}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -1,4 +1,17 @@
-import { Anchor, Badge, Button, Container, Group, Modal, Select, Stack, Tabs, Text, TextInput } from "@mantine/core"
+import {
+  Anchor,
+  Badge,
+  Box,
+  Button,
+  Container,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Tabs,
+  Text,
+  TextInput,
+} from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { useDisclosure } from "@mantine/hooks"
 import { notifications } from "@mantine/notifications"
@@ -130,23 +143,25 @@ function LegalEntityLayout() {
       />
       <Stack>
         <Tabs value={activeSection} onChange={handleSectionChange}>
-          <Tabs.List>
-            {LEGAL_ENTITY_SECTIONS.map((section) => (
-              <Tabs.Tab
-                key={section.value}
-                value={section.value}
-                rightSection={
-                  section.value === "documents" && unassignedCount > 0 ? (
-                    <Badge size="xs" variant="filled" color="orange" circle>
-                      {unassignedCount}
-                    </Badge>
-                  ) : null
-                }
-              >
-                {section.label}
-              </Tabs.Tab>
-            ))}
-          </Tabs.List>
+          <Box style={{ overflowX: "auto" }}>
+            <Tabs.List>
+              {LEGAL_ENTITY_SECTIONS.map((section) => (
+                <Tabs.Tab
+                  key={section.value}
+                  value={section.value}
+                  rightSection={
+                    section.value === "documents" && unassignedCount > 0 ? (
+                      <Badge size="xs" variant="filled" color="orange" circle>
+                        {unassignedCount}
+                      </Badge>
+                    ) : null
+                  }
+                >
+                  {section.label}
+                </Tabs.Tab>
+              ))}
+            </Tabs.List>
+          </Box>
         </Tabs>
 
         <Outlet />

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -1,80 +1,81 @@
+.header {
+  position: relative;
+  background: color-mix(in srgb, var(--mantine-color-body) 78%, transparent);
+  border-bottom: 1px solid var(--prive-border);
+  backdrop-filter: blur(18px);
+}
+
+.topRow {
+  height: 56px;
+  border-bottom: 1px solid var(--prive-border);
+}
+
+.tabsRow {
+  height: 56px;
+  align-items: flex-start;
+  padding-top: 7px;
+}
+
+.ledgerRule {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 22px;
+  border-top: 1px solid color-mix(in srgb, var(--prive-champagne) 58%, var(--prive-border));
+  color: var(--mantine-color-text);
+}
+
+.desktopNavLink,
+.drawerNavLink {
+  display: block;
+  border: 1px solid transparent;
+  color: var(--mantine-color-dimmed);
+  transition:
+    background-color 80ms ease,
+    border-color 80ms ease,
+    color 80ms ease;
+
+  &:hover {
+    background-color: color-mix(in srgb, var(--prive-surface-muted) 74%, transparent);
+    border-color: var(--prive-border);
+    color: var(--mantine-color-text);
+  }
+
+  &[data-active] {
+    border-color: color-mix(in srgb, var(--prive-champagne) 72%, var(--prive-border));
+    color: var(--mantine-color-text);
+    font-weight: 600;
+  }
+}
+
+.desktopNavLink {
+  padding: 7px 10px;
+  border-radius: var(--mantine-radius-sm);
+}
+
+.drawerNavLink {
+  padding: 9px 10px;
+  border-radius: var(--mantine-radius-sm);
+}
+
+.navLinkIcon {
+  color: var(--prive-champagne);
+}
+
 .brand {
   font-family: var(--mantine-font-family-headings);
   font-size: 1.28rem;
   font-variation-settings:
     "SOFT" 20,
     "WONK" 1;
-  letter-spacing: -0.035em;
-}
-
-.navBrand {
-  border-bottom: 1px solid var(--prive-border);
-}
-
-.navbar {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--prive-surface-strong) 92%, transparent),
-      color-mix(in srgb, var(--mantine-color-body) 92%, transparent)
-    ),
-    var(--mantine-color-body);
-  border-right: 1px solid var(--prive-border);
-  backdrop-filter: blur(18px);
-}
-
-.navFooter {
-  border-top: 1px solid var(--prive-border);
-}
-
-.navLink {
-  display: block;
-  padding: 8px 10px;
-  border: 1px solid transparent;
-  border-radius: var(--mantine-radius-lg);
-  color: var(--mantine-color-dimmed);
-  transition:
-    background-color 80ms ease,
-    border-color 80ms ease,
-    color 80ms ease,
-    transform 80ms ease;
-
-  &:hover {
-    background-color: color-mix(in srgb, var(--prive-surface-muted) 74%, transparent);
-    border-color: var(--prive-border);
-    color: var(--mantine-color-text);
-    transform: translateX(1px);
-  }
-
-  &[data-active] {
-    background:
-      linear-gradient(
-        135deg,
-        color-mix(in srgb, var(--prive-surface-strong) 84%, transparent),
-        color-mix(in srgb, var(--prive-champagne) 18%, var(--prive-surface-muted))
-      ),
-      var(--mantine-color-body);
-    border-color: color-mix(in srgb, var(--prive-champagne) 42%, var(--prive-border));
-    color: var(--mantine-color-text);
-    font-weight: 600;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  }
-}
-
-.header {
-  background: color-mix(in srgb, var(--mantine-color-body) 78%, transparent);
-  border-bottom: 1px solid var(--prive-border);
-  backdrop-filter: blur(18px);
+  letter-spacing: 0;
 }
 
 .main {
-  background: transparent;
   min-height: 100vh;
-}
-
-.sectionLabel {
-  letter-spacing: 0.075em;
-  font-size: 11px;
+  padding: var(--mantine-spacing-lg) 0 var(--mantine-spacing-xl);
+  background: transparent;
 }
 
 .user {
@@ -95,4 +96,16 @@
 .userActive {
   background-color: color-mix(in srgb, var(--prive-surface-muted) 82%, transparent);
   border-color: var(--prive-border);
+}
+
+@media (max-width: 47.9375em) {
+  .topRow {
+    height: 64px;
+    padding-inline: var(--mantine-spacing-md);
+  }
+
+  .tabsRow,
+  .ledgerRule {
+    display: none;
+  }
 }

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -6,17 +6,21 @@
 }
 
 .topRow {
-  height: 56px;
+  height: 64px;
   border-bottom: 1px solid var(--prive-border);
 }
 
 .tabsRow {
+  display: none;
   height: 56px;
-  align-items: flex-start;
-  padding-top: 7px;
+  align-items: center;
+  box-sizing: border-box;
+  padding-top: 0;
+  padding-bottom: 22px;
 }
 
 .ledgerRule {
+  display: none;
   position: absolute;
   right: 0;
   bottom: 0;
@@ -50,7 +54,7 @@
 }
 
 .desktopNavLink {
-  padding: 7px 10px;
+  padding: 5px 10px;
   border-radius: var(--mantine-radius-sm);
 }
 
@@ -98,14 +102,13 @@
   border-color: var(--prive-border);
 }
 
-@media (max-width: 47.9375em) {
+@media (min-width: 75em) {
   .topRow {
-    height: 64px;
-    padding-inline: var(--mantine-spacing-md);
+    height: 56px;
   }
 
   .tabsRow,
   .ledgerRule {
-    display: none;
+    display: flex;
   }
 }

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -1,26 +1,19 @@
 .header {
-  background: color-mix(in srgb, var(--mantine-color-body) 78%, transparent);
+  background: var(--prive-surface-strong);
   border-bottom: 1px solid var(--prive-border);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(12px);
 }
 
 .topRow {
   height: 64px;
-  border-bottom: 1px solid var(--prive-border);
 }
 
 .tabsRow {
   display: none;
-  height: 34px;
-  align-items: center;
+  height: 46px;
+  align-items: flex-end;
   box-sizing: border-box;
-}
-
-.ledgerRule {
-  display: none;
-  height: 22px;
-  border-top: 1px solid color-mix(in srgb, var(--prive-champagne) 58%, var(--prive-border));
-  color: var(--mantine-color-text);
+  border-top: 1px solid color-mix(in srgb, var(--prive-border) 76%, transparent);
 }
 
 .desktopNavLink,
@@ -34,20 +27,46 @@
     color 80ms ease;
 
   &:hover {
-    background-color: color-mix(in srgb, var(--prive-surface-muted) 74%, transparent);
-    border-color: var(--prive-border);
+    background-color: color-mix(in srgb, var(--mantine-color-default-hover) 80%, transparent);
     color: var(--mantine-color-text);
   }
 
   &[data-active] {
-    border-color: color-mix(in srgb, var(--prive-champagne) 72%, var(--prive-border));
     color: var(--mantine-color-text);
     font-weight: 600;
   }
 }
 
 .desktopNavLink {
-  padding: 5px 10px;
+  position: relative;
+  bottom: -1px;
+  height: 38px;
+  padding: 0 14px;
+  border-color: transparent;
+  border-radius: var(--mantine-radius-sm) var(--mantine-radius-sm) 0 0;
+  background: transparent;
+
+  &[data-active] {
+    background: var(--mantine-color-body);
+    border-color: var(--prive-border);
+    border-bottom-color: var(--mantine-color-body);
+  }
+}
+
+.desktopNavLink:hover {
+  border-color: var(--prive-border);
+  border-bottom-color: transparent;
+}
+
+.desktopNavLink[data-active]:hover {
+  border-bottom-color: var(--mantine-color-body);
+}
+
+.desktopNavLink [class*="mantine-Group-root"] {
+  height: 100%;
+}
+
+.desktopNavLink .mantine-Badge-root {
   border-radius: var(--mantine-radius-sm);
 }
 
@@ -79,7 +98,7 @@
   color: var(--mantine-color-text);
   padding: 6px 8px;
   border: 1px solid transparent;
-  border-radius: var(--mantine-radius-xl);
+  border-radius: var(--mantine-radius-sm);
   transition:
     background-color 100ms ease,
     border-color 100ms ease;
@@ -101,7 +120,7 @@
   }
 
   .tabsRow,
-  .ledgerRule {
+  .desktopNavLink {
     display: flex;
   }
 }

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -13,7 +13,6 @@
   height: 46px;
   align-items: flex-end;
   box-sizing: border-box;
-  border-top: 1px solid color-mix(in srgb, var(--prive-border) 76%, transparent);
 }
 
 .desktopNavLink,

--- a/apps/web/src/routes/_authenticated/route.module.css
+++ b/apps/web/src/routes/_authenticated/route.module.css
@@ -1,5 +1,4 @@
 .header {
-  position: relative;
   background: color-mix(in srgb, var(--mantine-color-body) 78%, transparent);
   border-bottom: 1px solid var(--prive-border);
   backdrop-filter: blur(18px);
@@ -12,19 +11,13 @@
 
 .tabsRow {
   display: none;
-  height: 56px;
+  height: 34px;
   align-items: center;
   box-sizing: border-box;
-  padding-top: 0;
-  padding-bottom: 22px;
 }
 
 .ledgerRule {
   display: none;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
   height: 22px;
   border-top: 1px solid color-mix(in srgb, var(--prive-champagne) 58%, var(--prive-border));
   color: var(--mantine-color-text);
@@ -78,7 +71,7 @@
 
 .main {
   min-height: 100vh;
-  padding: var(--mantine-spacing-lg) 0 var(--mantine-spacing-xl);
+  padding: calc(var(--app-shell-header-offset, 0px) + var(--mantine-spacing-lg)) 0 var(--mantine-spacing-xl);
   background: transparent;
 }
 

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -89,7 +89,7 @@ function HeaderTop({ opened, onToggle }: { opened: boolean; onToggle: () => void
   return (
     <Group className={classes.topRow} px="lg" justify="space-between" wrap="nowrap">
       <Group gap="sm" wrap="nowrap">
-        <Burger opened={opened} onClick={onToggle} hiddenFrom="sm" size="sm" aria-label="Toggle navigation" />
+        <Burger opened={opened} onClick={onToggle} hiddenFrom="lg" size="sm" aria-label="Toggle navigation" />
         <Title order={4} fw={600} className={classes.brand}>
           Privé
         </Title>

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -9,9 +9,9 @@ import {
   Burger,
   Button,
   Card,
+  Drawer,
   Group,
   Menu,
-  ScrollArea,
   Stack,
   Text,
   Title,
@@ -22,52 +22,23 @@ import {
 import { useDisclosure } from "@mantine/hooks"
 import {
   IconAlertCircle,
-  IconBuildingBank,
-  IconCalendar,
-  IconCash,
   IconChevronDown,
   IconDeviceDesktop,
-  IconLayoutDashboard,
   IconLogout,
   IconMoon,
-  IconReceipt,
   IconRefresh,
-  IconScissors,
-  IconSettings,
   IconSun,
   IconUserCircle,
-  IconUsers,
 } from "@tabler/icons-react"
 import { useQuery, useQueryErrorResetBoundary } from "@tanstack/react-query"
 import { Link, Outlet, createFileRoute, redirect, useLocation, useNavigate, useRouter } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { appNavGroups, flatAppNavItems, getActiveAppNavItem, type AppNavItem } from "@/lib/app-navigation"
 import { authClient } from "@/lib/auth-client"
 import { trpc } from "@/utils/trpc"
 
 import classes from "./route.module.css"
-
-type NavItem = {
-  to: string
-  label: string
-  icon: typeof IconUsers
-  badgeKey?: "unassigned"
-}
-
-const workspaceNav: NavItem[] = [
-  { to: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
-  { to: "/customers", label: "Customers", icon: IconUsers },
-  { to: "/calendar", label: "Calendar", icon: IconCalendar },
-  { to: "/hair-orders", label: "Hair orders", icon: IconScissors },
-  { to: "/hair-sales", label: "Hair sales", icon: IconReceipt },
-  { to: "/cash", label: "Cash", icon: IconCash },
-]
-
-const manageNav: NavItem[] = [
-  { to: "/legal-entities", label: "Legal entities", icon: IconBuildingBank, badgeKey: "unassigned" },
-]
-
-const footerNav: NavItem[] = [{ to: "/settings", label: "Settings", icon: IconSettings }]
 
 export const Route = createFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
@@ -89,57 +60,23 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedLayout() {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false)
+  const location = useLocation()
 
   const { data: unassignedAttachments = [] } = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
   )
   const badges = { unassigned: unassignedAttachments.length }
+  const activeItem = getActiveAppNavItem(location.pathname)
+  const activeBadge = activeItem?.badgeKey ? badges[activeItem.badgeKey] : 0
 
   return (
-    <AppShell
-      layout="alt"
-      header={{ height: 56 }}
-      navbar={{ width: 248, breakpoint: "sm", collapsed: { mobile: !mobileOpened } }}
-      padding="lg"
-    >
+    <AppShell header={{ height: { base: 64, sm: 112 } }} padding={0}>
       <AppShell.Header className={classes.header}>
-        <Group h="100%" px="lg" justify="space-between" wrap="nowrap">
-          <Group gap="sm" wrap="nowrap">
-            <Burger
-              opened={mobileOpened}
-              onClick={toggleMobile}
-              hiddenFrom="sm"
-              size="sm"
-              aria-label="Toggle navigation"
-            />
-          </Group>
-          <Group gap="xs" wrap="nowrap">
-            <ColorSchemeToggle />
-            <UserSection />
-          </Group>
-        </Group>
+        <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
+        <DesktopTabs badges={badges} />
+        <LedgerRule activeLabel={activeItem?.label ?? "Admin"} activeBadge={activeBadge} />
       </AppShell.Header>
-
-      <AppShell.Navbar className={classes.navbar}>
-        <AppShell.Section className={classes.navBrand}>
-          <Group gap="sm" wrap="nowrap" px="md" py="md">
-            <Title order={4} fw={600} className={classes.brand}>
-              Privé
-            </Title>
-          </Group>
-        </AppShell.Section>
-        <AppShell.Section grow component={ScrollArea} px="xs" py="sm">
-          <SidebarNav badges={badges} onNavigate={closeMobile} />
-        </AppShell.Section>
-        <AppShell.Section px="xs" py="sm" className={classes.navFooter}>
-          <NavSectionLabel>Account</NavSectionLabel>
-          <Stack gap={2}>
-            {footerNav.map((item) => (
-              <TopLink key={item.to} item={item} badge={0} onNavigate={closeMobile} />
-            ))}
-          </Stack>
-        </AppShell.Section>
-      </AppShell.Navbar>
+      <MobileNavigationDrawer opened={mobileOpened} onClose={closeMobile} badges={badges} />
 
       <AppShell.Main className={classes.main}>
         <Outlet />
@@ -148,49 +85,113 @@ function AuthenticatedLayout() {
   )
 }
 
-function SidebarNav({ badges, onNavigate }: { badges: { unassigned: number }; onNavigate: () => void }) {
+function HeaderTop({ opened, onToggle }: { opened: boolean; onToggle: () => void }) {
   return (
-    <Stack gap="md">
-      <Box>
-        <NavSectionLabel>Workspace</NavSectionLabel>
-        <Stack gap={2}>
-          {workspaceNav.map((item) => (
-            <TopLink
-              key={item.to}
-              item={item}
-              badge={item.badgeKey ? badges[item.badgeKey] : 0}
-              onNavigate={onNavigate}
-            />
-          ))}
-        </Stack>
-      </Box>
-
-      <Box>
-        <NavSectionLabel>Manage</NavSectionLabel>
-        <Stack gap={2}>
-          {manageNav.map((item) => (
-            <TopLink
-              key={item.to}
-              item={item}
-              badge={item.badgeKey ? badges[item.badgeKey] : 0}
-              onNavigate={onNavigate}
-            />
-          ))}
-        </Stack>
-      </Box>
-    </Stack>
+    <Group className={classes.topRow} px="lg" justify="space-between" wrap="nowrap">
+      <Group gap="sm" wrap="nowrap">
+        <Burger opened={opened} onClick={onToggle} hiddenFrom="sm" size="sm" aria-label="Toggle navigation" />
+        <Title order={4} fw={600} className={classes.brand}>
+          Privé
+        </Title>
+        <Text size="xs" c="dimmed" fw={600} tt="uppercase" visibleFrom="sm">
+          Atelier Ledger
+        </Text>
+      </Group>
+      <Group gap="xs" wrap="nowrap">
+        <ColorSchemeToggle />
+        <UserSection />
+      </Group>
+    </Group>
   )
 }
 
-function NavSectionLabel({ children }: { children: React.ReactNode }) {
+function DesktopTabs({ badges }: { badges: { unassigned: number } }) {
   return (
-    <Text size="xs" fw={600} c="dimmed" tt="uppercase" px="sm" py={6} className={classes.sectionLabel}>
-      {children}
-    </Text>
+    <Group className={classes.tabsRow} px="lg" gap={2} wrap="nowrap">
+      {flatAppNavItems.map((item) => (
+        <NavLinkButton key={item.to} item={item} badge={item.badgeKey ? badges[item.badgeKey] : 0} variant="desktop" />
+      ))}
+    </Group>
   )
 }
 
-function TopLink({ item, badge, onNavigate }: { item: NavItem; badge: number; onNavigate: () => void }) {
+function LedgerRule({ activeLabel, activeBadge }: { activeLabel: string; activeBadge: number }) {
+  return (
+    <Group className={classes.ledgerRule} px="lg" gap="xs" wrap="nowrap">
+      <Text size="xs" fw={700} tt="uppercase">
+        {activeLabel}
+      </Text>
+      {activeBadge > 0 ? (
+        <Badge size="xs" variant="light" color="yellow">
+          {activeBadge}
+        </Badge>
+      ) : null}
+    </Group>
+  )
+}
+
+function MobileNavigationDrawer({
+  opened,
+  onClose,
+  badges,
+}: {
+  opened: boolean
+  onClose: () => void
+  badges: { unassigned: number }
+}) {
+  return (
+    <Drawer opened={opened} onClose={onClose} title="Privé" size="xs" padding="md">
+      <Stack gap="lg">
+        {appNavGroups.map((group) => (
+          <DrawerNavGroup key={group.label} label={group.label} items={group.items} badges={badges} onClose={onClose} />
+        ))}
+      </Stack>
+    </Drawer>
+  )
+}
+
+function DrawerNavGroup({
+  label,
+  items,
+  badges,
+  onClose,
+}: {
+  label: string
+  items: AppNavItem[]
+  badges: { unassigned: number }
+  onClose: () => void
+}) {
+  return (
+    <Box>
+      <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb={6}>
+        {label}
+      </Text>
+      <Stack gap={2}>
+        {items.map((item) => (
+          <NavLinkButton
+            key={item.to}
+            item={item}
+            badge={item.badgeKey ? badges[item.badgeKey] : 0}
+            variant="drawer"
+            onNavigate={onClose}
+          />
+        ))}
+      </Stack>
+    </Box>
+  )
+}
+
+function NavLinkButton({
+  item,
+  badge,
+  variant,
+  onNavigate,
+}: {
+  item: AppNavItem
+  badge: number
+  variant: "desktop" | "drawer"
+  onNavigate?: () => void
+}) {
   const location = useLocation()
   const active = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`)
   const Icon = item.icon
@@ -201,17 +202,17 @@ function TopLink({ item, badge, onNavigate }: { item: NavItem; badge: number; on
       to={item.to}
       onClick={onNavigate}
       data-active={active || undefined}
-      className={classes.navLink}
+      className={variant === "desktop" ? classes.desktopNavLink : classes.drawerNavLink}
     >
       <Group gap="sm" wrap="nowrap" justify="space-between">
         <Group gap="sm" wrap="nowrap">
-          <Icon size={18} stroke={1.6} />
+          <Icon size={18} stroke={1.6} className={classes.navLinkIcon} />
           <Text size="sm" fw={500}>
-            {item.label}
+            {variant === "desktop" ? (item.shortLabel ?? item.label) : item.label}
           </Text>
         </Group>
         {badge > 0 ? (
-          <Badge size="xs" variant="filled" color="orange" circle>
+          <Badge size="xs" variant="filled" color="yellow" circle>
             {badge}
           </Badge>
         ) : null}

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -70,7 +70,7 @@ function AuthenticatedLayout() {
   const activeBadge = activeItem?.badgeKey ? badges[activeItem.badgeKey] : 0
 
   return (
-    <AppShell header={{ height: { base: 64, sm: 112 } }} padding={0}>
+    <AppShell header={{ height: { base: 64, lg: 112 } }} padding={0}>
       <AppShell.Header className={classes.header}>
         <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
         <DesktopTabs badges={badges} />

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -34,7 +34,7 @@ import { useQuery, useQueryErrorResetBoundary } from "@tanstack/react-query"
 import { Link, Outlet, createFileRoute, redirect, useLocation, useNavigate, useRouter } from "@tanstack/react-router"
 import { useState } from "react"
 
-import { appNavGroups, flatAppNavItems, getActiveAppNavItem, type AppNavItem } from "@/lib/app-navigation"
+import { appNavGroups, flatAppNavItems, type AppNavItem } from "@/lib/app-navigation"
 import { authClient } from "@/lib/auth-client"
 import { trpc } from "@/utils/trpc"
 
@@ -60,21 +60,17 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedLayout() {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false)
-  const location = useLocation()
 
   const { data: unassignedAttachments = [] } = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
   )
   const badges = { unassigned: unassignedAttachments.length }
-  const activeItem = getActiveAppNavItem(location.pathname)
-  const activeBadge = activeItem?.badgeKey ? badges[activeItem.badgeKey] : 0
 
   return (
-    <AppShell header={{ height: { base: 64, lg: 112 } }} padding={0}>
+    <AppShell header={{ height: { base: 64, lg: 102 } }} padding={0}>
       <AppShell.Header className={classes.header}>
         <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
         <DesktopTabs badges={badges} />
-        <LedgerRule activeLabel={activeItem?.label ?? "Admin"} activeBadge={activeBadge} />
       </AppShell.Header>
       <MobileNavigationDrawer opened={mobileOpened} onClose={closeMobile} badges={badges} />
 
@@ -93,9 +89,6 @@ function HeaderTop({ opened, onToggle }: { opened: boolean; onToggle: () => void
         <Title order={4} fw={600} className={classes.brand}>
           Privé
         </Title>
-        <Text size="xs" c="dimmed" fw={600} tt="uppercase" visibleFrom="sm">
-          Atelier Ledger
-        </Text>
       </Group>
       <Group gap="xs" wrap="nowrap">
         <ColorSchemeToggle />
@@ -111,21 +104,6 @@ function DesktopTabs({ badges }: { badges: { unassigned: number } }) {
       {flatAppNavItems.map((item) => (
         <NavLinkButton key={item.to} item={item} badge={item.badgeKey ? badges[item.badgeKey] : 0} variant="desktop" />
       ))}
-    </Group>
-  )
-}
-
-function LedgerRule({ activeLabel, activeBadge }: { activeLabel: string; activeBadge: number }) {
-  return (
-    <Group className={classes.ledgerRule} px="lg" gap="xs" wrap="nowrap">
-      <Text size="xs" fw={700} tt="uppercase">
-        {activeLabel}
-      </Text>
-      {activeBadge > 0 ? (
-        <Badge size="xs" variant="light" color="yellow">
-          {activeBadge}
-        </Badge>
-      ) : null}
     </Group>
   )
 }
@@ -206,7 +184,7 @@ function NavLinkButton({
     >
       <Group gap="sm" wrap="nowrap" justify="space-between">
         <Group gap="sm" wrap="nowrap">
-          <Icon size={18} stroke={1.6} className={classes.navLinkIcon} />
+          {variant === "drawer" ? <Icon size={18} stroke={1.6} className={classes.navLinkIcon} /> : null}
           <Text size="sm" fw={500}>
             {variant === "desktop" ? (item.shortLabel ?? item.label) : item.label}
           </Text>

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -258,7 +258,7 @@ function UserSection() {
       withinPortal
     >
       <Menu.Target>
-        <UnstyledButton className={triggerClass}>
+        <UnstyledButton className={triggerClass} aria-label="Open user menu">
           <Group gap={7} wrap="nowrap">
             <Avatar radius="xl" size={24} color="initials" name={user.name} />
             <Text fw={500} size="sm" lh={1} mr={3} visibleFrom="sm">

--- a/docs/superpowers/plans/2026-07-20-atelier-ledger-admin-ui.md
+++ b/docs/superpowers/plans/2026-07-20-atelier-ledger-admin-ui.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** React, TanStack Router, TanStack Query, Mantine 9, Tabler Icons, Vite+, Vitest.
 
+**Revision:** After implementation review, the visual direction was lightened to follow Mantine's `HeaderTabs` example more closely. The final shell uses a simple raised active tab and no separate ledger rule/status band.
+
 ## Global Constraints
 
 - Work on branch `feat/atelier-ledger-admin-ui`.

--- a/docs/superpowers/plans/2026-07-20-atelier-ledger-admin-ui.md
+++ b/docs/superpowers/plans/2026-07-20-atelier-ledger-admin-ui.md
@@ -1,0 +1,476 @@
+# Atelier Ledger Admin UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the authenticated left-sidebar dashboard with the Atelier Ledger top-header UI and refine shared page surfaces for responsive admin workflows.
+
+**Architecture:** Extract global navigation data and active-route matching into a pure helper, then rebuild the authenticated `AppShell` around a desktop two-tier header and mobile drawer. Keep route behavior, data loading, legal entity tabs, and Mantine as-is while improving shared `PageHeader`, `Section`, and filter/table layouts.
+
+**Tech Stack:** React, TanStack Router, TanStack Query, Mantine 9, Tabler Icons, Vite+, Vitest.
+
+## Global Constraints
+
+- Work on branch `feat/atelier-ledger-admin-ui`.
+- No API, database, authentication, or route behavior changes.
+- Preserve TanStack Router `Link`, current path active matching, and existing query loading behavior.
+- Existing legal entity navigation helpers remain the source of truth for legal entity section paths.
+- Keep Settings reachable as a visible global navigation item.
+- Keep the unassigned documents badge on Legal entities.
+- Mobile navigation uses a drawer grouped as Workspace, Manage, Account.
+- Run `vp check` and `vp test` after implementation.
+
+---
+
+## File Structure
+
+- Create `apps/web/src/lib/app-navigation.ts` for global nav groups, route metadata, and active-route matching.
+- Create `apps/web/src/lib/app-navigation.test.ts` for Vitest coverage of active matching and badge-bearing nav entries.
+- Modify `apps/web/src/routes/_authenticated/route.tsx` to replace the sidebar shell with the two-tier header and mobile drawer.
+- Modify `apps/web/src/routes/_authenticated/route.module.css` for the Atelier Ledger header, tabs, drawer links, active states, and responsive behavior.
+- Modify `apps/web/src/components/page-header.tsx` so actions wrap below titles on mobile and stay right-aligned on desktop.
+- Modify `apps/web/src/components/section.tsx` so shared surfaces are flatter and can mark table/filter content consistently.
+- Modify `packages/ui/src/theme.ts` and `packages/ui/src/styles/globals.css` only for shared token/radius/shadow refinements needed by the new shell.
+- Modify `apps/web/src/routes/_authenticated/dashboard.tsx`, `customers/index.tsx`, `cash.tsx`, `hair-orders/index.tsx`, and `legal-entities/$legalEntityId/route.tsx` for focused layout cleanup.
+
+---
+
+### Task 1: Navigation Model
+
+**Files:**
+- Create: `apps/web/src/lib/app-navigation.ts`
+- Create: `apps/web/src/lib/app-navigation.test.ts`
+
+**Interfaces:**
+- Produces: `type AppNavItem`, `type AppNavGroup`, `appNavGroups`, `flatAppNavItems`, `getActiveAppNavItem(pathname: string): AppNavItem`
+- Consumes: no prior task output
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/app-navigation.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { appNavGroups, flatAppNavItems, getActiveAppNavItem } from "./app-navigation"
+
+describe("app navigation", () => {
+  it("keeps settings as a visible account navigation item", () => {
+    expect(appNavGroups.find((group) => group.label === "Account")?.items.map((item) => item.to)).toContain(
+      "/settings",
+    )
+  })
+
+  it("marks nested routes by their parent navigation item", () => {
+    expect(getActiveAppNavItem("/customers/123")?.to).toBe("/customers")
+    expect(getActiveAppNavItem("/legal-entities/entity-1/documents")?.to).toBe("/legal-entities")
+    expect(getActiveAppNavItem("/hair-orders/order-1")?.to).toBe("/hair-orders")
+  })
+
+  it("keeps the unassigned badge on legal entities", () => {
+    expect(flatAppNavItems.find((item) => item.to === "/legal-entities")?.badgeKey).toBe("unassigned")
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `vp test apps/web/src/lib/app-navigation.test.ts`
+
+Expected: FAIL because `apps/web/src/lib/app-navigation.ts` does not exist.
+
+- [ ] **Step 3: Implement the navigation helper**
+
+Create `apps/web/src/lib/app-navigation.ts`:
+
+```ts
+import {
+  IconBuildingBank,
+  IconCalendar,
+  IconCash,
+  IconLayoutDashboard,
+  IconReceipt,
+  IconScissors,
+  IconSettings,
+  IconUsers,
+} from "@tabler/icons-react"
+
+export type AppNavBadgeKey = "unassigned"
+
+export type AppNavItem = {
+  to: string
+  label: string
+  shortLabel?: string
+  icon: typeof IconUsers
+  badgeKey?: AppNavBadgeKey
+}
+
+export type AppNavGroup = {
+  label: "Workspace" | "Manage" | "Account"
+  items: AppNavItem[]
+}
+
+export const appNavGroups: AppNavGroup[] = [
+  {
+    label: "Workspace",
+    items: [
+      { to: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
+      { to: "/customers", label: "Customers", icon: IconUsers },
+      { to: "/calendar", label: "Calendar", icon: IconCalendar },
+      { to: "/hair-orders", label: "Hair orders", shortLabel: "Orders", icon: IconScissors },
+      { to: "/hair-sales", label: "Hair sales", shortLabel: "Sales", icon: IconReceipt },
+      { to: "/cash", label: "Cash", icon: IconCash },
+    ],
+  },
+  {
+    label: "Manage",
+    items: [
+      {
+        to: "/legal-entities",
+        label: "Legal entities",
+        shortLabel: "Entities",
+        icon: IconBuildingBank,
+        badgeKey: "unassigned",
+      },
+    ],
+  },
+  {
+    label: "Account",
+    items: [{ to: "/settings", label: "Settings", icon: IconSettings }],
+  },
+]
+
+export const flatAppNavItems = appNavGroups.flatMap((group) => group.items)
+
+export function getActiveAppNavItem(pathname: string) {
+  return flatAppNavItems.find((item) => pathname === item.to || pathname.startsWith(`${item.to}/`))
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `vp test apps/web/src/lib/app-navigation.test.ts`
+
+Expected: PASS for all tests in `app-navigation.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/app-navigation.ts apps/web/src/lib/app-navigation.test.ts
+git commit -m "feat: add app navigation model"
+```
+
+---
+
+### Task 2: Authenticated Top Header Shell
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/route.tsx`
+- Modify: `apps/web/src/routes/_authenticated/route.module.css`
+
+**Interfaces:**
+- Consumes: `appNavGroups`, `flatAppNavItems`, `getActiveAppNavItem`
+- Produces: desktop two-tier header, mobile drawer, ledger rule bar, global active states
+
+- [ ] **Step 1: Replace local nav arrays with the navigation helper**
+
+In `apps/web/src/routes/_authenticated/route.tsx`, remove local `NavItem`, `workspaceNav`, `manageNav`, and `footerNav`. Import:
+
+```ts
+import { Drawer } from "@mantine/core"
+import { appNavGroups, flatAppNavItems, getActiveAppNavItem, type AppNavItem } from "@/lib/app-navigation"
+```
+
+Keep existing imports for Mantine components, hooks, auth, router, and Tabler icons that remain in use.
+
+- [ ] **Step 2: Rebuild `AuthenticatedLayout` around header-only AppShell**
+
+Update the `AppShell` configuration:
+
+```tsx
+<AppShell header={{ height: { base: 64, sm: 112 } }} padding={0}>
+  <AppShell.Header className={classes.header}>
+    <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
+    <DesktopTabs badges={badges} />
+    <LedgerRule activeLabel={activeItem?.label ?? "Admin"} activeBadge={activeBadge} />
+  </AppShell.Header>
+  <MobileNavigationDrawer opened={mobileOpened} onClose={closeMobile} badges={badges} />
+  <AppShell.Main className={classes.main}>
+    <Outlet />
+  </AppShell.Main>
+</AppShell>
+```
+
+Derive `activeItem` with `getActiveAppNavItem(useLocation().pathname)`. Derive `activeBadge` from `activeItem.badgeKey`.
+
+- [ ] **Step 3: Add focused shell components**
+
+Add these components in `route.tsx` below `AuthenticatedLayout`: `HeaderTop`, `DesktopTabs`, `LedgerRule`, `MobileNavigationDrawer`, `DrawerNavGroup`, and `NavLinkButton`. Use `UnstyledButton` with `component={Link}` for links, `ActionIcon` for icon-only controls, and existing `UserSection` plus `ColorSchemeToggle` for utilities. Drawer links call `onClose` after navigation.
+
+- [ ] **Step 4: Update shell CSS**
+
+Replace sidebar-focused CSS in `route.module.css` with classes for:
+
+```css
+.header {}
+.topRow {}
+.tabsRow {}
+.ledgerRule {}
+.desktopNavLink {}
+.drawerNavLink {}
+.navLinkIcon {}
+.brand {}
+.main {}
+.user {}
+.userActive {}
+```
+
+Requirements:
+
+- `.topRow` is 56px tall on desktop and 64px on mobile.
+- `.tabsRow` is hidden below Mantine `sm`.
+- `.ledgerRule` is hidden below Mantine `sm`.
+- `.main` uses `min-height: 100vh`, `padding: var(--mantine-spacing-lg) 0 var(--mantine-spacing-xl)`, and transparent background.
+- Active nav links use a champagne border or underline plus strong text color.
+- Hover states do not move layout dimensions.
+
+- [ ] **Step 5: Run type checking for shell changes**
+
+Run: `vp run --filter web check-types`
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/route.tsx apps/web/src/routes/_authenticated/route.module.css
+git commit -m "feat: redesign authenticated app shell"
+```
+
+---
+
+### Task 3: Shared Page Surfaces
+
+**Files:**
+- Modify: `apps/web/src/components/page-header.tsx`
+- Modify: `apps/web/src/components/section.tsx`
+- Modify: `packages/ui/src/theme.ts`
+- Modify: `packages/ui/src/styles/globals.css`
+
+**Interfaces:**
+- Consumes: shell spacing from Task 2
+- Produces: denser `PageHeader`, flatter `Section`, tighter shared card/paper treatment
+
+- [ ] **Step 1: Update `PageHeader` responsive action layout**
+
+Modify `PageHeader` so the root `Group` keeps the title and actions aligned on desktop, while the actions receive full width on mobile:
+
+```tsx
+<Group justify="space-between" align="flex-start" wrap="wrap" mb="lg" gap="md">
+  <Stack gap={4} miw={0} flex="1 1 22rem">
+    <Title order={2} fw={600} lh={1.2}>
+      {title}
+    </Title>
+    {description ? (
+      <Box c="dimmed" fz="sm">
+        {description}
+      </Box>
+    ) : null}
+  </Stack>
+  {actions ? (
+    <Group gap="xs" wrap="wrap" justify={{ base: "flex-start", sm: "flex-end" }} w={{ base: "100%", sm: "auto" }}>
+      {actions}
+    </Group>
+  ) : null}
+</Group>
+```
+
+- [ ] **Step 2: Update `Section` surface behavior**
+
+Modify `Section` so the card uses a class hook and header actions can wrap on narrow screens:
+
+```tsx
+<Card padding={0} className="prive-section">
+  {hasHeader ? (
+    <>
+      <Group justify="space-between" align="flex-start" wrap="wrap" p="lg" pb="md" gap="md">
+        <Stack gap={2} miw={0} flex="1 1 18rem">
+          {title ? (
+            <Title order={4} fw={600} lh={1.3}>
+              {title}
+            </Title>
+          ) : null}
+          {description ? (
+            <Box c="dimmed" fz="sm">
+              {description}
+            </Box>
+          ) : null}
+        </Stack>
+        {actions ? (
+          <Group gap="xs" wrap="wrap" justify={{ base: "flex-start", sm: "flex-end" }}>
+            {actions}
+          </Group>
+        ) : null}
+      </Group>
+      <Divider />
+    </>
+  ) : null}
+  <Box p={padding} className="prive-section-body">
+    {children}
+  </Box>
+</Card>
+```
+
+- [ ] **Step 3: Flatten shared surfaces**
+
+In `packages/ui/src/theme.ts`, change default `Card` and `Paper` radius from `xl` to `md`, keep `withBorder`, and reduce default card shadow to `xs`.
+
+In `packages/ui/src/styles/globals.css`, add:
+
+```css
+.prive-section {
+  overflow: hidden;
+}
+
+.prive-section-body {
+  min-width: 0;
+}
+
+[class^="mantine-Table-ScrollContainer-root"],
+[class*=" mantine-Table-ScrollContainer-root"] {
+  border-color: var(--prive-border);
+}
+```
+
+- [ ] **Step 4: Run type checking**
+
+Run: `vp run --filter web check-types`
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/page-header.tsx apps/web/src/components/section.tsx packages/ui/src/theme.ts packages/ui/src/styles/globals.css
+git commit -m "feat: refine admin page surfaces"
+```
+
+---
+
+### Task 4: Focused Page Layout Cleanup
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/dashboard.tsx`
+- Modify: `apps/web/src/routes/_authenticated/customers/index.tsx`
+- Modify: `apps/web/src/routes/_authenticated/cash.tsx`
+- Modify: `apps/web/src/routes/_authenticated/hair-orders/index.tsx`
+- Modify: `apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx`
+
+**Interfaces:**
+- Consumes: shared `PageHeader` and `Section` behavior from Task 3
+- Produces: page-level responsive wrapping aligned with the new shell
+
+- [ ] **Step 1: Wrap table-heavy content in `Table.ScrollContainer`**
+
+For Customers, Cash transactions, and Hair orders, ensure each table with more than three columns is inside Mantine `Table.ScrollContainer` or a component-provided scroll wrapper. Use `minWidth` values that match column density: `640` for Customers, `760` for Cash, and `760` for Hair orders.
+
+- [ ] **Step 2: Make filter rows wrap predictably**
+
+For Cash, change the filter `Group` to:
+
+```tsx
+<Group align="flex-end" mb="md" gap="sm" wrap="wrap">
+```
+
+Set the search input to `flex="1 1 18rem"` and date/select controls to `w={{ base: "100%", xs: 180 }}` where Mantine supports responsive width props.
+
+- [ ] **Step 3: Tighten dashboard controls**
+
+In Dashboard, let the month picker group wrap on mobile without shrinking controls below readability:
+
+```tsx
+<Group gap="xs" wrap="nowrap" w={{ base: "100%", sm: "auto" }}>
+```
+
+Set `MonthPickerInput` to `flex={{ base: 1, sm: "unset" }}` and `miw={170}`.
+
+- [ ] **Step 4: Align legal entity local tabs with the new shell**
+
+In legal entity detail route, keep `Tabs` and existing helper functions. Set `Tabs.List` to allow horizontal overflow on narrow screens by wrapping it in a `Box` with `style={{ overflowX: "auto" }}`. The local tabs remain below `PageHeader`, not in the global header.
+
+- [ ] **Step 5: Run web type checking**
+
+Run: `vp run --filter web check-types`
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/dashboard.tsx apps/web/src/routes/_authenticated/customers/index.tsx apps/web/src/routes/_authenticated/cash.tsx apps/web/src/routes/_authenticated/hair-orders/index.tsx 'apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx'
+git commit -m "feat: improve admin page responsiveness"
+```
+
+---
+
+### Task 5: Verification and Polish
+
+**Files:**
+- Modify only files from Tasks 1-4 if verification finds issues.
+
+**Interfaces:**
+- Consumes: completed implementation tasks
+- Produces: checked, responsive, working admin UI
+
+- [ ] **Step 1: Run full checks**
+
+Run:
+
+```bash
+vp check
+vp test
+```
+
+Expected: both commands complete successfully.
+
+- [ ] **Step 2: Start the web app**
+
+Run:
+
+```bash
+vp run dev:web
+```
+
+Expected: Vite dev server starts and prints a local URL.
+
+- [ ] **Step 3: Inspect desktop and mobile**
+
+Open the local URL and inspect:
+
+- Desktop width around `1440px`: primary tabs visible, no left sidebar, active tab clear, ledger rule visible.
+- Tablet width around `768px`: navigation collapses before tab labels overlap.
+- Mobile width around `390px`: burger opens drawer, drawer links close it, page actions wrap cleanly.
+- Dashboard month controls remain usable.
+- Customers search and pagination remain usable.
+- Cash filters wrap without horizontal page overflow.
+- Legal entity local tabs still navigate and show the unassigned document badge where applicable.
+
+- [ ] **Step 4: Fix verification findings**
+
+For each issue, patch the smallest affected file from Tasks 1-4 and rerun the narrowest relevant command:
+
+```bash
+vp run --filter web check-types
+```
+
+Then rerun `vp check` and `vp test` before completion.
+
+- [ ] **Step 5: Commit final polish**
+
+If Step 4 changed files, commit them:
+
+```bash
+git add apps/web/src packages/ui/src
+git commit -m "fix: polish atelier ledger admin UI"
+```
+
+If Step 4 changed no files, skip this commit.

--- a/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
@@ -10,13 +10,14 @@ The current web app uses Mantine AppShell with a persistent left navbar, a slim 
 
 The redesign is inspired by Mantine top-header patterns, but it should not copy them directly. It should use the existing Privé visual identity and adapt it to a data-heavy admin workflow.
 
-## Direction: Atelier Ledger Header
+## Direction: Light Header Tabs
 
 Use a two-tier top header on desktop:
 
 - First row: Privé brand, compact app context, color scheme toggle, and user menu.
-- Second row: primary route tabs for the main admin destinations.
-- A thin ledger-style rule beneath the tabs carries the active route label and, when present, route badges such as unassigned documents.
+- Second row: primary route tabs for the main admin destinations, following Mantine's `HeaderTabs` proportions more closely.
+- Active tabs use a light raised-tab treatment instead of a heavy bordered pill or status band.
+- Route badges such as unassigned documents stay inline with the relevant tab or drawer item.
 - Main content starts directly below the header with more horizontal space than the sidebar layout.
 
 Use a drawer on mobile:
@@ -44,7 +45,7 @@ Typography:
 
 Signature element:
 
-- Introduce a restrained ledger rule bar under the top tabs. It marks the active section and carries compact operational metadata that already exists in the shell, starting with the unassigned documents count.
+- Use a simple raised active tab in the global header. The distinctive Privé identity comes from the existing typography and palette rather than an additional status strip.
 
 ## Layout Behavior
 

--- a/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
@@ -14,7 +14,7 @@ The redesign is inspired by Mantine top-header patterns, but it should not copy 
 
 Use a two-tier top header on desktop:
 
-- First row: Privé brand, compact app context, color scheme toggle, and user menu.
+- First row: Privé brand, color scheme toggle, and user menu.
 - Second row: primary route tabs for the main admin destinations, following Mantine's `HeaderTabs` proportions more closely.
 - Active tabs use a light raised-tab treatment instead of a heavy bordered pill or status band.
 - Route badges such as unassigned documents stay inline with the relevant tab or drawer item.

--- a/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-07-20-atelier-ledger-admin-ui-design.md
@@ -1,0 +1,117 @@
+# Atelier Ledger Admin UI Design
+
+## Goal
+
+Redesign the authenticated admin interface around a compact, mobile-friendly top navigation system. The result should feel clearer and more intentional than the current left-sidebar dashboard while preserving the existing route structure and operational speed.
+
+## Context
+
+The current web app uses Mantine AppShell with a persistent left navbar, a slim top header, and page content rendered in `Container size="xl"`. Primary routes include Dashboard, Customers, Calendar, Hair orders, Hair sales, Cash, Legal entities, and Settings. Legal entity detail pages already have local tabs for Overview, Bank accounts, Salons, Reports, and Documents.
+
+The redesign is inspired by Mantine top-header patterns, but it should not copy them directly. It should use the existing Privé visual identity and adapt it to a data-heavy admin workflow.
+
+## Direction: Atelier Ledger Header
+
+Use a two-tier top header on desktop:
+
+- First row: Privé brand, compact app context, color scheme toggle, and user menu.
+- Second row: primary route tabs for the main admin destinations.
+- A thin ledger-style rule beneath the tabs carries the active route label and, when present, route badges such as unassigned documents.
+- Main content starts directly below the header with more horizontal space than the sidebar layout.
+
+Use a drawer on mobile:
+
+- The header remains one compact row with brand, burger, color scheme toggle, and user menu.
+- The burger opens grouped navigation: Workspace, Manage, Account.
+- The drawer mirrors the same route semantics as desktop tabs.
+
+## Visual System
+
+Keep the existing Privé palette but reduce the warm cream dominance so the interface reads as a refined operations tool, not a decorative landing page.
+
+- Ink: `#171512`
+- Ledger paper: `#f7f2e8`
+- Champagne rule: `#b58b43`
+- Mulberry mark: `#6e3c61`
+- Sage balance: `#51665b`
+- Steel text: `#625d55`
+
+Typography:
+
+- Use Fraunces sparingly for the Privé wordmark and major page titles.
+- Use Manrope for navigation, form controls, buttons, and body text.
+- Use IBM Plex Mono for numeric counts, currency, dates, and compact status values.
+
+Signature element:
+
+- Introduce a restrained ledger rule bar under the top tabs. It marks the active section and carries compact operational metadata that already exists in the shell, starting with the unassigned documents count.
+
+## Layout Behavior
+
+Desktop:
+
+- Remove the persistent left navbar from the authenticated shell.
+- Keep all primary routes visible as horizontal tabs when there is enough room.
+- Preserve clear active states for exact and nested routes.
+- Keep the unassigned documents badge on Legal entities.
+- Keep Settings reachable as a primary tab or right-side utility link; it must not disappear into only the user menu.
+
+Tablet and mobile:
+
+- Collapse global navigation into a drawer before labels become cramped.
+- Keep controls reachable with one tap from the header.
+- Let page actions wrap below titles instead of shrinking text or causing overflow.
+- Filter-heavy rows must wrap into a readable stacked layout.
+
+## Page Surface Refactor
+
+Update shared primitives instead of restyling every page independently:
+
+- `PageHeader` actions wrap to a full-width row below the title on small screens and remain right-aligned on desktop.
+- `Section` uses a flatter framed surface with smaller radius, lighter shadow, and clear dividers for tables and grouped tools.
+- Table and filter surfaces use stable gaps, predictable wrapping, and horizontal overflow handling where table columns cannot fit.
+
+Apply focused page cleanup to these pages:
+
+- Dashboard: keep monthly controls compact and ensure metric cards are readable on mobile.
+- Customers: improve the search/count/table area so it feels like a single work surface.
+- Cash: make the multi-filter row wrap predictably on mobile.
+- Hair orders and related list pages: align pagination and actions with the shared surface treatment.
+- Legal entities: preserve local entity tabs and make them visually compatible with the global top-tabs shell.
+
+## Data and Routing
+
+No API, database, authentication, or route behavior changes are required.
+
+Navigation should continue to use TanStack Router `Link`, current path active matching, and existing query loading behavior. Existing legal entity navigation helpers should remain the source of truth for legal entity section paths.
+
+## Accessibility
+
+- Preserve keyboard focus visibility.
+- Use semantic links for navigation.
+- Keep mobile drawer dismissible by navigation selection and standard Mantine drawer behavior.
+- Ensure active navigation state is visually clear and represented in attributes/classes.
+- Header controls must have accessible labels.
+
+## Testing and Verification
+
+Run the Vite+ project checks after implementation:
+
+- `vp check`
+- `vp test`
+
+Also run or inspect the web app locally and verify at least:
+
+- Desktop navigation active states.
+- Mobile drawer navigation.
+- Dashboard month controls.
+- Customers search and pagination.
+- Cash filter wrapping.
+- Legal entity local tabs and unassigned document badge.
+
+## Non-Goals
+
+- Do not redesign authentication flows unless needed for shell consistency.
+- Do not add a command palette in this pass.
+- Do not change backend data models or API contracts.
+- Do not replace Mantine or the existing theme system.

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -126,13 +126,13 @@ a {
 
 .prive-page-header-actions,
 .prive-section-actions {
-  --group-justify: flex-start;
+  justify-content: flex-start !important;
 }
 
 @media (min-width: 48em) {
   .prive-page-header-actions,
   .prive-section-actions {
-    --group-justify: flex-end;
+    justify-content: flex-end !important;
   }
 }
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -116,6 +116,26 @@ a {
   transform: translateY(1px) scale(0.995);
 }
 
+.prive-section {
+  overflow: hidden;
+}
+
+.prive-section-body {
+  min-width: 0;
+}
+
+.prive-page-header-actions,
+.prive-section-actions {
+  --group-justify: flex-start;
+}
+
+@media (min-width: 48em) {
+  .prive-page-header-actions,
+  .prive-section-actions {
+    --group-justify: flex-end;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -191,6 +211,11 @@ a {
 [class^="mantine-Table-table"],
 [class*=" mantine-Table-table"] {
   font-variant-numeric: tabular-nums;
+}
+
+[class^="mantine-Table-ScrollContainer-root"],
+[class*=" mantine-Table-ScrollContainer-root"] {
+  border-color: var(--prive-border);
 }
 
 [class^="mantine-Table-th"],

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -156,7 +156,7 @@ a {
   border-color: var(--prive-border);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 16px 42px var(--prive-surface-shadow);
+    0 8px 22px color-mix(in srgb, var(--prive-surface-shadow) 72%, transparent);
   backdrop-filter: blur(18px);
 }
 

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -150,9 +150,9 @@ export const theme = createTheme({
     Card: Card.extend({
       defaultProps: {
         withBorder: true,
-        radius: "xl",
+        radius: "md",
         padding: "lg",
-        shadow: "sm",
+        shadow: "xs",
       },
     }),
     Divider: Divider.extend({
@@ -196,7 +196,7 @@ export const theme = createTheme({
     }),
     Paper: Paper.extend({
       defaultProps: {
-        radius: "xl",
+        radius: "md",
         shadow: "sm",
       },
     }),


### PR DESCRIPTION
## Summary
- Replace the authenticated left-sidebar shell with a lighter Mantine-style top header and tab navigation
- Add a shared app navigation model with tests and keep mobile/tablet navigation in a grouped drawer
- Refine shared page surfaces and responsive layouts for dashboard, customers, cash, hair orders, and legal entities

## Validation
- vp run --filter web check-types
- vp check
- vp test
- Browser inspection at desktop and mobile widths