### PR TITLE
fix: combine customer hair sales table

### DIFF
--- a/apps/web/src/components/hair-assigned/hair-assigned-source.ts
+++ b/apps/web/src/components/hair-assigned/hair-assigned-source.ts
@@ -1,0 +1,3 @@
+export function getHairAssignedSource(item: { appointmentId?: string | null }) {
+  return item.appointmentId ? { color: "blue", label: "Appointment" } : { color: "grape", label: "Individual" }
+}

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test"
 
-import { getHairAssignedSource } from "./hair-assigned-table"
+import { getHairAssignedSource } from "./hair-assigned-source"
 
 describe("hair assigned table", () => {
   it("labels appointment-tied and individual hair sales", () => {

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import { getHairAssignedSource } from "./hair-assigned-table"
+
+describe("hair assigned table", () => {
+  it("labels appointment-tied and individual hair sales", () => {
+    expect(getHairAssignedSource({ appointmentId: "appointment-1" })).toEqual({
+      color: "blue",
+      label: "Appointment",
+    })
+    expect(getHairAssignedSource({ appointmentId: null })).toEqual({
+      color: "grape",
+      label: "Individual",
+    })
+    expect(getHairAssignedSource({})).toEqual({
+      color: "grape",
+      label: "Individual",
+    })
+  })
+})

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -2,6 +2,8 @@ import { ActionIcon, Badge, Group, Table, Text } from "@mantine/core"
 import { IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 
+import { getHairAssignedSource } from "./hair-assigned-source"
+
 export type HairAssignedRow = {
   id: string
   appointmentId?: string | null
@@ -22,10 +24,6 @@ type HairAssignedTableProps = {
 }
 
 const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
-
-export function getHairAssignedSource(item: { appointmentId?: string | null }) {
-  return item.appointmentId ? { color: "blue", label: "Appointment" } : { color: "grape", label: "Individual" }
-}
 
 export function HairAssignedTable({
   items,

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -1,9 +1,10 @@
-import { ActionIcon, Group, Table, Text } from "@mantine/core"
+import { ActionIcon, Badge, Group, Table, Text } from "@mantine/core"
 import { IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 
 export type HairAssignedRow = {
   id: string
+  appointmentId?: string | null
   weightInGrams: number
   soldFor: number
   profit: number
@@ -14,6 +15,7 @@ export type HairAssignedRow = {
 
 type HairAssignedTableProps = {
   items: HairAssignedRow[]
+  showSourceColumn?: boolean
   showHairOrderColumn?: boolean
   onEdit: (item: HairAssignedRow) => void
   onDelete: (item: HairAssignedRow) => void
@@ -21,7 +23,17 @@ type HairAssignedTableProps = {
 
 const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 
-export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, onDelete }: HairAssignedTableProps) {
+export function getHairAssignedSource(item: { appointmentId?: string | null }) {
+  return item.appointmentId ? { color: "blue", label: "Appointment" } : { color: "grape", label: "Individual" }
+}
+
+export function HairAssignedTable({
+  items,
+  showSourceColumn = false,
+  showHairOrderColumn = false,
+  onEdit,
+  onDelete,
+}: HairAssignedTableProps) {
   if (items.length === 0) {
     return (
       <Text size="sm" c="dimmed">
@@ -35,6 +47,7 @@ export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, 
       <Table.Thead>
         <Table.Tr>
           <Table.Th>Client</Table.Th>
+          {showSourceColumn && <Table.Th>Source</Table.Th>}
           {showHairOrderColumn && <Table.Th>Hair Order</Table.Th>}
           <Table.Th>Weight</Table.Th>
           <Table.Th>Sold For</Table.Th>
@@ -46,6 +59,7 @@ export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, 
       <Table.Tbody>
         {items.map((ha) => {
           const needsAttention = ha.weightInGrams === 0 || ha.soldFor === 0
+          const source = getHairAssignedSource(ha)
           return (
             <Table.Tr key={ha.id} bg={needsAttention ? "var(--mantine-color-red-0)" : undefined}>
               <Table.Td>
@@ -62,6 +76,13 @@ export function HairAssignedTable({ items, showHairOrderColumn = false, onEdit, 
                   "—"
                 )}
               </Table.Td>
+              {showSourceColumn && (
+                <Table.Td>
+                  <Badge variant="light" color={source.color}>
+                    {source.label}
+                  </Badge>
+                </Table.Td>
+              )}
               {showHairOrderColumn && (
                 <Table.Td>
                   {ha.hairOrder ? (

--- a/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Group, Pagination, Stack, Text, TextInput, Title } from "@mantine/core"
+import { Button, Group, Pagination, Stack, Text, TextInput } from "@mantine/core"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
@@ -50,8 +50,6 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/hair
   },
 })
 
-type HairAssignedItem = HairAssignedRow & { appointmentId?: string | null }
-
 function HairSalesRoute() {
   const { customerId } = Route.useParams()
   const search = Route.useSearch()
@@ -65,14 +63,11 @@ function HairSalesRoute() {
   const normalizedSearch = searchValue.trim()
   const queryOptions = hairSalesQueryOptions(customerId, page, searchValue)
   const { data } = useQuery(queryOptions)
-  const hairAssigned = (data?.items ?? []) as HairAssignedItem[]
+  const hairAssigned = (data?.items ?? []) as HairAssignedRow[]
   const totalCount = data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const clampedPage = Math.min(page, totalPages)
   const hasItemsOnCurrentPage = hairAssigned.length > 0
-
-  const throughAppointment = hairAssigned.filter((ha) => !!ha.appointmentId)
-  const individual = hairAssigned.filter((ha) => !ha.appointmentId)
 
   return (
     <>
@@ -106,43 +101,13 @@ function HairSalesRoute() {
       >
         <Stack gap="md">
           {hasItemsOnCurrentPage ? (
-            <Stack>
-              <Card withBorder>
-                <Title order={5} mb="sm">
-                  Hair Sales through Appointment
-                </Title>
-                {throughAppointment.length > 0 ? (
-                  <HairAssignedTable
-                    items={throughAppointment}
-                    showHairOrderColumn
-                    onEdit={setHairEditItem}
-                    onDelete={setHairDeleteItem}
-                  />
-                ) : (
-                  <Text size="sm" c="dimmed">
-                    No appointment-tied hair sales on this page.
-                  </Text>
-                )}
-              </Card>
-
-              <Card withBorder>
-                <Title order={5} mb="sm">
-                  Hair Sales Individual
-                </Title>
-                {individual.length > 0 ? (
-                  <HairAssignedTable
-                    items={individual}
-                    showHairOrderColumn
-                    onEdit={setHairEditItem}
-                    onDelete={setHairDeleteItem}
-                  />
-                ) : (
-                  <Text size="sm" c="dimmed">
-                    No individual hair sales on this page.
-                  </Text>
-                )}
-              </Card>
-            </Stack>
+            <HairAssignedTable
+              items={hairAssigned}
+              showSourceColumn
+              showHairOrderColumn
+              onEdit={setHairEditItem}
+              onDelete={setHairDeleteItem}
+            />
           ) : (
             <Text size="sm" c="dimmed" p="lg">
               {normalizedSearch ? "No hair sales match your search." : "No hair sales on this page."}


### PR DESCRIPTION
## Summary
- combine appointment-tied and individual customer hair sales into one table
- add an optional Source badge column to the shared hair-assigned table
- cover source label mapping with a focused unit test

## Validation
- vp check
- vp test
- vp run -r check-types