### PR TITLE
refactor: share resource pagination

### DIFF
--- a/apps/web/src/components/cash-transactions/cash-transactions-table.tsx
+++ b/apps/web/src/components/cash-transactions/cash-transactions-table.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react"
 
-import { ActionIcon, Group, Menu, Pagination, Table, Text } from "@mantine/core"
+import { ActionIcon, Menu, Table, Text } from "@mantine/core"
 import { IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 import dayjs from "dayjs"
@@ -11,6 +11,7 @@ import {
   getCompoundTableColumns,
   getCompoundTablePagination,
 } from "@/components/compound-table"
+import { ResourcePagination } from "@/components/resource-pagination"
 import { formatMinor } from "@/lib/currency"
 
 import { coerceCashTransactionCurrency } from "./currency"
@@ -161,20 +162,18 @@ function CashTransactionsTableRoot({ items, children }: CashTransactionsTableRoo
 }
 
 const TablePagination = Object.assign(
-  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: CashTransactionPaginationProps) => {
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
-    const clampedPage = Math.min(page, totalPages)
-    return (
-      <Group justify={label ? "space-between" : "flex-end"} mt={mt} px={px} pb={pb}>
-        {label ? (
-          <Text size="sm" c="dimmed">
-            {label}
-          </Text>
-        ) : null}
-        <Pagination total={totalPages} value={clampedPage} onChange={onChange} />
-      </Group>
-    )
-  },
+  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: CashTransactionPaginationProps) => (
+    <ResourcePagination
+      page={page}
+      pageSize={pageSize}
+      totalCount={totalCount}
+      onChange={onChange}
+      label={label}
+      mt={mt}
+      px={px}
+      pb={pb}
+    />
+  ),
   { isTablePagination: true as const },
 )
 

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react"
 
-import { ActionIcon, Badge, Group, Pagination, Table, Text } from "@mantine/core"
+import { ActionIcon, Badge, Group, Table, Text } from "@mantine/core"
 import { IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 import { createContext, useContext } from "react"
@@ -10,6 +10,7 @@ import {
   getCompoundTableColumns,
   getCompoundTablePagination,
 } from "@/components/compound-table"
+import { ResourcePagination } from "@/components/resource-pagination"
 
 import { getHairAssignedSource } from "./hair-assigned-source"
 
@@ -157,20 +158,18 @@ function HairAssignedTableRoot({ items, children }: HairAssignedTableRootProps) 
 }
 
 const TablePagination = Object.assign(
-  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: HairAssignedPaginationProps) => {
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
-    const clampedPage = Math.min(page, totalPages)
-    return (
-      <Group justify={label ? "space-between" : "flex-end"} mt={mt} px={px} pb={pb}>
-        {label ? (
-          <Text size="sm" c="dimmed">
-            {label}
-          </Text>
-        ) : null}
-        <Pagination total={totalPages} value={clampedPage} onChange={onChange} />
-      </Group>
-    )
-  },
+  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: HairAssignedPaginationProps) => (
+    <ResourcePagination
+      page={page}
+      pageSize={pageSize}
+      totalCount={totalCount}
+      onChange={onChange}
+      label={label}
+      mt={mt}
+      px={px}
+      pb={pb}
+    />
+  ),
   { isTablePagination: true as const },
 )
 

--- a/apps/web/src/components/resource-pagination.test.tsx
+++ b/apps/web/src/components/resource-pagination.test.tsx
@@ -1,0 +1,25 @@
+import { MantineProvider } from "@mantine/core"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vite-plus/test"
+
+import { ResourcePagination } from "./resource-pagination"
+
+function renderResourcePagination(props: Parameters<typeof ResourcePagination>[0]) {
+  return renderToStaticMarkup(createElement(MantineProvider, null, createElement(ResourcePagination, props)))
+}
+
+describe("ResourcePagination", () => {
+  it("renders a controlled pagination footer with a clamped active page", () => {
+    const markup = renderResourcePagination({
+      page: 5,
+      pageSize: 25,
+      totalCount: 80,
+      onChange: () => {},
+      label: "Showing resources",
+    })
+
+    expect(markup).toContain("Showing resources")
+    expect(markup).toContain("Page 4 of 4")
+  })
+})

--- a/apps/web/src/components/resource-pagination.tsx
+++ b/apps/web/src/components/resource-pagination.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react"
+
+import { Group, Pagination, Text } from "@mantine/core"
+import { usePagination } from "@mantine/hooks"
+
+export type ResourcePaginationProps = {
+  page: number
+  pageSize: number
+  totalCount: number
+  onChange: (page: number) => void
+  label?: ReactNode
+  mt?: "md"
+  px?: "md"
+  pb?: "md"
+  p?: "md"
+  size?: "sm"
+}
+
+function getTotalPages(totalCount: number, pageSize: number) {
+  return Math.max(1, Math.ceil(totalCount / pageSize))
+}
+
+export function ResourcePagination({
+  page,
+  pageSize,
+  totalCount,
+  onChange,
+  label,
+  mt,
+  px,
+  pb,
+  p,
+  size,
+}: ResourcePaginationProps) {
+  const totalPages = getTotalPages(totalCount, pageSize)
+  const clampedPage = Math.min(page, totalPages)
+  const pagination = usePagination({ total: totalPages, page: clampedPage, onChange })
+
+  return (
+    <Group justify={label ? "space-between" : "flex-end"} mt={mt} px={px} pb={pb} p={p}>
+      {label ? (
+        <Text size="sm" c="dimmed">
+          {label} · Page {pagination.active} of {totalPages}
+        </Text>
+      ) : null}
+      <Pagination size={size} total={totalPages} value={pagination.active} onChange={pagination.setPage} />
+    </Group>
+  )
+}

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react"
 
-import { ActionIcon, Group, Menu, Pagination, Table, Text } from "@mantine/core"
+import { ActionIcon, Menu, Table, Text } from "@mantine/core"
 import { IconDots, IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 import { createContext, useContext } from "react"
@@ -10,6 +10,7 @@ import {
   getCompoundTableColumns,
   getCompoundTablePagination,
 } from "@/components/compound-table"
+import { ResourcePagination } from "@/components/resource-pagination"
 import { type Currency, formatMinor } from "@/lib/currency"
 
 export type TransactionRow = {
@@ -154,20 +155,18 @@ function TransactionsTableRoot({ items, children }: TransactionsTableRootProps) 
 }
 
 const TablePagination = Object.assign(
-  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: TransactionPaginationProps) => {
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
-    const clampedPage = Math.min(page, totalPages)
-    return (
-      <Group justify={label ? "space-between" : "flex-end"} mt={mt} px={px} pb={pb}>
-        {label ? (
-          <Text size="sm" c="dimmed">
-            {label}
-          </Text>
-        ) : null}
-        <Pagination total={totalPages} value={clampedPage} onChange={onChange} />
-      </Group>
-    )
-  },
+  ({ page, pageSize, totalCount, onChange, label, mt = "md", px, pb }: TransactionPaginationProps) => (
+    <ResourcePagination
+      page={page}
+      pageSize={pageSize}
+      totalCount={totalCount}
+      onChange={onChange}
+      label={label}
+      mt={mt}
+      px={px}
+      pb={pb}
+    />
+  ),
   { isTablePagination: true as const },
 )
 


### PR DESCRIPTION
## Summary
- Add a shared ResourcePagination component backed by Mantine usePagination in controlled mode
- Reuse it from transactions, cash transactions, and hair assigned table footers
- Add coverage for clamped active page footer rendering

## Verification
- vp check
- vp test