### PR TITLE
refactor: align trpc document API names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,18 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 
 <!--VITE PLUS END-->
 
+## API Governance
+
+Backend capability must be modeled first as an application service in `packages/application/src/services`.
+
+tRPC routers are transport adapters, not UI-specific backend-for-frontend endpoints. New procedures should be named around domain resources and stable use cases, usually `list`, `get`, `create`, `update`, `delete`, or domain verbs such as `assign`, `unassign`, `importCsv`, and `recalculatePrices`.
+
+Collection reads should use a single `list` procedure with resource-oriented filters instead of separate procedures for each filtered subset. List procedures must return the standard paged response envelope and use the backend default `pageSize` of 10 when the caller does not provide one.
+
+Do not add procedures named after pages, components, drawers, tabs, or UI workflows unless the same use case is first modeled as an application service and the API naming is reviewed.
+
+Do not create REST/Hono adapters solely to satisfy this rule. Keep using tRPC for the internal web app unless a task explicitly asks for REST endpoints or HTTP-specific behavior such as uploads, downloads, redirects, streaming, caching semantics, or third-party integration.
+
 ## PR Titles
 
 Use a conventional-commits PR title when opening or editing PRs. Allowed types are `feat`, `fix`, `chore`, `ci`, `docs`, `refactor`, `perf`, `test`, `build`, `style`, and `revert`. Scope is optional, and the subject must start with a letter.

--- a/apps/web/src/components/appointments/create-appointment-dialog.tsx
+++ b/apps/web/src/components/appointments/create-appointment-dialog.tsx
@@ -69,7 +69,7 @@ function CreateAppointmentForm({
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const appointmentListQueryOptions = trpc.appointments.list.queryOptions(defaultAppointmentsListInput)
-  const salonsQueryOptions = trpc.salons.list.queryOptions({})
+  const salonsQueryOptions = trpc.salons.list.queryOptions({ pageSize: 100 })
   const [clientSearch, setClientSearch] = useState("")
   const [masterSearch, setMasterSearch] = useState("")
   const [selectedCustomerOptions, setSelectedCustomerOptions] = useState<Record<string, SelectOption>>({})
@@ -115,7 +115,8 @@ function CreateAppointmentForm({
     setSelectedCustomerOptions((current) => ({ ...current, [option.value]: option }))
   }
 
-  const { data: salons } = useQuery(salonsQueryOptions)
+  const { data: salonsData } = useQuery(salonsQueryOptions)
+  const salons = salonsData?.items ?? []
 
   const mutation = useMutation({
     ...trpc.appointments.create.mutationOptions(),
@@ -183,7 +184,7 @@ function CreateAppointmentForm({
         <Select
           label="Salon"
           required
-          data={(salons ?? []).map((s: SalonOption) => ({ value: s.id, label: s.name }))}
+          data={salons.map((s: SalonOption) => ({ value: s.id, label: s.name }))}
           {...form.getInputProps("salonId")}
         />
         <Group justify="flex-end" gap="xs">

--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -24,14 +24,18 @@ export function CreateHairAssignedDialog({
 }: CreateHairAssignedDialogProps) {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
   const queryClient = useQueryClient()
-  const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const availableOrdersQueryOptions = trpc.hairOrders.list.queryOptions({
+    availability: "availableForAssignment",
+    pageSize: 100,
+  })
   const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 
-  const { data: availableOrders, isLoading } = useQuery({
+  const { data: availableOrdersData, isLoading } = useQuery({
     ...availableOrdersQueryOptions,
     enabled: open,
   })
+  const availableOrders = availableOrdersData?.items ?? []
 
   const mutation = useMutation({
     ...trpc.hairAssigned.create.mutationOptions(),
@@ -66,7 +70,7 @@ export function CreateHairAssignedDialog({
           <Text size="sm" c="dimmed">
             Loading…
           </Text>
-        ) : availableOrders && availableOrders.length > 0 ? (
+        ) : availableOrders.length > 0 ? (
           <Radio.Group value={selectedOrderId} onChange={setSelectedOrderId}>
             <Table>
               <Table.Thead>

--- a/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/delete-hair-assigned-dialog.tsx
@@ -25,7 +25,10 @@ export function DeleteHairAssignedDialog({
   onSuccess,
 }: DeleteHairAssignedDialogProps) {
   const queryClient = useQueryClient()
-  const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const availableOrdersQueryOptions = trpc.hairOrders.list.queryOptions({
+    availability: "availableForAssignment",
+    pageSize: 100,
+  })
   const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 

--- a/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
@@ -19,7 +19,10 @@ export function EditHairAssignedDialog({
   invalidateKeys,
 }: EditHairAssignedDialogProps) {
   const queryClient = useQueryClient()
-  const availableOrdersQueryOptions = trpc.hairAssigned.availableOrders.queryOptions()
+  const availableOrdersQueryOptions = trpc.hairOrders.list.queryOptions({
+    availability: "availableForAssignment",
+    pageSize: 100,
+  })
   const hairAssignedListQueryKey = trpc.hairAssigned.list.queryKey()
   const hairOrdersListQueryKey = trpc.hairOrders.list.queryKey()
 

--- a/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
+++ b/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
@@ -45,7 +45,8 @@ function documentQueryOptions(documentId: string) {
 }
 
 function matchCandidatesQueryOptions(page: number) {
-  return trpc.bankStatementEntries.listMatchCandidates.queryOptions({
+  return trpc.bankStatementEntries.list.queryOptions({
+    status: "PENDING",
     page,
     pageSize: MATCH_CANDIDATES_PAGE_SIZE,
   })
@@ -107,9 +108,7 @@ function DocumentMatchPage() {
   const invalidate = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.get.queryKey({ id: documentId }) }),
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.listGlobal.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() }),
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.listAssigned.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.counts.queryKey() }),
     ])
   }

--- a/apps/web/src/routes/_authenticated/documents/index.tsx
+++ b/apps/web/src/routes/_authenticated/documents/index.tsx
@@ -38,8 +38,8 @@ const searchSchema = z.object({
 type DocumentStatus = z.infer<typeof documentStatusSchema>
 
 function documentsQueryOptions(input: { status: DocumentStatus; page: number }) {
-  return trpc.bankStatementAttachments.listGlobal.queryOptions(
-    { status: input.status, page: input.page, pageSize: PAGE_SIZE },
+  return trpc.bankStatementAttachments.list.queryOptions(
+    { assignmentStatus: input.status, page: input.page, pageSize: PAGE_SIZE },
     { placeholderData: (previousData) => previousData },
   )
 }
@@ -80,9 +80,7 @@ function DocumentsPage() {
 
   const invalidate = async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.listGlobal.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() }),
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.listAssigned.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.counts.queryKey() }),
     ])
   }

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -370,22 +370,23 @@ function AttachmentsCell({
   const [busy, setBusy] = useState(false)
   const [fileInputKey, setFileInputKey] = useState(0)
 
-  const listQueryOptions = trpc.bankStatementAttachments.list.queryOptions({ entryId })
-  const { data: attachments = [], isLoading: attachmentsLoading } = useQuery({
+  const listQueryOptions = trpc.bankStatementAttachments.list.queryOptions({ entryId, pageSize: 100 })
+  const { data: attachmentsData, isLoading: attachmentsLoading } = useQuery({
     ...listQueryOptions,
     enabled: opened,
   })
+  const attachments = attachmentsData?.items.map((row) => row.attachment) ?? []
 
-  const { data: unassignedAttachments = [] } = useQuery({
-    ...trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  const { data: unassignedAttachmentsData } = useQuery({
+    ...trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned", pageSize: 100 }),
     enabled: opened,
   })
+  const unassignedAttachments = unassignedAttachmentsData?.items.map((row) => row.attachment) ?? []
 
   const invalidate = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.list.queryKey() }),
       queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.counts.queryKey() }),
-      queryClient.invalidateQueries({ queryKey: trpc.bankStatementAttachments.listAssigned.queryKey() }),
     ])
   }
 
@@ -569,7 +570,8 @@ function EditBankAccountModal({
   initial: FormValues
 }) {
   const queryClient = useQueryClient()
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: legalEntitiesData } = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+  const legalEntities = legalEntitiesData?.items ?? []
 
   const form = useForm<FormValues & { id: string }>({
     initialValues: {
@@ -642,7 +644,8 @@ function BankAccountNew() {
   const { legalEntityId: pathLegalEntityId } = Route.useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: legalEntitiesData } = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+  const legalEntities = legalEntitiesData?.items ?? []
 
   const form = useForm<FormValues>({
     initialValues: {

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -36,7 +36,8 @@ function LegalEntityLayout() {
     retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
   })
   const legalEntity = legalEntityQuery.data
-  const { data: legalEntities = [] } = useQuery(trpc.legalEntities.list.queryOptions({}))
+  const { data: legalEntitiesData } = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+  const legalEntities = legalEntitiesData?.items ?? []
   const country = legalEntity?.country as Country | undefined
   const description = legalEntity
     ? `${legalEntity.type}${country ? ` · ${COUNTRY_FLAGS[country]} ${COUNTRY_LABELS[country]}` : ""} · ${legalEntity.defaultCurrency}`
@@ -196,7 +197,7 @@ function EditLegalEntityForm({
   onClose: () => void
 }) {
   const queryClient = useQueryClient()
-  const legalEntitiesQueryOptions = trpc.legalEntities.list.queryOptions({})
+  const legalEntitiesQueryOptions = trpc.legalEntities.list.queryOptions({ pageSize: 100 })
   const legalEntityQueryOptions = trpc.legalEntities.get.queryOptions({ id: initialValues.id })
 
   const form = useForm<EditValues & { id: string }>({

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
@@ -12,7 +12,8 @@ export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntit
 })
 
 function SalonsTab() {
-  const { data: salons = [] } = useQuery(trpc.salons.list.queryOptions({}))
+  const { data: salonsData } = useQuery(trpc.salons.list.queryOptions({ pageSize: 100 }))
+  const salons = salonsData?.items ?? []
 
   return (
     <>

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -13,12 +13,12 @@ export const Route = createFileRoute("/_authenticated/legal-entities/")({
 })
 
 function LegalEntitiesIndex() {
-  const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({}))
-  const legalEntities = legalEntitiesQuery.data ?? []
-  const { data: unassignedAttachments = [] } = useQuery(
-    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+  const legalEntities = legalEntitiesQuery.data?.items ?? []
+  const { data: unassignedAttachments } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
   )
-  const unassignedCount = unassignedAttachments.length
+  const unassignedCount = unassignedAttachments?.totalCount ?? 0
 
   return (
     <Container size="xl">

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -62,10 +62,10 @@ export const Route = createFileRoute("/_authenticated")({
 function AuthenticatedLayout() {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false)
 
-  const { data: unassignedAttachments = [] } = useQuery(
-    trpc.bankStatementAttachments.list.queryOptions({ assigned: false }),
+  const { data: unassignedAttachments } = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
   )
-  const badges = { unassigned: unassignedAttachments.length }
+  const badges = { unassigned: unassignedAttachments?.totalCount ?? 0 }
 
   return (
     <BreadcrumbProvider>

--- a/apps/web/src/routes/_authenticated/salons/$salonId.tsx
+++ b/apps/web/src/routes/_authenticated/salons/$salonId.tsx
@@ -20,7 +20,7 @@ function SalonEdit() {
   const isNew = salonId === "new"
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const salonsQueryOptions = trpc.salons.list.queryOptions({})
+  const salonsQueryOptions = trpc.salons.list.queryOptions({ pageSize: 100 })
   const salonQueryOptions = trpc.salons.get.queryOptions({ id: salonId })
 
   const { data: salon } = useQuery({

--- a/packages/api/src/pagination.test.ts
+++ b/packages/api/src/pagination.test.ts
@@ -4,7 +4,7 @@ import { getOffset, pageSchema, pagedResult, searchSchema } from "./pagination"
 
 describe("pagination helpers", () => {
   it("defaults page and pageSize", () => {
-    expect(pageSchema.parse({})).toEqual({ page: 1, pageSize: 25 })
+    expect(pageSchema.parse({})).toEqual({ page: 1, pageSize: 10 })
   })
 
   it("rejects unsafe page sizes", () => {

--- a/packages/api/src/pagination.ts
+++ b/packages/api/src/pagination.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 export const pageSchema = z.object({
   page: z.number().int().min(1).max(1000).default(1),
-  pageSize: z.number().int().min(1).max(100).default(25),
+  pageSize: z.number().int().min(1).max(100).default(10),
 })
 
 export const searchSchema = z

--- a/packages/api/src/routers/bank-statement-attachments.test.ts
+++ b/packages/api/src/routers/bank-statement-attachments.test.ts
@@ -7,9 +7,7 @@ const servicesMock = vi.hoisted(() => ({
   countBankStatementAttachments: vi.fn(),
   deleteBankStatementAttachmentFile: vi.fn(),
   getBankStatementAttachment: vi.fn(),
-  listAssignedBankStatementAttachments: vi.fn(),
   listBankStatementAttachments: vi.fn(),
-  listGlobalBankStatementAttachments: vi.fn(),
   unassignBankStatementAttachment: vi.fn(),
 }))
 
@@ -22,26 +20,27 @@ describe("bank statement attachments router", () => {
     vi.clearAllMocks()
   })
 
-  it("lists assigned documents in the standard page envelope", async () => {
+  it("lists documents filtered by legal entity in the standard page envelope", async () => {
     const caller = bankStatementAttachmentsRouter.createCaller(ctx)
     const rows = [{ attachment: { id: "attachment-1" }, entry: { id: "entry-1" }, bankAccount: { id: "account-1" } }]
-    servicesMock.listAssignedBankStatementAttachments.mockResolvedValue({ items: rows, totalCount: 42 })
+    servicesMock.listBankStatementAttachments.mockResolvedValue({ items: rows, totalCount: 42 })
 
-    const result = await caller.listAssigned({
+    const result = await caller.list({
       legalEntityId: "legal-entity-1",
       page: 3,
       pageSize: 10,
     })
 
     expect(result).toEqual({ items: rows, page: 3, pageSize: 10, totalCount: 42 })
-    expect(servicesMock.listAssignedBankStatementAttachments).toHaveBeenCalledWith({
+    expect(servicesMock.listBankStatementAttachments).toHaveBeenCalledWith({
+      assignmentStatus: "all",
       legalEntityId: "legal-entity-1",
       pageSize: 10,
       offset: 20,
     })
   })
 
-  it("lists global documents in the standard page envelope", async () => {
+  it("lists documents by assignment status in the standard page envelope", async () => {
     const caller = bankStatementAttachmentsRouter.createCaller(ctx)
     const rows = [
       {
@@ -52,19 +51,33 @@ describe("bank statement attachments router", () => {
         legalEntity: { id: "legal-entity-1", name: "Prive LT" },
       },
     ]
-    servicesMock.listGlobalBankStatementAttachments.mockResolvedValue({ items: rows, totalCount: 12 })
+    servicesMock.listBankStatementAttachments.mockResolvedValue({ items: rows, totalCount: 12 })
 
-    const result = await caller.listGlobal({
-      status: "assigned",
+    const result = await caller.list({
+      assignmentStatus: "assigned",
       page: 2,
       pageSize: 10,
     })
 
     expect(result).toEqual({ items: rows, page: 2, pageSize: 10, totalCount: 12 })
-    expect(servicesMock.listGlobalBankStatementAttachments).toHaveBeenCalledWith({
-      status: "assigned",
+    expect(servicesMock.listBankStatementAttachments).toHaveBeenCalledWith({
+      assignmentStatus: "assigned",
       pageSize: 10,
       offset: 10,
+    })
+  })
+
+  it("uses the backend default page size for list queries", async () => {
+    const caller = bankStatementAttachmentsRouter.createCaller(ctx)
+    servicesMock.listBankStatementAttachments.mockResolvedValue({ items: [], totalCount: 0 })
+
+    const result = await caller.list({})
+
+    expect(result).toEqual({ items: [], page: 1, pageSize: 10, totalCount: 0 })
+    expect(servicesMock.listBankStatementAttachments).toHaveBeenCalledWith({
+      assignmentStatus: "all",
+      pageSize: 10,
+      offset: 0,
     })
   })
 

--- a/packages/api/src/routers/bank-statement-attachments.ts
+++ b/packages/api/src/routers/bank-statement-attachments.ts
@@ -3,9 +3,7 @@ import {
   countBankStatementAttachments,
   deleteBankStatementAttachmentFile,
   getBankStatementAttachment,
-  listAssignedBankStatementAttachments,
   listBankStatementAttachments,
-  listGlobalBankStatementAttachments,
   unassignBankStatementAttachment,
 } from "@prive-admin-tanstack/application/services"
 import { z } from "zod"
@@ -17,48 +15,18 @@ import { getOffset, pagedResult, pageSchema } from "../pagination"
 export const bankStatementAttachmentsRouter = router({
   list: protectedProcedure
     .input(
-      z.object({
+      pageSchema.extend({
+        assignmentStatus: z.enum(["assigned", "unassigned", "all"]).default("all"),
         entryId: z.string().min(1).optional(),
-        assigned: z.boolean().optional(),
+        legalEntityId: z.string().min(1).optional(),
       }),
     )
     .query(async ({ input }) => {
       try {
-        return await listBankStatementAttachments(input)
-      } catch (error) {
-        throw toTrpcError(error)
-      }
-    }),
-
-  listAssigned: protectedProcedure
-    .input(
-      pageSchema.extend({
-        legalEntityId: z.string().min(1),
-      }),
-    )
-    .query(async ({ input }) => {
-      try {
-        const result = await listAssignedBankStatementAttachments({
-          legalEntityId: input.legalEntityId,
-          pageSize: input.pageSize,
-          offset: getOffset(input),
-        })
-        return pagedResult(result.items, input, result.totalCount)
-      } catch (error) {
-        throw toTrpcError(error)
-      }
-    }),
-
-  listGlobal: protectedProcedure
-    .input(
-      pageSchema.extend({
-        status: z.enum(["assigned", "unassigned", "all"]).default("unassigned"),
-      }),
-    )
-    .query(async ({ input }) => {
-      try {
-        const result = await listGlobalBankStatementAttachments({
-          status: input.status,
+        const result = await listBankStatementAttachments({
+          assignmentStatus: input.assignmentStatus,
+          ...(input.entryId ? { entryId: input.entryId } : {}),
+          ...(input.legalEntityId ? { legalEntityId: input.legalEntityId } : {}),
           pageSize: input.pageSize,
           offset: getOffset(input),
         })

--- a/packages/api/src/routers/bank-statement-entries.test.ts
+++ b/packages/api/src/routers/bank-statement-entries.test.ts
@@ -8,7 +8,6 @@ const servicesMock = vi.hoisted(() => ({
   ignoreBankStatementEntry: vi.fn(),
   importBankStatementEntries: vi.fn(),
   listBankStatementEntries: vi.fn(),
-  listBankStatementEntryMatchCandidates: vi.fn(),
   parseBankCsv: vi.fn(),
   undoBankStatementEntry: vi.fn(),
 }))
@@ -22,7 +21,7 @@ describe("bank statement entries router", () => {
     vi.clearAllMocks()
   })
 
-  it("lists match candidates in the standard page envelope", async () => {
+  it("lists pending entries in the standard page envelope", async () => {
     const caller = bankStatementEntriesRouter.createCaller(ctx)
     const rows = [
       {
@@ -35,14 +34,15 @@ describe("bank statement entries router", () => {
         },
       },
     ]
-    servicesMock.listBankStatementEntryMatchCandidates.mockResolvedValue({ items: rows, totalCount: 12 })
+    servicesMock.listBankStatementEntries.mockResolvedValue({ items: rows, totalCount: 12 })
 
-    const result = await caller.listMatchCandidates({ page: 3, pageSize: 100 })
+    const result = await caller.list({ status: "PENDING", page: 3, pageSize: 100 })
 
     expect(result).toEqual({ items: rows, page: 3, pageSize: 100, totalCount: 12 })
-    expect(servicesMock.listBankStatementEntryMatchCandidates).toHaveBeenCalledWith({
+    expect(servicesMock.listBankStatementEntries).toHaveBeenCalledWith({
       pageSize: 100,
       offset: 200,
+      status: "PENDING",
     })
   })
 })

--- a/packages/api/src/routers/bank-statement-entries.ts
+++ b/packages/api/src/routers/bank-statement-entries.ts
@@ -4,7 +4,6 @@ import {
   getBankStatementEntry,
   ignoreBankStatementEntry,
   importBankStatementEntries,
-  listBankStatementEntryMatchCandidates,
   listBankStatementEntries,
   undoBankStatementEntry,
 } from "@prive-admin-tanstack/application/services"
@@ -75,18 +74,6 @@ export const bankStatementEntriesRouter = router({
         offset: getOffset(input),
         bankAccountId: input.bankAccountId,
         status: input.status,
-      })
-      return pagedResult(result.items, input, result.totalCount)
-    } catch (error) {
-      throw toTrpcError(error)
-    }
-  }),
-
-  listMatchCandidates: protectedProcedure.input(pageSchema).query(async ({ input }) => {
-    try {
-      const result = await listBankStatementEntryMatchCandidates({
-        pageSize: input.pageSize,
-        offset: getOffset(input),
       })
       return pagedResult(result.items, input, result.totalCount)
     } catch (error) {

--- a/packages/api/src/routers/hair-assigned.ts
+++ b/packages/api/src/routers/hair-assigned.ts
@@ -1,5 +1,4 @@
 import {
-  availableHairOrders,
   createHairAssigned,
   deleteHairAssigned,
   getHairAssigned,
@@ -43,14 +42,6 @@ export const hairAssignedRouter = router({
   get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {
     try {
       return await getHairAssigned(input.id)
-    } catch (error) {
-      throw toTrpcError(error)
-    }
-  }),
-
-  availableOrders: protectedProcedure.query(async () => {
-    try {
-      return await availableHairOrders()
     } catch (error) {
       throw toTrpcError(error)
     }

--- a/packages/api/src/routers/hair-orders.ts
+++ b/packages/api/src/routers/hair-orders.ts
@@ -25,6 +25,7 @@ const hairOrderInputSchema = z.object({
 const hairOrderListSchema = pageSchema.extend({
   customerId: z.string().optional(),
   status: z.enum(["PENDING", "COMPLETED"]).optional(),
+  availability: z.enum(["availableForAssignment"]).optional(),
 })
 
 export const hairOrdersRouter = router({
@@ -35,6 +36,7 @@ export const hairOrdersRouter = router({
         offset: getOffset(input),
         customerId: input.customerId,
         status: input.status,
+        availability: input.availability,
       })
       return pagedResult(result.items, input, result.totalCount)
     } catch (error) {

--- a/packages/api/src/routers/legal-entities.ts
+++ b/packages/api/src/routers/legal-entities.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { toTrpcError } from "../errors"
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const legalEntityUpdateSchema = z.object({
   id: z.string().min(1),
@@ -12,8 +13,9 @@ const legalEntityUpdateSchema = z.object({
 })
 
 export const legalEntitiesRouter = router({
-  list: protectedProcedure.input(z.object({}).optional().default({})).query(() => {
-    return listLegalEntities()
+  list: protectedProcedure.input(pageSchema).query(async ({ input }) => {
+    const result = await listLegalEntities({ pageSize: input.pageSize, offset: getOffset(input) })
+    return pagedResult(result.items, input, result.totalCount)
   }),
 
   get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {

--- a/packages/api/src/routers/notes.ts
+++ b/packages/api/src/routers/notes.ts
@@ -2,6 +2,7 @@ import { createNote, deleteNote, listNotes } from "@prive-admin-tanstack/applica
 import { z } from "zod"
 
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const noteSchema = z.object({
   id: z.string().optional(),
@@ -14,18 +15,21 @@ const noteSchema = z.object({
 export const notesRouter = router({
   list: protectedProcedure
     .input(
-      z.object({
+      pageSchema.extend({
         customerId: z.string().optional(),
         appointmentId: z.string().optional(),
         hairOrderId: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
-      return listNotes({
+      const result = await listNotes({
+        pageSize: input.pageSize,
+        offset: getOffset(input),
         customerId: input.customerId,
         appointmentId: input.appointmentId,
         hairOrderId: input.hairOrderId,
       })
+      return pagedResult(result.items, input, result.totalCount)
     }),
 
   create: protectedProcedure.input(noteSchema).mutation(async ({ input, ctx }) => {

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -4,6 +4,10 @@ import { appointmentsRouter } from "./appointments"
 import { bankAccountsRouter } from "./bank-accounts"
 import { customersRouter } from "./customers"
 import { hairAssignedRouter } from "./hair-assigned"
+import { hairOrdersRouter } from "./hair-orders"
+import { legalEntitiesRouter } from "./legal-entities"
+import { notesRouter } from "./notes"
+import { salonsRouter } from "./salons"
 import { transactionsRouter } from "./transactions"
 
 const servicesMock = vi.hoisted(() => ({
@@ -17,10 +21,14 @@ const servicesMock = vi.hoisted(() => ({
   getHairAssigned: vi.fn(),
   updateBankAccount: vi.fn(),
   listHairAssigned: vi.fn(),
+  listHairOrders: vi.fn(),
   listCustomers: vi.fn(),
   listCustomerAppointments: vi.fn(),
   listCustomerHairAssigned: vi.fn(),
   listCustomerNotes: vi.fn(),
+  listLegalEntities: vi.fn(),
+  listNotes: vi.fn(),
+  listSalons: vi.fn(),
   createTransaction: vi.fn(),
   deleteTransaction: vi.fn(),
   listTransactions: vi.fn(),
@@ -216,5 +224,57 @@ describe("resource read routers", () => {
         search: "42",
       }),
     )
+  })
+
+  it("lists notes in the standard page envelope", async () => {
+    const caller = notesRouter.createCaller(ctx)
+    const noteRows = [{ id: "note-1", customerId: "customer-1" }]
+    servicesMock.listNotes.mockResolvedValue({ items: noteRows, totalCount: 5 })
+
+    const result = await caller.list({ page: 2, pageSize: 10, customerId: "customer-1" })
+
+    expect(result).toEqual({ items: noteRows, page: 2, pageSize: 10, totalCount: 5 })
+    expect(servicesMock.listNotes).toHaveBeenCalledWith({
+      customerId: "customer-1",
+      pageSize: 10,
+      offset: 10,
+    })
+  })
+
+  it("lists legal entities in the standard page envelope", async () => {
+    const caller = legalEntitiesRouter.createCaller(ctx)
+    const legalEntityRows = [{ id: "legal-entity-1", name: "Prive LT" }]
+    servicesMock.listLegalEntities.mockResolvedValue({ items: legalEntityRows, totalCount: 2 })
+
+    const result = await caller.list({})
+
+    expect(result).toEqual({ items: legalEntityRows, page: 1, pageSize: 10, totalCount: 2 })
+    expect(servicesMock.listLegalEntities).toHaveBeenCalledWith({ pageSize: 10, offset: 0 })
+  })
+
+  it("lists salons in the standard page envelope", async () => {
+    const caller = salonsRouter.createCaller(ctx)
+    const salonRows = [{ id: "salon-1", name: "Prive Salon" }]
+    servicesMock.listSalons.mockResolvedValue({ items: salonRows, totalCount: 3 })
+
+    const result = await caller.list({ page: 2, pageSize: 10 })
+
+    expect(result).toEqual({ items: salonRows, page: 2, pageSize: 10, totalCount: 3 })
+    expect(servicesMock.listSalons).toHaveBeenCalledWith({ pageSize: 10, offset: 10 })
+  })
+
+  it("lists hair orders available for assignment through the resource list", async () => {
+    const caller = hairOrdersRouter.createCaller(ctx)
+    const hairOrderRows = [{ id: "hair-order-1", uid: 42 }]
+    servicesMock.listHairOrders.mockResolvedValue({ items: hairOrderRows, totalCount: 1 })
+
+    const result = await caller.list({ availability: "availableForAssignment" })
+
+    expect(result).toEqual({ items: hairOrderRows, page: 1, pageSize: 10, totalCount: 1 })
+    expect(servicesMock.listHairOrders).toHaveBeenCalledWith({
+      pageSize: 10,
+      offset: 0,
+      availability: "availableForAssignment",
+    })
   })
 })

--- a/packages/api/src/routers/salons.ts
+++ b/packages/api/src/routers/salons.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { toTrpcError } from "../errors"
 import { protectedProcedure, router } from "../index"
+import { getOffset, pagedResult, pageSchema } from "../pagination"
 
 const salonSchema = z.object({
   id: z.string().optional(),
@@ -11,8 +12,9 @@ const salonSchema = z.object({
 })
 
 export const salonsRouter = router({
-  list: protectedProcedure.input(z.object({}).optional().default({})).query(() => {
-    return listSalons()
+  list: protectedProcedure.input(pageSchema).query(async ({ input }) => {
+    const result = await listSalons({ pageSize: input.pageSize, offset: getOffset(input) })
+    return pagedResult(result.items, input, result.totalCount)
   }),
 
   get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(async ({ input }) => {

--- a/packages/application/src/services/bank-statement-attachments.test.ts
+++ b/packages/application/src/services/bank-statement-attachments.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
-import { listAssignedBankStatementAttachments, listGlobalBankStatementAttachments } from "./bank-statement-attachments"
+import { listBankStatementAttachments } from "./bank-statement-attachments"
 
 const dbMock = vi.hoisted(() => ({
-  listAssignedBankStatementAttachments: vi.fn(),
-  listGlobalBankStatementAttachments: vi.fn(),
+  listBankStatementAttachments: vi.fn(),
 }))
 
 vi.mock("@prive-admin-tanstack/db", () => dbMock)
@@ -14,33 +13,34 @@ describe("bank statement attachment service", () => {
     vi.clearAllMocks()
   })
 
-  it("forwards assigned document paging and legal entity scope to the database layer", async () => {
-    dbMock.listAssignedBankStatementAttachments.mockResolvedValue({ items: [], totalCount: 0 })
+  it("forwards document paging and legal entity scope to the database layer", async () => {
+    dbMock.listBankStatementAttachments.mockResolvedValue({ items: [], totalCount: 0 })
 
-    await listAssignedBankStatementAttachments({
+    await listBankStatementAttachments({
       legalEntityId: "legal-entity-1",
       pageSize: 25,
       offset: 50,
     })
 
-    expect(dbMock.listAssignedBankStatementAttachments).toHaveBeenCalledWith(undefined, {
+    expect(dbMock.listBankStatementAttachments).toHaveBeenCalledWith(undefined, {
       legalEntityId: "legal-entity-1",
+      assignmentStatus: "all",
       pageSize: 25,
       offset: 50,
     })
   })
 
-  it("forwards global document status and paging to the database layer", async () => {
-    dbMock.listGlobalBankStatementAttachments.mockResolvedValue({ items: [], totalCount: 0 })
+  it("forwards document assignment status and paging to the database layer", async () => {
+    dbMock.listBankStatementAttachments.mockResolvedValue({ items: [], totalCount: 0 })
 
-    await listGlobalBankStatementAttachments({
-      status: "all",
+    await listBankStatementAttachments({
+      assignmentStatus: "assigned",
       pageSize: 50,
       offset: 100,
     })
 
-    expect(dbMock.listGlobalBankStatementAttachments).toHaveBeenCalledWith(undefined, {
-      status: "all",
+    expect(dbMock.listBankStatementAttachments).toHaveBeenCalledWith(undefined, {
+      assignmentStatus: "assigned",
       pageSize: 50,
       offset: 100,
     })

--- a/packages/application/src/services/bank-statement-attachments.ts
+++ b/packages/application/src/services/bank-statement-attachments.ts
@@ -5,8 +5,6 @@ import {
   countBankStatementAttachments as fetchBankStatementAttachmentCounts,
   getBankStatementAttachment as findBankStatementAttachment,
   getBankStatementEntry as findBankStatementEntry,
-  listAssignedBankStatementAttachments as fetchAssignedBankStatementAttachments,
-  listGlobalBankStatementAttachments as fetchGlobalBankStatementAttachments,
   deleteBankStatementAttachment as removeBankStatementAttachment,
   listBankStatementAttachmentExportRows as fetchBankStatementAttachmentExportRows,
   listBankStatementAttachments as fetchBankStatementAttachments,
@@ -40,24 +38,17 @@ const ZipArchive = (
   }
 ).ZipArchive
 
-export async function listBankStatementAttachments(input: { entryId?: string; assigned?: boolean } = {}) {
-  return fetchBankStatementAttachments(undefined, input)
-}
-
-export async function listAssignedBankStatementAttachments(input: {
-  legalEntityId: string
+export async function listBankStatementAttachments(input: {
+  assignmentStatus?: "assigned" | "unassigned" | "all"
   pageSize: number
   offset: number
+  entryId?: string
+  legalEntityId?: string
 }) {
-  return fetchAssignedBankStatementAttachments(undefined, input)
-}
-
-export async function listGlobalBankStatementAttachments(input: {
-  status: "assigned" | "unassigned" | "all"
-  pageSize: number
-  offset: number
-}) {
-  return fetchGlobalBankStatementAttachments(undefined, input)
+  return fetchBankStatementAttachments(undefined, {
+    ...input,
+    assignmentStatus: input.assignmentStatus ?? "all",
+  })
 }
 
 export async function countBankStatementAttachments() {

--- a/packages/application/src/services/bank-statement-entries.test.ts
+++ b/packages/application/src/services/bank-statement-entries.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
-import { listBankStatementEntryMatchCandidates } from "./bank-statement-entries"
+import { listBankStatementEntries } from "./bank-statement-entries"
 
 const dbMock = vi.hoisted(() => ({
   listBankStatementEntries: vi.fn(),
@@ -13,10 +13,10 @@ describe("bank statement entry service", () => {
     vi.clearAllMocks()
   })
 
-  it("lists pending match candidates with paging", async () => {
+  it("lists pending entries with paging", async () => {
     dbMock.listBankStatementEntries.mockResolvedValue({ items: [], totalCount: 0 })
 
-    await listBankStatementEntryMatchCandidates({ pageSize: 100, offset: 200 })
+    await listBankStatementEntries({ pageSize: 100, offset: 200, status: "PENDING" })
 
     expect(dbMock.listBankStatementEntries).toHaveBeenCalledWith(undefined, {
       pageSize: 100,

--- a/packages/application/src/services/bank-statement-entries.ts
+++ b/packages/application/src/services/bank-statement-entries.ts
@@ -47,14 +47,6 @@ export async function listBankStatementEntries(input: {
   return fetchBankStatementEntries(undefined, input)
 }
 
-export async function listBankStatementEntryMatchCandidates(input: { pageSize: number; offset: number }) {
-  return fetchBankStatementEntries(undefined, {
-    pageSize: input.pageSize,
-    offset: input.offset,
-    status: "PENDING",
-  })
-}
-
 export async function getBankStatementEntry(id: string) {
   const row = await findBankStatementEntry(undefined, id)
   if (!row) throw notFound("Statement entry not found")

--- a/packages/application/src/services/hair.ts
+++ b/packages/application/src/services/hair.ts
@@ -6,7 +6,6 @@ import {
   getHairOrder as findHairOrder,
   listHairAssigned as fetchHairAssigned,
   listHairOrders as fetchHairOrders,
-  availableHairOrders as fetchAvailableHairOrders,
   recalculateHairOrderPrices as recalculateHairOrderPricesRepo,
   updateHairAssigned as patchHairAssigned,
   updateHairOrder as patchHairOrder,
@@ -48,15 +47,12 @@ export async function getHairAssigned(id: string) {
   return result
 }
 
-export async function availableHairOrders() {
-  return fetchAvailableHairOrders(undefined)
-}
-
 export async function listHairOrders(input: {
   pageSize: number
   offset: number
   customerId?: string
   status?: "PENDING" | "COMPLETED"
+  availability?: "availableForAssignment"
 }) {
   return fetchHairOrders(undefined, input)
 }

--- a/packages/application/src/services/legal-entities.ts
+++ b/packages/application/src/services/legal-entities.ts
@@ -6,8 +6,8 @@ import {
 
 import { notFound } from "../errors"
 
-export async function listLegalEntities() {
-  return fetchLegalEntities()
+export async function listLegalEntities(input: { pageSize: number; offset: number }) {
+  return fetchLegalEntities(undefined, input)
 }
 
 export async function getLegalEntity(id: string) {

--- a/packages/application/src/services/notes.ts
+++ b/packages/application/src/services/notes.ts
@@ -2,7 +2,13 @@ import { createNote as insertNote, deleteNote as removeNote, listNotes as fetchN
 
 import { unexpectedError } from "../errors"
 
-export async function listNotes(filter: { customerId?: string; appointmentId?: string; hairOrderId?: string }) {
+export async function listNotes(filter: {
+  pageSize: number
+  offset: number
+  customerId?: string
+  appointmentId?: string
+  hairOrderId?: string
+}) {
   return fetchNotes(undefined, filter)
 }
 

--- a/packages/application/src/services/salons.ts
+++ b/packages/application/src/services/salons.ts
@@ -7,8 +7,8 @@ import {
 
 import { notFound, unexpectedError } from "../errors"
 
-export async function listSalons() {
-  return fetchSalons()
+export async function listSalons(input: { pageSize: number; offset: number }) {
+  return fetchSalons(undefined, input)
 }
 
 export async function getSalon(id: string) {

--- a/packages/db/src/repositories/bank-statement-attachments.test.ts
+++ b/packages/db/src/repositories/bank-statement-attachments.test.ts
@@ -5,7 +5,7 @@ import { bankAccount } from "../schema/bank-account"
 import { bankStatementAttachment } from "../schema/bank-statement-attachment"
 import { bankStatementEntry } from "../schema/bank-statement-entry"
 import { legalEntity } from "../schema/legal-entity"
-import { listAssignedBankStatementAttachments, listGlobalBankStatementAttachments } from "./bank-statement-attachments"
+import { listBankStatementAttachments } from "./bank-statement-attachments"
 
 vi.mock("../index", () => ({ db: {} }))
 
@@ -55,14 +55,14 @@ describe("bank statement attachment repository", () => {
     const countRows = [{ totalCount: 7 }]
     const calls: {
       from: unknown[]
-      innerJoin: Array<{ table: unknown; condition: unknown }>
+      leftJoin: Array<{ table: unknown; condition: unknown }>
       limit: number[]
       offset: number[]
       orderBy: unknown[][]
       where: unknown[]
     } = {
       from: [],
-      innerJoin: [],
+      leftJoin: [],
       limit: [],
       offset: [],
       orderBy: [],
@@ -74,8 +74,8 @@ describe("bank statement attachment repository", () => {
         calls.from.push(table)
         return itemsBuilder
       }),
-      innerJoin: vi.fn((table: unknown, condition: unknown) => {
-        calls.innerJoin.push({ table, condition })
+      leftJoin: vi.fn((table: unknown, condition: unknown) => {
+        calls.leftJoin.push({ table, condition })
         return itemsBuilder
       }),
       limit: vi.fn((value: number) => {
@@ -100,8 +100,8 @@ describe("bank statement attachment repository", () => {
         calls.from.push(table)
         return countBuilder
       }),
-      innerJoin: vi.fn((table: unknown, condition: unknown) => {
-        calls.innerJoin.push({ table, condition })
+      leftJoin: vi.fn((table: unknown, condition: unknown) => {
+        calls.leftJoin.push({ table, condition })
         return countBuilder
       }),
       where: vi.fn(async (condition: unknown) => {
@@ -113,7 +113,8 @@ describe("bank statement attachment repository", () => {
       select: vi.fn().mockReturnValueOnce(itemsBuilder).mockReturnValueOnce(countBuilder),
     }
 
-    const result = await listAssignedBankStatementAttachments(database as never, {
+    const result = await listBankStatementAttachments(database as never, {
+      assignmentStatus: "assigned",
       legalEntityId: "legal-entity-1",
       pageSize: 25,
       offset: 50,
@@ -122,25 +123,25 @@ describe("bank statement attachment repository", () => {
     expect(result).toEqual({ items: assignedRows, totalCount: 7 })
     expect(database.select).toHaveBeenCalledTimes(2)
     expect(calls.from).toEqual([bankStatementAttachment, bankStatementAttachment])
-    expect(calls.innerJoin.map((call) => call.table)).toEqual([
+    expect(calls.leftJoin.map((call) => call.table)).toEqual([
       bankStatementEntry,
       bankAccount,
+      legalEntity,
       bankStatementEntry,
       bankAccount,
+      legalEntity,
     ])
     const expectedWhere = and(
-      isNotNull(bankStatementAttachment.bankStatementEntryId),
       eq(bankAccount.legalEntityId, "legal-entity-1"),
+      isNotNull(bankStatementAttachment.bankStatementEntryId),
     )
     expect(calls.where).toEqual([expectedWhere, expectedWhere])
-    expect(calls.orderBy).toEqual([
-      [desc(bankStatementEntry.date), desc(bankStatementAttachment.uploadedAt), desc(bankStatementAttachment.id)],
-    ])
+    expect(calls.orderBy).toEqual([[desc(bankStatementAttachment.uploadedAt), desc(bankStatementAttachment.id)]])
     expect(calls.limit).toEqual([25])
     expect(calls.offset).toEqual([50])
   })
 
-  it("lists global assigned documents with legal entity context", async () => {
+  it("lists assigned documents with legal entity context", async () => {
     const rows = [
       {
         attachment: { id: "attachment-1", bankStatementEntryId: "entry-1" },
@@ -152,8 +153,8 @@ describe("bank statement attachment repository", () => {
     ]
     const { calls, database } = createSelectBuilders(rows, [{ totalCount: 3 }])
 
-    const result = await listGlobalBankStatementAttachments(database as never, {
-      status: "assigned",
+    const result = await listBankStatementAttachments(database as never, {
+      assignmentStatus: "assigned",
       pageSize: 25,
       offset: 50,
     })
@@ -176,7 +177,7 @@ describe("bank statement attachment repository", () => {
     expect(calls.offset).toEqual([50])
   })
 
-  it("lists global unassigned documents with null assignment context", async () => {
+  it("lists unassigned documents with null assignment context", async () => {
     const rows = [
       {
         attachment: { id: "attachment-1", bankStatementEntryId: null },
@@ -188,8 +189,8 @@ describe("bank statement attachment repository", () => {
     ]
     const { calls, database } = createSelectBuilders(rows, [{ totalCount: 1 }])
 
-    await listGlobalBankStatementAttachments(database as never, {
-      status: "unassigned",
+    await listBankStatementAttachments(database as never, {
+      assignmentStatus: "unassigned",
       pageSize: 10,
       offset: 0,
     })
@@ -200,11 +201,11 @@ describe("bank statement attachment repository", () => {
     expect(calls.offset).toEqual([0])
   })
 
-  it("lists all global documents without assignment filter", async () => {
+  it("lists all documents without assignment filter", async () => {
     const { calls, database } = createSelectBuilders([], [{ totalCount: 0 }])
 
-    await listGlobalBankStatementAttachments(database as never, {
-      status: "all",
+    await listBankStatementAttachments(database as never, {
+      assignmentStatus: "all",
       pageSize: 25,
       offset: 0,
     })

--- a/packages/db/src/repositories/bank-statement-attachments.ts
+++ b/packages/db/src/repositories/bank-statement-attachments.ts
@@ -28,68 +28,9 @@ export async function getBankStatementAttachment(database: Db = db, id: string) 
   })
 }
 
-export async function listBankStatementAttachments(
-  database: Db = db,
-  filter: { entryId?: string; assigned?: boolean } = {},
-) {
-  const conditions = []
-  if (filter.entryId) conditions.push(eq(bankStatementAttachment.bankStatementEntryId, filter.entryId))
-  if (filter.assigned === false) conditions.push(isNull(bankStatementAttachment.bankStatementEntryId))
-  if (filter.assigned === true) conditions.push(isNotNull(bankStatementAttachment.bankStatementEntryId))
+export type BankStatementAttachmentAssignmentStatus = "assigned" | "unassigned" | "all"
 
-  return database.query.bankStatementAttachment.findMany({
-    where: conditions.length > 0 ? and(...conditions) : undefined,
-    orderBy: [desc(bankStatementAttachment.uploadedAt)],
-  })
-}
-
-export type AssignedBankStatementAttachmentRow = {
-  attachment: typeof bankStatementAttachment.$inferSelect
-  entry: typeof bankStatementEntry.$inferSelect
-  bankAccount: Pick<typeof bankAccount.$inferSelect, "id" | "displayName" | "bankName" | "currency">
-}
-
-export async function listAssignedBankStatementAttachments(
-  database: Db = db,
-  input: { legalEntityId: string; pageSize: number; offset: number },
-) {
-  const where = and(
-    isNotNull(bankStatementAttachment.bankStatementEntryId),
-    eq(bankAccount.legalEntityId, input.legalEntityId),
-  )
-
-  const items = await database
-    .select({
-      attachment: bankStatementAttachment,
-      entry: bankStatementEntry,
-      bankAccount: {
-        id: bankAccount.id,
-        displayName: bankAccount.displayName,
-        bankName: bankAccount.bankName,
-        currency: bankAccount.currency,
-      },
-    })
-    .from(bankStatementAttachment)
-    .innerJoin(bankStatementEntry, eq(bankStatementAttachment.bankStatementEntryId, bankStatementEntry.id))
-    .innerJoin(bankAccount, eq(bankStatementEntry.bankAccountId, bankAccount.id))
-    .where(where)
-    .orderBy(desc(bankStatementEntry.date), desc(bankStatementAttachment.uploadedAt), desc(bankStatementAttachment.id))
-    .limit(input.pageSize)
-    .offset(input.offset)
-
-  const [countRow] = await database
-    .select({ totalCount: count() })
-    .from(bankStatementAttachment)
-    .innerJoin(bankStatementEntry, eq(bankStatementAttachment.bankStatementEntryId, bankStatementEntry.id))
-    .innerJoin(bankAccount, eq(bankStatementEntry.bankAccountId, bankAccount.id))
-    .where(where)
-
-  return { items, totalCount: countRow?.totalCount ?? 0 }
-}
-
-export type GlobalBankStatementAttachmentStatus = "assigned" | "unassigned" | "all"
-
-export type GlobalBankStatementAttachmentRow = {
+export type BankStatementAttachmentRow = {
   attachment: typeof bankStatementAttachment.$inferSelect
   assignmentState: "assigned" | "unassigned"
   entry: typeof bankStatementEntry.$inferSelect | null
@@ -97,16 +38,22 @@ export type GlobalBankStatementAttachmentRow = {
   legalEntity: Pick<typeof legalEntity.$inferSelect, "id" | "name"> | null
 }
 
-export async function listGlobalBankStatementAttachments(
+export async function listBankStatementAttachments(
   database: Db = db,
-  input: { status: GlobalBankStatementAttachmentStatus; pageSize: number; offset: number },
+  filter: {
+    assignmentStatus: BankStatementAttachmentAssignmentStatus
+    pageSize: number
+    offset: number
+    entryId?: string
+    legalEntityId?: string
+  },
 ) {
-  const where =
-    input.status === "assigned"
-      ? isNotNull(bankStatementAttachment.bankStatementEntryId)
-      : input.status === "unassigned"
-        ? isNull(bankStatementAttachment.bankStatementEntryId)
-        : undefined
+  const conditions = []
+  if (filter.entryId) conditions.push(eq(bankStatementAttachment.bankStatementEntryId, filter.entryId))
+  if (filter.legalEntityId) conditions.push(eq(bankAccount.legalEntityId, filter.legalEntityId))
+  if (filter.assignmentStatus === "assigned") conditions.push(isNotNull(bankStatementAttachment.bankStatementEntryId))
+  if (filter.assignmentStatus === "unassigned") conditions.push(isNull(bankStatementAttachment.bankStatementEntryId))
+  const where = conditions.length === 1 ? conditions[0] : conditions.length > 1 ? and(...conditions) : undefined
 
   const itemsQuery = database
     .select({
@@ -137,8 +84,8 @@ export async function listGlobalBankStatementAttachments(
   const items = await itemsQuery
     .where(where)
     .orderBy(desc(bankStatementAttachment.uploadedAt), desc(bankStatementAttachment.id))
-    .limit(input.pageSize)
-    .offset(input.offset)
+    .limit(filter.pageSize)
+    .offset(filter.offset)
 
   const countQuery = database
     .select({ totalCount: count() })

--- a/packages/db/src/repositories/hair.ts
+++ b/packages/db/src/repositories/hair.ts
@@ -114,21 +114,22 @@ export async function getHairAssigned(database: Db = db, id: string) {
   })
 }
 
-export async function availableHairOrders(database: Db = db) {
-  return database.query.hairOrder.findMany({
-    where: gt(sql`${hairOrder.weightReceived} - ${hairOrder.weightUsed}`, 0),
-    with: { customer: true },
-    orderBy: (ho, { asc }) => [asc(ho.uid)],
-  })
-}
-
 export async function listHairOrders(
   database: Db = db,
-  filter: { pageSize: number; offset: number; customerId?: string; status?: "PENDING" | "COMPLETED" },
+  filter: {
+    pageSize: number
+    offset: number
+    customerId?: string
+    status?: "PENDING" | "COMPLETED"
+    availability?: "availableForAssignment"
+  },
 ) {
   const conditions = []
   if (filter.customerId) conditions.push(eq(hairOrder.customerId, filter.customerId))
   if (filter.status) conditions.push(eq(hairOrder.status, filter.status))
+  if (filter.availability === "availableForAssignment") {
+    conditions.push(gt(sql`${hairOrder.weightReceived} - ${hairOrder.weightUsed}`, 0))
+  }
   const where = conditions.length > 0 ? and(...conditions) : undefined
 
   const items = await database.query.hairOrder.findMany({

--- a/packages/db/src/repositories/legal-entities.ts
+++ b/packages/db/src/repositories/legal-entities.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm"
+import { asc, count, eq } from "drizzle-orm"
 
 import { db, type Db } from "../index"
 import { legalEntity } from "../schema/legal-entity"
@@ -10,10 +10,15 @@ export type LegalEntityUpsertInput = {
   vatNumber?: string | null
 }
 
-export async function listLegalEntities(database: Db = db) {
-  return database.query.legalEntity.findMany({
+export async function listLegalEntities(database: Db = db, input: { pageSize: number; offset: number }) {
+  const items = await database.query.legalEntity.findMany({
     orderBy: (le) => [asc(le.country), asc(le.name)],
+    limit: input.pageSize,
+    offset: input.offset,
   })
+
+  const [countRow] = await database.select({ totalCount: count() }).from(legalEntity)
+  return { items, totalCount: countRow?.totalCount ?? 0 }
 }
 
 export async function getLegalEntity(database: Db = db, id: string) {

--- a/packages/db/src/repositories/notes.ts
+++ b/packages/db/src/repositories/notes.ts
@@ -1,9 +1,11 @@
-import { and, desc, eq } from "drizzle-orm"
+import { and, count, desc, eq } from "drizzle-orm"
 
 import { db, type Db } from "../index"
 import { note } from "../schema/note"
 
 export type NoteListFilter = {
+  pageSize: number
+  offset: number
   customerId?: string
   appointmentId?: string
   hairOrderId?: string
@@ -18,17 +20,23 @@ export type NoteInput = {
   createdById: string
 }
 
-export async function listNotes(database: Db = db, filter: NoteListFilter = {}) {
+export async function listNotes(database: Db = db, filter: NoteListFilter) {
   const conditions = []
   if (filter.customerId) conditions.push(eq(note.customerId, filter.customerId))
   if (filter.appointmentId) conditions.push(eq(note.appointmentId, filter.appointmentId))
   if (filter.hairOrderId) conditions.push(eq(note.hairOrderId, filter.hairOrderId))
+  const where = conditions.length > 0 ? and(...conditions) : undefined
 
-  return database.query.note.findMany({
-    where: conditions.length > 0 ? and(...conditions) : undefined,
+  const items = await database.query.note.findMany({
+    where,
     with: { createdBy: true },
     orderBy: (n) => [desc(n.createdAt)],
+    limit: filter.pageSize,
+    offset: filter.offset,
   })
+
+  const [countRow] = await database.select({ totalCount: count() }).from(note).where(where)
+  return { items, totalCount: countRow?.totalCount ?? 0 }
 }
 
 export async function createNote(database: Db = db, input: NoteInput) {

--- a/packages/db/src/repositories/salons.ts
+++ b/packages/db/src/repositories/salons.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm"
+import { asc, count, eq } from "drizzle-orm"
 
 import { db, type Db } from "../index"
 import { salon } from "../schema/salon"
@@ -9,10 +9,15 @@ export type SalonUpsertInput = {
   address?: string | null
 }
 
-export async function listSalons(database: Db = db) {
-  return database.query.salon.findMany({
+export async function listSalons(database: Db = db, input: { pageSize: number; offset: number }) {
+  const items = await database.query.salon.findMany({
     orderBy: (s) => [asc(s.name)],
+    limit: input.pageSize,
+    offset: input.offset,
   })
+
+  const [countRow] = await database.select({ totalCount: count() }).from(salon)
+  return { items, totalCount: countRow?.totalCount ?? 0 }
 }
 
 export async function getSalon(database: Db = db, id: string) {


### PR DESCRIPTION
## Summary
- add API governance guidance for service-first, resource-shaped tRPC procedures
- require collection reads to use paged list procedures with backend default pageSize 10
- collapse bank statement attachment list variants into one filtered bankStatementAttachments.list procedure
- convert notes, legalEntities, and salons list procedures to paged envelopes
- fold hairAssigned.availableOrders into hairOrders.list with an availability filter
- remove the redundant match-candidate procedure in favor of filtering bank statement entries by pending status

## Verification
- vp install
- vp run -r check-types
- vp check
- vp test