### PR TITLE
feat: add route-driven breadcrumbs

### DIFF
--- a/apps/web/src/components/breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs.tsx
@@ -89,10 +89,6 @@ export function BreadcrumbItem({ label, to }: BreadcrumbDefinition) {
   return null
 }
 
-export function BreadcrumbItems({ items }: { items: readonly BreadcrumbDefinition[] }) {
-  return items.map((item) => <BreadcrumbItem key={`${item.to ?? "current"}-${String(item.label)}`} {...item} />)
-}
-
 function useBreadcrumbContext() {
   const context = useContext(BreadcrumbPortalContext)
 

--- a/apps/web/src/components/breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs.tsx
@@ -1,0 +1,104 @@
+import { Anchor, Box, Breadcrumbs as MantineBreadcrumbs, Text } from "@mantine/core"
+import { Link } from "@tanstack/react-router"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+
+import {
+  removeBreadcrumb,
+  upsertBreadcrumb,
+  type BreadcrumbDefinition,
+  type RegisteredBreadcrumb,
+} from "@/lib/breadcrumbs"
+
+type BreadcrumbContextValue = {
+  items: readonly RegisteredBreadcrumb[]
+  register: (id: string, item: BreadcrumbDefinition) => void
+  unregister: (id: string) => void
+}
+
+const BreadcrumbPortalContext = createContext<BreadcrumbContextValue | null>(null)
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<RegisteredBreadcrumb[]>([])
+  const orderById = useRef(new Map<string, number>())
+  const nextOrder = useRef(0)
+
+  const register = useCallback((id: string, item: BreadcrumbDefinition) => {
+    let order = orderById.current.get(id)
+    if (order === undefined) {
+      order = nextOrder.current
+      nextOrder.current += 1
+      orderById.current.set(id, order)
+    }
+
+    setItems((current) => upsertBreadcrumb(current, { ...item, id, order: item.order ?? order }))
+  }, [])
+
+  const unregister = useCallback((id: string) => {
+    setItems((current) => removeBreadcrumb(current, id))
+  }, [])
+
+  const value = useMemo(() => ({ items, register, unregister }), [items, register, unregister])
+
+  return <BreadcrumbPortalContext.Provider value={value}>{children}</BreadcrumbPortalContext.Provider>
+}
+
+export function BreadcrumbPortal() {
+  const { items } = useBreadcrumbContext()
+  const visibleItems = items.filter((item) => item.label !== "Privé")
+
+  if (visibleItems.length <= 1) return null
+
+  return (
+    <Box component="nav" aria-label="Breadcrumb">
+      <MantineBreadcrumbs fz="11px" separator="›" separatorMargin={6} c="dimmed">
+        {visibleItems.map((item) =>
+          item.to ? (
+            <Anchor key={item.id} component={Link} to={item.to} fz="11px" c="dimmed" underline="never">
+              {item.label}
+            </Anchor>
+          ) : (
+            <Text key={item.id} fz="11px" fw={500} c="dimmed">
+              {item.label}
+            </Text>
+          ),
+        )}
+      </MantineBreadcrumbs>
+    </Box>
+  )
+}
+
+export function BreadcrumbItem({ label, to }: BreadcrumbDefinition) {
+  const id = useId()
+  const { register, unregister } = useBreadcrumbContext()
+
+  useEffect(() => {
+    register(id, { label, to })
+    return () => unregister(id)
+  }, [id, label, register, to, unregister])
+
+  return null
+}
+
+export function BreadcrumbItems({ items }: { items: readonly BreadcrumbDefinition[] }) {
+  return items.map((item) => <BreadcrumbItem key={`${item.to ?? "current"}-${String(item.label)}`} {...item} />)
+}
+
+function useBreadcrumbContext() {
+  const context = useContext(BreadcrumbPortalContext)
+
+  if (!context) {
+    throw new Error("Missing BreadcrumbProvider.")
+  }
+
+  return context
+}

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react"
 
 import { Box, Group, Stack, Title } from "@mantine/core"
 
+import { BreadcrumbPortal } from "@/components/breadcrumbs"
+
 export function PageHeader({
   title,
   description,
@@ -13,7 +15,8 @@ export function PageHeader({
 }) {
   return (
     <Group justify="space-between" align="flex-start" wrap="wrap" mb="lg" gap="md">
-      <Stack gap={4} miw={0} flex="1 1 22rem">
+      <Stack gap={2} miw={0} flex="1 1 22rem">
+        <BreadcrumbPortal />
         <Title order={2} fw={600} lh={1.2}>
           {title}
         </Title>

--- a/apps/web/src/lib/breadcrumbs.test.ts
+++ b/apps/web/src/lib/breadcrumbs.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vite-plus/test"
+
+import { defineBreadcrumbs, removeBreadcrumb, upsertBreadcrumb } from "./breadcrumbs"
+
+describe("breadcrumbs", () => {
+  it("keeps route-local breadcrumb items in declaration order", () => {
+    expect(
+      defineBreadcrumbs([
+        { label: "Customers", to: "/customers" },
+        { label: "Ada Lovelace", to: "/customers/$customerId", params: { customerId: "customer-1" } },
+        { label: "Notes" },
+      ]),
+    ).toEqual([
+      { label: "Customers", to: "/customers" },
+      { label: "Ada Lovelace", to: "/customers/$customerId", params: { customerId: "customer-1" } },
+      { label: "Notes" },
+    ])
+  })
+
+  it("keeps registered breadcrumb items ordered and removable", () => {
+    const registered = upsertBreadcrumb(upsertBreadcrumb([], { id: "child", order: 2, label: "Ada Lovelace" }), {
+      id: "parent",
+      order: 1,
+      label: "Customers",
+      to: "/customers",
+    })
+
+    expect(registered.map((item) => item.label)).toEqual(["Customers", "Ada Lovelace"])
+    expect(removeBreadcrumb(registered, "parent").map((item) => item.label)).toEqual(["Ada Lovelace"])
+  })
+
+  it("does not duplicate breadcrumbs with detail-page back links", () => {
+    const routesDir = join(import.meta.dirname, "../routes/_authenticated")
+    const duplicateBackLinkRoutes = [
+      "customers/$customerId/route.tsx",
+      "appointments/$appointmentId.tsx",
+      "hair-orders/$hairOrderId.tsx",
+      "hair-sales/$hairSaleId.tsx",
+      "legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx",
+    ]
+
+    for (const route of duplicateBackLinkRoutes) {
+      expect(readFileSync(join(routesDir, route), "utf8")).not.toMatch(/Back to /)
+    }
+  })
+
+  it("keeps the breadcrumb host in page content instead of the app shell header", () => {
+    const webSrcDir = join(import.meta.dirname, "..")
+
+    expect(readFileSync(join(webSrcDir, "components/page-header.tsx"), "utf8")).toContain("<BreadcrumbPortal />")
+    expect(readFileSync(join(webSrcDir, "routes/_authenticated/route.tsx"), "utf8")).not.toContain(
+      "<BreadcrumbPortal />",
+    )
+    expect(readFileSync(join(webSrcDir, "routes/_authenticated/route.tsx"), "utf8")).not.toContain('label="Privé"')
+  })
+})

--- a/apps/web/src/lib/breadcrumbs.ts
+++ b/apps/web/src/lib/breadcrumbs.ts
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react"
+
+export type BreadcrumbDefinition = {
+  label: ReactNode
+  to?: string
+  order?: number
+}
+
+export type RegisteredBreadcrumb = BreadcrumbDefinition & {
+  id: string
+  order: number
+}
+
+export function defineBreadcrumbs<const T extends readonly BreadcrumbDefinition[]>(items: T): T {
+  return items
+}
+
+export function upsertBreadcrumb(
+  items: readonly RegisteredBreadcrumb[],
+  item: RegisteredBreadcrumb,
+): RegisteredBreadcrumb[] {
+  return [...items.filter((candidate) => candidate.id !== item.id), item].sort((a, b) => a.order - b.order)
+}
+
+export function removeBreadcrumb(items: readonly RegisteredBreadcrumb[], id: string): RegisteredBreadcrumb[] {
+  return items.filter((item) => item.id !== id)
+}

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -1,6 +1,5 @@
 import {
   ActionIcon,
-  Anchor,
   Button,
   Card,
   Checkbox,
@@ -18,11 +17,12 @@ import {
   Title,
 } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
-import { IconArrowLeft, IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
+import { IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
 import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair-assigned-dialog"
@@ -161,12 +161,7 @@ function AppointmentDetailPage({ appointmentId }: { appointmentId: string }) {
 
   return (
     <Container size="xl">
-      <Anchor component={Link} to="/calendar" size="xs" c="dimmed" mb="xs" display="inline-block">
-        <Group gap={4}>
-          <IconArrowLeft size={12} />
-          Back to calendar
-        </Group>
-      </Anchor>
+      <BreadcrumbItem label={appointment.name} order={20} />
       <PageHeader
         title={appointment.name}
         description={

--- a/apps/web/src/routes/_authenticated/appointments/route.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/route.tsx
@@ -1,5 +1,16 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
+
 export const Route = createFileRoute("/_authenticated/appointments")({
-  component: () => <Outlet />,
+  component: AppointmentsLayout,
 })
+
+function AppointmentsLayout() {
+  return (
+    <>
+      <BreadcrumbItem label="Calendar" to="/calendar" order={10} />
+      <Outlet />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -6,6 +6,7 @@ import dayjs from "dayjs"
 import { useCallback, useMemo, useState } from "react"
 
 import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
@@ -91,6 +92,7 @@ function CalendarPage() {
 
   return (
     <Container size="xl">
+      <BreadcrumbItem label="Calendar" order={10} />
       <PageHeader title="Calendar" description="Click a slot to book or open an existing appointment." />
       <Stack>
         {hasHiddenAppointments && (

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -16,6 +16,7 @@ import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { CashTransactionsTable, type CashTransactionRow } from "@/components/cash-transactions/cash-transactions-table"
 import { CreateCashTransactionDialog } from "@/components/cash-transactions/create-cash-transaction-dialog"
 import { DeleteCashTransactionDialog } from "@/components/cash-transactions/delete-cash-transaction-dialog"
@@ -98,6 +99,7 @@ function CashPage() {
 
   return (
     <Container size="xl">
+      <BreadcrumbItem label="Cash" order={10} />
       <PageHeader
         title="Cash"
         description="Record manual cash received from or paid to customers."

--- a/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { z } from "zod"
 
 import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
@@ -65,85 +66,97 @@ function CustomerAppointmentsRoute() {
   const hasItemsOnCurrentPage = appointments.length > 0
 
   return (
-    <Section
-      title="Appointments"
-      description="Appointment history for this customer."
-      actions={
-        <>
-          <TextInput
-            label="Search"
-            placeholder="Search appointments"
-            leftSection={<IconSearch size={16} />}
-            value={searchValue}
-            onChange={(event) => {
-              navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
-            }}
-            w={260}
-          />
-          <Button variant="default" size="sm" leftSection={<IconPlus size={12} />} onClick={() => setDialogOpen(true)}>
-            New
-          </Button>
-        </>
-      }
-      padding={hasItemsOnCurrentPage ? 0 : "lg"}
-    >
-      <Stack gap="md">
-        {hasItemsOnCurrentPage ? (
-          <Table>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Name</Table.Th>
-                <Table.Th>Date</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {appointments.map((appointment) => (
-                <Table.Tr key={appointment.id}>
-                  <Table.Td>
-                    <Text
-                      renderRoot={(props) => (
-                        <Link to="/appointments/$appointmentId" params={{ appointmentId: appointment.id }} {...props} />
-                      )}
-                      c="blue"
-                    >
-                      {appointment.name}
-                    </Text>
-                  </Table.Td>
-                  <Table.Td c="dimmed">
-                    <ClientDate date={appointment.startsAt} />
-                  </Table.Td>
+    <>
+      <BreadcrumbItem label="Appointments" order={30} />
+      <Section
+        title="Appointments"
+        description="Appointment history for this customer."
+        actions={
+          <>
+            <TextInput
+              label="Search"
+              placeholder="Search appointments"
+              leftSection={<IconSearch size={16} />}
+              value={searchValue}
+              onChange={(event) => {
+                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+              }}
+              w={260}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => setDialogOpen(true)}
+            >
+              New
+            </Button>
+          </>
+        }
+        padding={hasItemsOnCurrentPage ? 0 : "lg"}
+      >
+        <Stack gap="md">
+          {hasItemsOnCurrentPage ? (
+            <Table>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Name</Table.Th>
+                  <Table.Th>Date</Table.Th>
                 </Table.Tr>
-              ))}
-            </Table.Tbody>
-          </Table>
-        ) : (
-          <Text size="sm" c="dimmed" p="lg">
-            {normalizedSearch ? "No appointments match your search." : "No appointments on this page."}
-          </Text>
-        )}
+              </Table.Thead>
+              <Table.Tbody>
+                {appointments.map((appointment) => (
+                  <Table.Tr key={appointment.id}>
+                    <Table.Td>
+                      <Text
+                        renderRoot={(props) => (
+                          <Link
+                            to="/appointments/$appointmentId"
+                            params={{ appointmentId: appointment.id }}
+                            {...props}
+                          />
+                        )}
+                        c="blue"
+                      >
+                        {appointment.name}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td c="dimmed">
+                      <ClientDate date={appointment.startsAt} />
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          ) : (
+            <Text size="sm" c="dimmed" p="lg">
+              {normalizedSearch ? "No appointments match your search." : "No appointments on this page."}
+            </Text>
+          )}
 
-        <Group justify="space-between" px="md" pb="md">
-          <Text size="sm" c="dimmed">
-            {totalCount} appointment{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
-          </Text>
-          <Pagination
-            value={clampedPage}
-            total={totalPages}
-            onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-          />
-        </Group>
-      </Stack>
+          <Group justify="space-between" px="md" pb="md">
+            <Text size="sm" c="dimmed">
+              {totalCount} appointment{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
+            </Text>
+            <Pagination
+              value={clampedPage}
+              total={totalPages}
+              onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+            />
+          </Group>
+        </Stack>
 
-      <CreateAppointmentDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        defaultClientId={customerId}
-        invalidateKeys={[
-          { queryKey: trpc.customers.appointments.list.queryKey() },
-          { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
-        ]}
-        navigateOnSuccess
-      />
-    </Section>
+        <CreateAppointmentDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          defaultClientId={customerId}
+          invalidateKeys={[
+            { queryKey: trpc.customers.appointments.list.queryKey() },
+            { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
+          ]}
+          navigateOnSuccess
+        />
+      </Section>
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 import { useState } from "react"
 import { z } from "zod"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
 import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair-assigned-dialog"
 import { EditHairAssignedDialog } from "@/components/hair-assigned/edit-hair-assigned-dialog"
@@ -74,124 +75,127 @@ function HairSalesRoute() {
   const individual = hairAssigned.filter((ha) => !ha.appointmentId)
 
   return (
-    <Section
-      title="Hair Sales"
-      description="Hair sales tied to this customer."
-      actions={
-        <>
-          <TextInput
-            label="Search"
-            placeholder="Search hair sales"
-            leftSection={<IconSearch size={16} />}
-            value={searchValue}
-            onChange={(event) => {
-              navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
-            }}
-            w={260}
-          />
-          <Button
-            variant="default"
-            size="sm"
-            leftSection={<IconPlus size={12} />}
-            onClick={() => setHairCreateOpen(true)}
-          >
-            New
-          </Button>
-        </>
-      }
-      padding={hasItemsOnCurrentPage ? 0 : "lg"}
-    >
-      <Stack gap="md">
-        {hasItemsOnCurrentPage ? (
-          <Stack>
-            <Card withBorder>
-              <Title order={5} mb="sm">
-                Hair Sales through Appointment
-              </Title>
-              {throughAppointment.length > 0 ? (
-                <HairAssignedTable
-                  items={throughAppointment}
-                  showHairOrderColumn
-                  onEdit={setHairEditItem}
-                  onDelete={setHairDeleteItem}
-                />
-              ) : (
-                <Text size="sm" c="dimmed">
-                  No appointment-tied hair sales on this page.
-                </Text>
-              )}
-            </Card>
+    <>
+      <BreadcrumbItem label="Hair sales" order={30} />
+      <Section
+        title="Hair Sales"
+        description="Hair sales tied to this customer."
+        actions={
+          <>
+            <TextInput
+              label="Search"
+              placeholder="Search hair sales"
+              leftSection={<IconSearch size={16} />}
+              value={searchValue}
+              onChange={(event) => {
+                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+              }}
+              w={260}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => setHairCreateOpen(true)}
+            >
+              New
+            </Button>
+          </>
+        }
+        padding={hasItemsOnCurrentPage ? 0 : "lg"}
+      >
+        <Stack gap="md">
+          {hasItemsOnCurrentPage ? (
+            <Stack>
+              <Card withBorder>
+                <Title order={5} mb="sm">
+                  Hair Sales through Appointment
+                </Title>
+                {throughAppointment.length > 0 ? (
+                  <HairAssignedTable
+                    items={throughAppointment}
+                    showHairOrderColumn
+                    onEdit={setHairEditItem}
+                    onDelete={setHairDeleteItem}
+                  />
+                ) : (
+                  <Text size="sm" c="dimmed">
+                    No appointment-tied hair sales on this page.
+                  </Text>
+                )}
+              </Card>
 
-            <Card withBorder>
-              <Title order={5} mb="sm">
-                Hair Sales Individual
-              </Title>
-              {individual.length > 0 ? (
-                <HairAssignedTable
-                  items={individual}
-                  showHairOrderColumn
-                  onEdit={setHairEditItem}
-                  onDelete={setHairDeleteItem}
-                />
-              ) : (
-                <Text size="sm" c="dimmed">
-                  No individual hair sales on this page.
-                </Text>
-              )}
-            </Card>
-          </Stack>
-        ) : (
-          <Text size="sm" c="dimmed" p="lg">
-            {normalizedSearch ? "No hair sales match your search." : "No hair sales on this page."}
-          </Text>
-        )}
+              <Card withBorder>
+                <Title order={5} mb="sm">
+                  Hair Sales Individual
+                </Title>
+                {individual.length > 0 ? (
+                  <HairAssignedTable
+                    items={individual}
+                    showHairOrderColumn
+                    onEdit={setHairEditItem}
+                    onDelete={setHairDeleteItem}
+                  />
+                ) : (
+                  <Text size="sm" c="dimmed">
+                    No individual hair sales on this page.
+                  </Text>
+                )}
+              </Card>
+            </Stack>
+          ) : (
+            <Text size="sm" c="dimmed" p="lg">
+              {normalizedSearch ? "No hair sales match your search." : "No hair sales on this page."}
+            </Text>
+          )}
 
-        <Group justify="space-between" px="md" pb="md">
-          <Text size="sm" c="dimmed">
-            {totalCount} hair sale{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
-          </Text>
-          <Pagination
-            value={clampedPage}
-            total={totalPages}
-            onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-          />
-        </Group>
-      </Stack>
+          <Group justify="space-between" px="md" pb="md">
+            <Text size="sm" c="dimmed">
+              {totalCount} hair sale{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
+            </Text>
+            <Pagination
+              value={clampedPage}
+              total={totalPages}
+              onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+            />
+          </Group>
+        </Stack>
 
-      <CreateHairAssignedDialog
-        open={hairCreateOpen}
-        onOpenChange={setHairCreateOpen}
-        clientId={customerId}
-        appointmentId={null}
-        invalidateKeys={[
-          { queryKey: trpc.customers.hairAssigned.list.queryKey() },
-          { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
-        ]}
-        onSuccess={() => navigate({ search: { page: 1, search: searchValue }, replace: true })}
-      />
-      {hairEditItem && (
-        <EditHairAssignedDialog
-          open={!!hairEditItem}
-          onOpenChange={(open) => !open && setHairEditItem(null)}
-          hairAssigned={hairEditItem}
-          invalidateKeys={[
-            { queryKey: trpc.customers.hairAssigned.list.queryKey() },
-            { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
-          ]}
-        />
-      )}
-      {hairDeleteItem && (
-        <DeleteHairAssignedDialog
-          open={!!hairDeleteItem}
-          onOpenChange={(open) => !open && setHairDeleteItem(null)}
-          hairAssigned={hairDeleteItem}
+        <CreateHairAssignedDialog
+          open={hairCreateOpen}
+          onOpenChange={setHairCreateOpen}
+          clientId={customerId}
+          appointmentId={null}
           invalidateKeys={[
             { queryKey: trpc.customers.hairAssigned.list.queryKey() },
             { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
           ]}
           onSuccess={() => navigate({ search: { page: 1, search: searchValue }, replace: true })}
         />
-      )}
-    </Section>
+        {hairEditItem && (
+          <EditHairAssignedDialog
+            open={!!hairEditItem}
+            onOpenChange={(open) => !open && setHairEditItem(null)}
+            hairAssigned={hairEditItem}
+            invalidateKeys={[
+              { queryKey: trpc.customers.hairAssigned.list.queryKey() },
+              { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
+            ]}
+          />
+        )}
+        {hairDeleteItem && (
+          <DeleteHairAssignedDialog
+            open={!!hairDeleteItem}
+            onOpenChange={(open) => !open && setHairDeleteItem(null)}
+            hairAssigned={hairDeleteItem}
+            invalidateKeys={[
+              { queryKey: trpc.customers.hairAssigned.list.queryKey() },
+              { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
+            ]}
+            onSuccess={() => navigate({ search: { page: 1, search: searchValue }, replace: true })}
+          />
+        )}
+      </Section>
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
@@ -7,6 +7,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 import { useState } from "react"
 import { z } from "zod"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
@@ -84,72 +85,80 @@ function NotesRoute() {
   })
 
   return (
-    <Section
-      title="Notes"
-      description="Customer notes and internal reminders."
-      actions={
-        <>
-          <TextInput
-            label="Search"
-            placeholder="Search notes"
-            leftSection={<IconSearch size={16} />}
-            value={searchValue}
-            onChange={(event) => {
-              navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
-            }}
-            w={260}
-          />
-          <Button variant="default" size="sm" leftSection={<IconPlus size={12} />} onClick={() => setDialogOpen(true)}>
-            Add
-          </Button>
-        </>
-      }
-      padding={hasItemsOnCurrentPage ? 0 : "lg"}
-    >
-      <Stack gap="md">
-        {hasItemsOnCurrentPage ? (
-          <Stack gap="xs">
-            {notes.map((note) => (
-              <Card key={note.id} padding="sm">
-                <Group justify="space-between" align="flex-start">
-                  <Stack gap={2}>
-                    <Text size="sm">{note.note}</Text>
-                    <Text size="xs" c="dimmed">
-                      {note.createdBy?.name ?? "Unknown"} · <ClientDate date={note.createdAt} />
-                    </Text>
-                  </Stack>
-                  <ActionIcon variant="subtle" color="red" onClick={() => deleteNoteMutation.mutate({ id: note.id })}>
-                    <IconTrash size={14} />
-                  </ActionIcon>
-                </Group>
-              </Card>
-            ))}
-          </Stack>
-        ) : (
-          <Text size="sm" c="dimmed" p="lg">
-            {normalizedSearch ? "No notes match your search." : "No notes on this page."}
-          </Text>
-        )}
+    <>
+      <BreadcrumbItem label="Notes" order={30} />
+      <Section
+        title="Notes"
+        description="Customer notes and internal reminders."
+        actions={
+          <>
+            <TextInput
+              label="Search"
+              placeholder="Search notes"
+              leftSection={<IconSearch size={16} />}
+              value={searchValue}
+              onChange={(event) => {
+                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+              }}
+              w={260}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => setDialogOpen(true)}
+            >
+              Add
+            </Button>
+          </>
+        }
+        padding={hasItemsOnCurrentPage ? 0 : "lg"}
+      >
+        <Stack gap="md">
+          {hasItemsOnCurrentPage ? (
+            <Stack gap="xs">
+              {notes.map((note) => (
+                <Card key={note.id} padding="sm">
+                  <Group justify="space-between" align="flex-start">
+                    <Stack gap={2}>
+                      <Text size="sm">{note.note}</Text>
+                      <Text size="xs" c="dimmed">
+                        {note.createdBy?.name ?? "Unknown"} · <ClientDate date={note.createdAt} />
+                      </Text>
+                    </Stack>
+                    <ActionIcon variant="subtle" color="red" onClick={() => deleteNoteMutation.mutate({ id: note.id })}>
+                      <IconTrash size={14} />
+                    </ActionIcon>
+                  </Group>
+                </Card>
+              ))}
+            </Stack>
+          ) : (
+            <Text size="sm" c="dimmed" p="lg">
+              {normalizedSearch ? "No notes match your search." : "No notes on this page."}
+            </Text>
+          )}
 
-        <Group justify="space-between" px="md" pb="md">
-          <Text size="sm" c="dimmed">
-            {totalCount} note{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
-          </Text>
-          <Pagination
-            value={clampedPage}
-            total={totalPages}
-            onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-          />
-        </Group>
-      </Stack>
+          <Group justify="space-between" px="md" pb="md">
+            <Text size="sm" c="dimmed">
+              {totalCount} note{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
+            </Text>
+            <Pagination
+              value={clampedPage}
+              total={totalPages}
+              onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+            />
+          </Group>
+        </Stack>
 
-      <AddNoteDialog
-        customerId={customerId}
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        onSuccess={() => navigate({ search: { page: 1, search: searchValue }, replace: true })}
-      />
-    </Section>
+        <AddNoteDialog
+          customerId={customerId}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onSuccess={() => navigate({ search: { page: 1, search: searchValue }, replace: true })}
+        />
+      </Section>
+    </>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
@@ -1,24 +1,12 @@
-import {
-  Anchor,
-  Button,
-  Card,
-  Container,
-  Group,
-  Modal,
-  SimpleGrid,
-  Stack,
-  Tabs,
-  Text,
-  TextInput,
-  Title,
-} from "@mantine/core"
+import { Button, Card, Container, Group, Modal, SimpleGrid, Stack, Tabs, Text, TextInput, Title } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
-import { IconArrowLeft, IconPencil, IconPhone } from "@tabler/icons-react"
+import { IconPencil, IconPhone } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Link, Outlet, createFileRoute, useLocation } from "@tanstack/react-router"
+import { Outlet, createFileRoute, useLocation } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { CURRENCIES, formatMinor } from "@/lib/currency"
@@ -74,12 +62,7 @@ function CustomerDetailRoute() {
 
   return (
     <Container size="xl">
-      <Anchor component={Link} to="/customers" size="xs" c="dimmed" mb="xs" display="inline-block">
-        <Group gap={4}>
-          <IconArrowLeft size={12} />
-          Back to customers
-        </Group>
-      </Anchor>
+      <BreadcrumbItem label={customer.name} to={`/customers/${customerId}/appointments`} order={20} />
       <PageHeader
         title={customer.name}
         description={

--- a/apps/web/src/routes/_authenticated/customers/route.tsx
+++ b/apps/web/src/routes/_authenticated/customers/route.tsx
@@ -1,5 +1,16 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
+
 export const Route = createFileRoute("/_authenticated/customers")({
-  component: () => <Outlet />,
+  component: CustomersLayout,
 })
+
+function CustomersLayout() {
+  return (
+    <>
+      <BreadcrumbItem label="Customers" to="/customers" order={10} />
+      <Outlet />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { formatMinor, type Currency } from "@/lib/currency"
@@ -101,6 +102,7 @@ function DashboardPage() {
 
   return (
     <Container size="xl">
+      <BreadcrumbItem label="Dashboard" order={10} />
       <PageHeader
         title="Dashboard"
         description="Monthly performance against the previous month."

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -1,5 +1,4 @@
 import {
-  Anchor,
   Badge,
   Button,
   Card,
@@ -16,11 +15,12 @@ import {
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
-import { IconArrowLeft, IconCalculator, IconPencil, IconPlus, IconUser } from "@tabler/icons-react"
+import { IconCalculator, IconPencil, IconPlus, IconUser } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
 import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair-assigned-dialog"
@@ -83,12 +83,7 @@ function HairOrderDetailPage() {
 
   return (
     <Container size="xl">
-      <Anchor component={Link} to="/hair-orders" size="xs" c="dimmed" mb="xs" display="inline-block">
-        <Group gap={4}>
-          <IconArrowLeft size={12} />
-          Back to hair orders
-        </Group>
-      </Anchor>
+      <BreadcrumbItem label={`#${hairOrder.uid}`} order={20} />
       <PageHeader
         title={
           <Group gap="sm">

--- a/apps/web/src/routes/_authenticated/hair-orders/route.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/route.tsx
@@ -1,5 +1,16 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
+
 export const Route = createFileRoute("/_authenticated/hair-orders")({
-  component: () => <Outlet />,
+  component: HairOrdersLayout,
 })
+
+function HairOrdersLayout() {
+  return (
+    <>
+      <BreadcrumbItem label="Hair orders" to="/hair-orders" order={10} />
+      <Outlet />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
@@ -1,8 +1,9 @@
 import { Anchor, Badge, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
-import { IconArrowLeft, IconCalendar, IconScissors, IconUser } from "@tabler/icons-react"
+import { IconCalendar, IconScissors, IconUser } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
@@ -31,12 +32,7 @@ function HairSaleDetailPage() {
 
   return (
     <Container size="xl">
-      <Anchor component={Link} to="/hair-sales" size="xs" c="dimmed" mb="xs" display="inline-block">
-        <Group gap={4}>
-          <IconArrowLeft size={12} />
-          Back to hair sales
-        </Group>
-      </Anchor>
+      <BreadcrumbItem label="Hair sale" order={20} />
       <PageHeader
         title={
           <Group gap="sm">

--- a/apps/web/src/routes/_authenticated/hair-sales/route.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/route.tsx
@@ -1,5 +1,16 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
+
 export const Route = createFileRoute("/_authenticated/hair-sales")({
-  component: () => <Outlet />,
+  component: HairSalesLayout,
 })
+
+function HairSalesLayout() {
+  return (
+    <>
+      <BreadcrumbItem label="Hair sales" to="/hair-sales" order={10} />
+      <Outlet />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -24,20 +24,14 @@ import { MonthPickerInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
 import { useDisclosure } from "@mantine/hooks"
 import { notifications } from "@mantine/notifications"
-import {
-  IconArrowLeft,
-  IconDotsVertical,
-  IconDownload,
-  IconLinkOff,
-  IconPaperclip,
-  IconTrash,
-} from "@tabler/icons-react"
+import { IconDotsVertical, IconDownload, IconLinkOff, IconPaperclip, IconTrash } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { zodResolver } from "mantine-form-zod-resolver"
 import { useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { CURRENCY_OPTIONS, type Currency, formatMinor } from "@/lib/currency"
 import { bankAccountSchema } from "@/lib/schemas"
 import { trpc } from "@/utils/trpc"
@@ -56,6 +50,7 @@ function BankAccountRoute() {
 type StatusFilter = "PENDING" | "IGNORED" | "ALL"
 
 function BankAccountShow({ id }: { id: string }) {
+  const { legalEntityId } = Route.useParams()
   const queryClient = useQueryClient()
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
   const [file, setFile] = useState<File | null>(null)
@@ -133,26 +128,9 @@ function BankAccountShow({ id }: { id: string }) {
 
   return (
     <>
+      <BreadcrumbItem label="Bank accounts" to={`/legal-entities/${legalEntityId}/bank-accounts`} order={30} />
+      <BreadcrumbItem label={bankAccount?.displayName ?? "Bank account"} order={40} />
       <Stack>
-        {bankAccount?.legalEntity && (
-          <Anchor
-            renderRoot={(props) => (
-              <Link
-                to="/legal-entities/$legalEntityId/bank-accounts"
-                params={{ legalEntityId: bankAccount.legalEntity!.id }}
-                {...props}
-              />
-            )}
-            size="xs"
-            c="dimmed"
-          >
-            <Group gap={4}>
-              <IconArrowLeft size={12} />
-              Back to {bankAccount.legalEntity.name}
-            </Group>
-          </Anchor>
-        )}
-
         <Group justify="space-between">
           <Title order={3}>{bankAccount?.displayName ?? "Bank account"}</Title>
           <Button onClick={openEdit} disabled={!bankAccount}>
@@ -697,6 +675,8 @@ function BankAccountNew() {
 
   return (
     <Stack>
+      <BreadcrumbItem label="Bank accounts" to={`/legal-entities/${pathLegalEntityId}/bank-accounts`} order={30} />
+      <BreadcrumbItem label="New bank account" order={40} />
       <Title order={3}>New bank account</Title>
       <Card withBorder>
         <form onSubmit={form.onSubmit((values) => save.mutate(values))}>

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
@@ -2,6 +2,7 @@ import { Anchor, Button, Table } from "@mantine/core"
 import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
 
@@ -15,67 +16,70 @@ function BankAccountsTab() {
   const bankAccounts = legalEntity?.bankAccounts ?? []
 
   return (
-    <Section
-      title="Bank accounts"
-      description="Accounts that feed bank-statement imports."
-      actions={
-        <Button
-          size="sm"
-          variant="default"
-          renderRoot={(props) => (
-            <Link
-              to="/legal-entities/$legalEntityId/bank-accounts/$bankAccountId"
-              params={{ legalEntityId, bankAccountId: "new" }}
-              {...props}
-            />
-          )}
-        >
-          New bank account
-        </Button>
-      }
-      padding={0}
-    >
-      <Table>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Name</Table.Th>
-            <Table.Th>IBAN</Table.Th>
-            <Table.Th>Currency</Table.Th>
-            <Table.Th>Bank</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {bankAccounts.map((a) => (
-            <Table.Tr key={a.id}>
-              <Table.Td>
-                <Anchor
-                  renderRoot={(props) => (
-                    <Link
-                      to="/legal-entities/$legalEntityId/bank-accounts/$bankAccountId"
-                      params={{ legalEntityId, bankAccountId: a.id }}
-                      {...props}
-                    />
-                  )}
-                >
-                  {a.displayName}
-                </Anchor>
-              </Table.Td>
-              <Table.Td>
-                <code>{a.iban}</code>
-              </Table.Td>
-              <Table.Td>{a.currency}</Table.Td>
-              <Table.Td>{a.bankName ?? "—"}</Table.Td>
-            </Table.Tr>
-          ))}
-          {legalEntity && bankAccounts.length === 0 && (
+    <>
+      <BreadcrumbItem label="Bank accounts" order={30} />
+      <Section
+        title="Bank accounts"
+        description="Accounts that feed bank-statement imports."
+        actions={
+          <Button
+            size="sm"
+            variant="default"
+            renderRoot={(props) => (
+              <Link
+                to="/legal-entities/$legalEntityId/bank-accounts/$bankAccountId"
+                params={{ legalEntityId, bankAccountId: "new" }}
+                {...props}
+              />
+            )}
+          >
+            New bank account
+          </Button>
+        }
+        padding={0}
+      >
+        <Table>
+          <Table.Thead>
             <Table.Tr>
-              <Table.Td colSpan={4} ta="center" c="dimmed">
-                No bank accounts.
-              </Table.Td>
+              <Table.Th>Name</Table.Th>
+              <Table.Th>IBAN</Table.Th>
+              <Table.Th>Currency</Table.Th>
+              <Table.Th>Bank</Table.Th>
             </Table.Tr>
-          )}
-        </Table.Tbody>
-      </Table>
-    </Section>
+          </Table.Thead>
+          <Table.Tbody>
+            {bankAccounts.map((a) => (
+              <Table.Tr key={a.id}>
+                <Table.Td>
+                  <Anchor
+                    renderRoot={(props) => (
+                      <Link
+                        to="/legal-entities/$legalEntityId/bank-accounts/$bankAccountId"
+                        params={{ legalEntityId, bankAccountId: a.id }}
+                        {...props}
+                      />
+                    )}
+                  >
+                    {a.displayName}
+                  </Anchor>
+                </Table.Td>
+                <Table.Td>
+                  <code>{a.iban}</code>
+                </Table.Td>
+                <Table.Td>{a.currency}</Table.Td>
+                <Table.Td>{a.bankName ?? "—"}</Table.Td>
+              </Table.Tr>
+            ))}
+            {legalEntity && bankAccounts.length === 0 && (
+              <Table.Tr>
+                <Table.Td colSpan={4} ta="center" c="dimmed">
+                  No bank accounts.
+                </Table.Td>
+              </Table.Tr>
+            )}
+          </Table.Tbody>
+        </Table>
+      </Section>
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/documents.tsx
@@ -18,6 +18,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { Section } from "@/components/section"
 import { type Currency, formatMinor } from "@/lib/currency"
 import { trpc } from "@/utils/trpc"
@@ -143,6 +144,7 @@ function DocumentsTab() {
 
   return (
     <>
+      <BreadcrumbItem label="Documents" order={30} />
       <Section
         title="Documents"
         description={

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { BankAccountReportBlock } from "@/components/reports-cards"
 import { trpc } from "@/utils/trpc"
 
@@ -30,6 +31,7 @@ function OverviewTab() {
 
   return (
     <Stack gap="lg">
+      <BreadcrumbItem label="Overview" order={30} />
       <Group justify="space-between" align="flex-end">
         <Stack gap={2}>
           <Title order={4} fw={600} lh={1.3}>

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -21,6 +21,7 @@ import { Link, Outlet, createFileRoute, useLocation } from "@tanstack/react-rout
 import { TRPCClientError } from "@trpc/client"
 import { zodResolver } from "mantine-form-zod-resolver"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
 import {
@@ -114,12 +115,12 @@ function LegalEntityLayout() {
 
   return (
     <Container size="xl">
-      <Anchor component={Link} to="/legal-entities" size="xs" c="dimmed" mb="xs" display="inline-block">
-        <Group gap={4}>
-          <IconArrowLeft size={12} />
-          Back to legal entities
-        </Group>
-      </Anchor>
+      <BreadcrumbItem label="Legal entities" to="/legal-entities" order={10} />
+      <BreadcrumbItem
+        label={legalEntity?.name ?? "Legal entity"}
+        to={`/legal-entities/${legalEntityId}/overview`}
+        order={20}
+      />
       <PageHeader
         title={legalEntity?.name ?? "Legal entity"}
         description={description}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
@@ -2,6 +2,7 @@ import { Button } from "@mantine/core"
 import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { SalonsTable } from "@/components/salons-table"
 import { Section } from "@/components/section"
 import { trpc } from "@/utils/trpc"
@@ -14,20 +15,23 @@ function SalonsTab() {
   const { data: salons = [] } = useQuery(trpc.salons.list.queryOptions({}))
 
   return (
-    <Section
-      title="Salons"
-      description="Locations associated with this legal entity."
-      actions={
-        <Button
-          size="sm"
-          variant="default"
-          renderRoot={(props) => <Link to="/salons/$salonId" params={{ salonId: "new" }} {...props} />}
-        >
-          New salon
-        </Button>
-      }
-    >
-      <SalonsTable salons={salons} />
-    </Section>
+    <>
+      <BreadcrumbItem label="Salons" order={30} />
+      <Section
+        title="Salons"
+        description="Locations associated with this legal entity."
+        actions={
+          <Button
+            size="sm"
+            variant="default"
+            renderRoot={(props) => <Link to="/salons/$salonId" params={{ salonId: "new" }} {...props} />}
+          >
+            New salon
+          </Button>
+        }
+      >
+        <SalonsTable salons={salons} />
+      </Section>
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -2,6 +2,7 @@ import { Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title }
 import { useQuery } from "@tanstack/react-query"
 import { Link, createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
 import { LEGAL_ENTITY_SECTIONS, getLegalEntitySectionPath } from "@/lib/legal-entity-navigation"
@@ -21,6 +22,7 @@ function LegalEntitiesIndex() {
 
   return (
     <Container size="xl">
+      <BreadcrumbItem label="Legal entities" order={10} />
       <PageHeader title="Legal entities" description="Companies and sole-trader registrations." />
       {unassignedCount > 0 ? (
         <Group gap="xs" mb="md">

--- a/apps/web/src/routes/_authenticated/profile.tsx
+++ b/apps/web/src/routes/_authenticated/profile.tsx
@@ -20,6 +20,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import Loader2 from "@/components/loader"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
@@ -87,6 +88,7 @@ function ProfilePage() {
 
   return (
     <Container size="md">
+      <BreadcrumbItem label="Profile" order={10} />
       <PageHeader title="Profile" description="Manage account details, password, and active sessions." />
       <Stack>
         <Section

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -34,6 +34,7 @@ import { useQuery, useQueryErrorResetBoundary } from "@tanstack/react-query"
 import { Link, Outlet, createFileRoute, redirect, useLocation, useNavigate, useRouter } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { BreadcrumbProvider } from "@/components/breadcrumbs"
 import { appNavGroups, flatAppNavItems, type AppNavItem } from "@/lib/app-navigation"
 import { authClient } from "@/lib/auth-client"
 import { trpc } from "@/utils/trpc"
@@ -67,17 +68,19 @@ function AuthenticatedLayout() {
   const badges = { unassigned: unassignedAttachments.length }
 
   return (
-    <AppShell header={{ height: { base: 64, lg: 102 } }} padding={0}>
-      <AppShell.Header className={classes.header}>
-        <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
-        <DesktopTabs badges={badges} />
-      </AppShell.Header>
-      <MobileNavigationDrawer opened={mobileOpened} onClose={closeMobile} badges={badges} />
+    <BreadcrumbProvider>
+      <AppShell header={{ height: { base: 64, lg: 102 } }} padding={0}>
+        <AppShell.Header className={classes.header}>
+          <HeaderTop opened={mobileOpened} onToggle={toggleMobile} />
+          <DesktopTabs badges={badges} />
+        </AppShell.Header>
+        <MobileNavigationDrawer opened={mobileOpened} onClose={closeMobile} badges={badges} />
 
-      <AppShell.Main className={classes.main}>
-        <Outlet />
-      </AppShell.Main>
-    </AppShell>
+        <AppShell.Main className={classes.main}>
+          <Outlet />
+        </AppShell.Main>
+      </AppShell>
+    </BreadcrumbProvider>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/settings.tsx
+++ b/apps/web/src/routes/_authenticated/settings.tsx
@@ -1,6 +1,7 @@
 import { Container, Group, Stack, Text } from "@mantine/core"
 import { createFileRoute } from "@tanstack/react-router"
 
+import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
@@ -15,6 +16,7 @@ function SettingsPage() {
 
   return (
     <Container size="md">
+      <BreadcrumbItem label="Settings" order={10} />
       <PageHeader title="Settings" description="Read-only workspace preferences detected from your browser." />
       <Section title="Locale & timezone" description="Used to format dates, times and currency throughout the app.">
         <Stack gap="xs">


### PR DESCRIPTION
## Summary
- add route-local breadcrumb registration rendered through Mantine Breadcrumbs
- show quieter breadcrumbs inside page headers for nested/detail pages
- remove duplicate detail-page back links covered by breadcrumbs

## Verification
- vp test
- vp check
- vp run --filter web check-types
- vp run --filter web build