### PR TITLE
fix: remove release environment metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,6 @@ jobs:
     name: Pre-deploy Postgres Backup
     needs: promote-release
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://prive.salon
     timeout-minutes: 15
     permissions:
       contents: read
@@ -174,9 +171,6 @@ jobs:
     name: Deploy to prive
     needs: [promote-release, pre-deploy-backup]
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://prive.salon
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- remove GitHub Actions environment metadata from release backup and deploy jobs
- keep production URL/domain sourced from 1Password runtime configuration
- avoid misleading deployment links and environment URL secret-mask warnings

## Verification
- vp check
- vp test