### PR TITLE
refactor: move server state to route owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,13 @@ Do not create REST/Hono adapters solely to satisfy this rule. Keep using tRPC fo
 
 ## Frontend Data Ownership
 
-Reusable components should not initiate route data fetching. Start read queries in route/page owners, preferably through TanStack Router loaders with `queryClient.ensureQueryData` or `prefetchQuery`, and pass the data or view-ready options into child components. Component-level read queries are an exception for user-initiated, highly localized, polling, or subscription-style behavior that would be worse at the route boundary.
+Components must not initiate server reads or mutations. This applies to shared components and route-private `-components`.
 
-Reusable components should not mutate server data. Start mutations in route/page owners and pass explicit event handlers such as `onCreate`, `onUpdate`, `onDelete`, or `onSubmit` into child components. Pass loading and error-display state as props when the reusable component needs to render pending or failure UI. Mutation side effects such as cache invalidation, navigation, notifications, route refreshes, and dialog close/reset behavior belong in the route/page owner.
+Route files and route/page owner modules own server state. Start read queries in TanStack Router loaders when data is needed for route rendering, and use `queryClient.ensureQueryData` or `prefetchQuery` for preload. Put reusable query option builders in route-local `-data` modules when helpful.
+
+Start mutations in route/page owners and pass explicit event handlers such as `onCreate`, `onUpdate`, `onDelete`, or `onSubmit` into child components. Pass data, loading state, and error-display state as props when components need to render pending or failure UI. Mutation side effects such as cache invalidation, navigation, notifications, route refreshes, and dialog close/reset behavior belong in the route/page owner.
+
+Add or update architecture tests when introducing route/component structure so `useQuery`, `useMutation`, and route action hooks stay out of component files.
 
 ## PR Titles
 

--- a/apps/web/src/routes/-route-component-organization.test.ts
+++ b/apps/web/src/routes/-route-component-organization.test.ts
@@ -25,7 +25,7 @@ describe("route component organization", () => {
     const source = readFileSync(path, "utf8")
     const routePath = relative(routesDir, path)
 
-    expect(source, routePath).not.toMatch(/function\s+(?!Route\b)[A-Z][A-Za-z0-9_]*/)
-    expect(source, routePath).not.toMatch(/(?:const|let|var)\s+(?!Route\b)[A-Z][A-Za-z0-9_]*\s*=/)
+    expect(source, routePath).not.toMatch(/function\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*/)
+    expect(source, routePath).not.toMatch(/(?:const|let|var)\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*\s*=/)
   })
 })

--- a/apps/web/src/routes/-route-helper-folder-organization.test.ts
+++ b/apps/web/src/routes/-route-helper-folder-organization.test.ts
@@ -53,15 +53,13 @@ describe("route helper folder organization", () => {
     expect(declarations.length, relative(routesDir, path)).toBeLessThanOrEqual(4)
   })
 
-  it.each(componentFiles(routesDir))("keeps non-page route-local components server-state free %s", (path) => {
-    const basename = path.split("/").at(-1) ?? ""
-    if (basename.endsWith("page.tsx") || basename === "route-page.tsx") return
-
+  it.each(componentFiles(routesDir))("keeps route-local components server-state free %s", (path) => {
     const source = readFileSync(path, "utf8")
     const routePath = relative(routesDir, path)
 
     expect(source, routePath).not.toContain("useQuery(")
     expect(source, routePath).not.toContain("useSuspenseQuery(")
     expect(source, routePath).not.toContain("useMutation(")
+    expect(source, routePath).not.toMatch(/use[A-Z][A-Za-z0-9]*(Action|Actions)\(/)
   })
 })

--- a/apps/web/src/routes/_authenticated/-components/calendar-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/calendar-page.tsx
@@ -1,7 +1,7 @@
+import type { ComponentProps } from "react"
+
 import { Alert, Container, Stack, Text } from "@mantine/core"
 import { Schedule, type ScheduleEventData, type ScheduleViewLevel } from "@mantine/schedule"
-import { useQuery } from "@tanstack/react-query"
-import { useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
 import { useCallback, useMemo, useState } from "react"
 
@@ -10,26 +10,52 @@ import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 
-import { useCreateAppointmentAction } from "../-actions/appointment-actions"
-import {
-  appointmentCustomerOptionsQueryOptions,
-  appointmentSalonOptionsQueryOptions,
-  calendarAppointmentsQueryOptions,
-} from "../-data/calendar-data"
+type OptionData = { items: { id: string; name: string }[] }
+type AppointmentData = {
+  items: {
+    id: string
+    name: string
+    startsAt: string | Date
+    client?: { name: string } | null
+  }[]
+  totalCount: number
+}
 
-export function CalendarPage() {
-  const navigate = useNavigate()
-  const [view, setView] = useState<ScheduleViewLevel>("month")
-  const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))
+export function CalendarPage({
+  view,
+  date,
+  clientSearch,
+  masterSearch,
+  appointmentsData,
+  clientCustomersData,
+  masterCustomersData,
+  salonsData,
+  createPending,
+  onViewChange,
+  onDateChange,
+  onClientSearchChange,
+  onMasterSearchChange,
+  onCreateAppointment,
+  onOpenAppointment,
+}: {
+  view: ScheduleViewLevel
+  date: string
+  clientSearch: string
+  masterSearch: string
+  appointmentsData: AppointmentData | undefined
+  clientCustomersData: OptionData | undefined
+  masterCustomersData: OptionData | undefined
+  salonsData: OptionData | undefined
+  createPending: boolean
+  onViewChange: (view: ScheduleViewLevel) => void
+  onDateChange: (date: string) => void
+  onClientSearchChange: (search: string) => void
+  onMasterSearchChange: (search: string) => void
+  onCreateAppointment: ComponentProps<typeof CreateAppointmentDialog>["onCreate"]
+  onOpenAppointment: (appointmentId: string) => void
+}) {
   const [createOpen, setCreateOpen] = useState(false)
   const [defaultStartsAt, setDefaultStartsAt] = useState<string | null>(null)
-  const [clientSearch, setClientSearch] = useState("")
-  const [masterSearch, setMasterSearch] = useState("")
-  const appointmentsQueryOptions = calendarAppointmentsQueryOptions(date, view)
-  const { data: appointmentsData } = useQuery(appointmentsQueryOptions)
-  const { data: clientCustomersData } = useQuery(appointmentCustomerOptionsQueryOptions(clientSearch))
-  const { data: masterCustomersData } = useQuery(appointmentCustomerOptionsQueryOptions(masterSearch))
-  const { data: salonsData } = useQuery(appointmentSalonOptionsQueryOptions())
   const clientOptions = (clientCustomersData?.items ?? []).map((customer) => ({
     value: customer.id,
     label: customer.name,
@@ -63,22 +89,6 @@ export function CalendarPage() {
     })
   }, [appointmentsData])
 
-  const goToAppointment = useCallback(
-    (id: string) => {
-      navigate({ to: "/appointments/$appointmentId", params: { appointmentId: id } })
-    },
-    [navigate],
-  )
-  const createAppointment = useCreateAppointmentAction({
-    invalidateKeys: [{ queryKey: appointmentsQueryOptions.queryKey }],
-    onCreated: (created) => {
-      setCreateOpen(false)
-      if (created?.id) {
-        navigate({ to: "/appointments/$appointmentId", params: { appointmentId: created.id } })
-      }
-    },
-  })
-
   return (
     <Container size="xl">
       <BreadcrumbItem label="Calendar" order={10} />
@@ -96,11 +106,11 @@ export function CalendarPage() {
           <Schedule
             events={events}
             view={view}
-            onViewChange={setView}
+            onViewChange={onViewChange}
             date={date}
-            onDateChange={setDate}
+            onDateChange={onDateChange}
             layout="responsive"
-            onEventClick={(event) => goToAppointment(String(event.id))}
+            onEventClick={(event) => onOpenAppointment(String(event.id))}
             onTimeSlotClick={({ slotStart }) => openCreate(slotStart)}
             onDayClick={(d) => openCreate(`${d} 09:00:00`)}
             dayViewProps={{
@@ -123,15 +133,18 @@ export function CalendarPage() {
           open={createOpen}
           onOpenChange={setCreateOpen}
           defaultStartsAt={defaultStartsAt}
-          loading={createAppointment.isPending}
-          onCreate={(values) => createAppointment.mutate(values)}
+          loading={createPending}
+          onCreate={(values) => {
+            onCreateAppointment(values)
+            setCreateOpen(false)
+          }}
           clientOptions={clientOptions}
           masterOptions={masterOptions}
           salonOptions={salonOptions}
           clientSearch={clientSearch}
           masterSearch={masterSearch}
-          onClientSearchChange={setClientSearch}
-          onMasterSearchChange={setMasterSearch}
+          onClientSearchChange={onClientSearchChange}
+          onMasterSearchChange={onMasterSearchChange}
         />
       </Stack>
     </Container>

--- a/apps/web/src/routes/_authenticated/-components/cash-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/cash-page.tsx
@@ -1,7 +1,8 @@
+import type { ComponentProps } from "react"
+
 import { Box, Button, Container, Group, LoadingOverlay, NativeSelect, Select, Table, TextInput } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
@@ -13,16 +14,13 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { type Currency } from "@/lib/currency"
 import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
-import { trpc } from "@/utils/trpc"
 
-import { useCashTransactionActions } from "../-actions/cash-transaction-actions"
-
-const PAGE_SIZE = 25
-const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+export const PAGE_SIZE = 25
+export const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 type CashTransactionDirection = "all" | "received" | "paid"
 type CashTransactionCurrencyFilter = Currency | ""
-type CashTransactionFilters = {
+export type CashTransactionFilters = {
   search: string
   customerId: string
   currency: CashTransactionCurrencyFilter
@@ -30,60 +28,58 @@ type CashTransactionFilters = {
   dateFrom: string
   dateTo: string
 }
+type CustomersData = { items: { id: string; name: string }[] }
+type CashTransactionsData = { items: CashTransactionRow[]; totalCount: number }
 
-export function CashPage() {
-  const [page, setPage] = useState(1)
-  const [filters, setFilters] = useState<CashTransactionFilters>({
-    search: "",
-    customerId: "",
-    currency: "",
-    direction: "all",
-    dateFrom: "",
-    dateTo: "",
-  })
+export function CashPage({
+  page,
+  filters,
+  customersData,
+  createCustomersData,
+  editCustomersData,
+  result,
+  isFetching,
+  customerSearch,
+  createCustomerSearch,
+  editCustomerSearch,
+  createPending,
+  updatePending,
+  deletePending,
+  onPageChange,
+  onFiltersChange,
+  onCustomerSearchChange,
+  onCreateCustomerSearchChange,
+  onEditCustomerSearchChange,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: {
+  page: number
+  filters: CashTransactionFilters
+  customersData: CustomersData | undefined
+  createCustomersData: CustomersData | undefined
+  editCustomersData: CustomersData | undefined
+  result: CashTransactionsData | undefined
+  isFetching: boolean
+  customerSearch: string
+  createCustomerSearch: string
+  editCustomerSearch: string
+  createPending: boolean
+  updatePending: boolean
+  deletePending: boolean
+  onPageChange: (page: number) => void
+  onFiltersChange: (filters: Partial<CashTransactionFilters>) => void
+  onCustomerSearchChange: (search: string) => void
+  onCreateCustomerSearchChange: (search: string) => void
+  onEditCustomerSearchChange: (search: string) => void
+  onCreate: ComponentProps<typeof CreateCashTransactionDialog>["onCreate"]
+  onUpdate: ComponentProps<typeof EditCashTransactionDialog>["onUpdate"]
+  onDelete: (id: string) => void
+}) {
   const [createOpen, setCreateOpen] = useState(false)
   const [editing, setEditing] = useState<CashTransactionRow | null>(null)
   const [deleting, setDeleting] = useState<CashTransactionRow | null>(null)
-  const [customerSearch, setCustomerSearch] = useState("")
-  const [createCustomerSearch, setCreateCustomerSearch] = useState("")
-  const [editCustomerSearch, setEditCustomerSearch] = useState("")
   const [selectedCustomerOption, setSelectedCustomerOption] = useState<SelectOption | null>(null)
-
-  const { data: customersData } = useQuery(
-    trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: customerSearch.trim() || undefined,
-    }),
-  )
-  const { data: createCustomersData } = useQuery({
-    ...trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: createCustomerSearch.trim() || undefined,
-    }),
-    enabled: createOpen,
-  })
-  const { data: editCustomersData } = useQuery({
-    ...trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: editCustomerSearch.trim() || undefined,
-    }),
-    enabled: !!editing,
-  })
-
-  const queryFilter = {
-    page,
-    pageSize: PAGE_SIZE,
-    search: filters.search.trim() || undefined,
-    customerId: filters.customerId || undefined,
-    currency: filters.currency || undefined,
-    direction: filters.direction,
-    dateFrom: filters.dateFrom || undefined,
-    dateTo: filters.dateTo || undefined,
-  }
-
-  const { data: result, isFetching } = useQuery(
-    trpc.cashTransactions.list.queryOptions(queryFilter, { placeholderData: (previousData) => previousData }),
-  )
 
   const customers = customersData?.items ?? []
   const createCustomers = createCustomersData?.items ?? []
@@ -93,17 +89,6 @@ export function CashPage() {
     selectedCustomerOption,
   )
   const totalCount = result?.totalCount ?? 0
-
-  const resetPage = () => setPage(1)
-  const updateFilters = (nextFilters: Partial<CashTransactionFilters>) => {
-    setFilters((current) => ({ ...current, ...nextFilters }))
-    resetPage()
-  }
-  const { createCashTransaction, updateCashTransaction, deleteCashTransaction } = useCashTransactionActions({
-    onCreated: () => setCreateOpen(false),
-    onUpdated: () => setEditing(null),
-    onDeleted: () => setDeleting(null),
-  })
 
   return (
     <Container size="xl">
@@ -126,7 +111,7 @@ export function CashPage() {
             leftSection={<IconSearch size={16} />}
             value={filters.search}
             onChange={(event) => {
-              updateFilters({ search: event.currentTarget.value })
+              onFiltersChange({ search: event.currentTarget.value })
             }}
             flex="1 1 18rem"
           />
@@ -136,11 +121,11 @@ export function CashPage() {
             searchable
             clearable
             searchValue={customerSearch}
-            onSearchChange={setCustomerSearch}
+            onSearchChange={onCustomerSearchChange}
             data={customerOptions}
             value={filters.customerId}
             onChange={(value) => {
-              updateFilters({ customerId: value ?? "" })
+              onFiltersChange({ customerId: value ?? "" })
               const option = customerOptions.find((candidate) => candidate.value === value)
               setSelectedCustomerOption(option ?? null)
             }}
@@ -155,7 +140,7 @@ export function CashPage() {
             ]}
             value={filters.currency}
             onChange={(event) => {
-              updateFilters({ currency: event.currentTarget.value as CashTransactionCurrencyFilter })
+              onFiltersChange({ currency: event.currentTarget.value as CashTransactionCurrencyFilter })
             }}
             w={{ base: "100%", xs: 180 }}
           />
@@ -168,7 +153,7 @@ export function CashPage() {
             ]}
             value={filters.direction}
             onChange={(event) => {
-              updateFilters({ direction: event.currentTarget.value as CashTransactionDirection })
+              onFiltersChange({ direction: event.currentTarget.value as CashTransactionDirection })
             }}
             w={{ base: "100%", xs: 180 }}
           />
@@ -178,7 +163,7 @@ export function CashPage() {
             clearable
             value={filters.dateFrom}
             onChange={(value) => {
-              updateFilters({ dateFrom: value ?? "" })
+              onFiltersChange({ dateFrom: value ?? "" })
             }}
             w={{ base: "100%", xs: 180 }}
           />
@@ -188,7 +173,7 @@ export function CashPage() {
             clearable
             value={filters.dateTo}
             onChange={(value) => {
-              updateFilters({ dateTo: value ?? "" })
+              onFiltersChange({ dateTo: value ?? "" })
             }}
             w={{ base: "100%", xs: 180 }}
           />
@@ -209,7 +194,7 @@ export function CashPage() {
                 pageSize={PAGE_SIZE}
                 itemCount={result?.items.length ?? 0}
                 totalCount={totalCount}
-                onChange={setPage}
+                onChange={onPageChange}
               />
             </CashTransactionsTable>
           </Table.ScrollContainer>
@@ -221,9 +206,12 @@ export function CashPage() {
         onOpenChange={setCreateOpen}
         customers={createCustomers}
         customerSearch={createCustomerSearch}
-        onCustomerSearchChange={setCreateCustomerSearch}
-        loading={createCashTransaction.isPending}
-        onCreate={(values) => createCashTransaction.mutate(values)}
+        onCustomerSearchChange={onCreateCustomerSearchChange}
+        loading={createPending}
+        onCreate={(values) => {
+          onCreate(values)
+          setCreateOpen(false)
+        }}
       />
       {editing ? (
         <EditCashTransactionDialog
@@ -234,9 +222,12 @@ export function CashPage() {
           transaction={editing}
           customers={editCustomers}
           customerSearch={editCustomerSearch}
-          onCustomerSearchChange={setEditCustomerSearch}
-          loading={updateCashTransaction.isPending}
-          onUpdate={(values) => updateCashTransaction.mutate(values)}
+          onCustomerSearchChange={onEditCustomerSearchChange}
+          loading={updatePending}
+          onUpdate={(values) => {
+            onUpdate(values)
+            setEditing(null)
+          }}
         />
       ) : null}
       {deleting ? (
@@ -246,8 +237,11 @@ export function CashPage() {
             if (!open) setDeleting(null)
           }}
           transaction={deleting}
-          loading={deleteCashTransaction.isPending}
-          onDelete={(id) => deleteCashTransaction.mutate({ id })}
+          loading={deletePending}
+          onDelete={(id) => {
+            onDelete(id)
+            setDeleting(null)
+          }}
         />
       ) : null}
     </Container>

--- a/apps/web/src/routes/_authenticated/-components/cash-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/cash-page.tsx
@@ -12,22 +12,15 @@ import { DeleteCashTransactionDialog } from "@/components/cash-transactions/dele
 import { EditCashTransactionDialog } from "@/components/cash-transactions/edit-cash-transaction-dialog"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
-import { type Currency } from "@/lib/currency"
 import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
 
-export const PAGE_SIZE = 25
-export const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+import {
+  CASH_TRANSACTIONS_PAGE_SIZE,
+  type CashTransactionDirection,
+  type CashTransactionCurrencyFilter,
+  type CashTransactionFilters,
+} from "../-data/cash-data"
 
-type CashTransactionDirection = "all" | "received" | "paid"
-type CashTransactionCurrencyFilter = Currency | ""
-export type CashTransactionFilters = {
-  search: string
-  customerId: string
-  currency: CashTransactionCurrencyFilter
-  direction: CashTransactionDirection
-  dateFrom: string
-  dateTo: string
-}
 type CustomersData = { items: { id: string; name: string }[] }
 type CashTransactionsData = { items: CashTransactionRow[]; totalCount: number }
 
@@ -191,7 +184,7 @@ export function CashPage({
               <CashTransactionsTable.Actions onEdit={setEditing} onDelete={setDeleting} />
               <CashTransactionsTable.Pagination
                 page={page}
-                pageSize={PAGE_SIZE}
+                pageSize={CASH_TRANSACTIONS_PAGE_SIZE}
                 itemCount={result?.items.length ?? 0}
                 totalCount={totalCount}
                 onChange={onPageChange}

--- a/apps/web/src/routes/_authenticated/-components/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/dashboard-page.tsx
@@ -1,7 +1,6 @@
 import { ActionIcon, Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
 import { MonthPickerInput } from "@mantine/dates"
 import { IconChevronLeft, IconChevronRight, IconEye } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
@@ -15,13 +14,9 @@ import {
   parseMonthKey,
   previousMonth,
   selectedMonthData,
-  selectedYearInputs,
   type HairMonthlyBreakdown,
   type MonthlyMetric,
 } from "@/lib/dashboard-monthly-stats"
-import { trpc } from "@/utils/trpc"
-
-import { Route } from "../dashboard"
 
 type TransactionStatsByCurrency = {
   currency: string
@@ -29,41 +24,37 @@ type TransactionStatsByCurrency = {
   total: number
 }
 
-export function DashboardPage() {
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const selectedMonthKey = search.month ?? monthKeyFromDate(new Date())
-  const selected = parseMonthKey(selectedMonthKey)
-  const { currentYear, previousYear } = selectedYearInputs(selected)
-  const monthDate = dateFromMonthKey(selectedMonthKey)
+type DashboardPageProps = {
+  selectedMonthKey: string
+  transactionData: TransactionStatsByCurrency[] | undefined
+  previousTransactionData: TransactionStatsByCurrency[] | undefined
+  appointmentsData: HairMonthlyBreakdown | undefined
+  previousAppointmentsData: HairMonthlyBreakdown | undefined
+  salesData: HairMonthlyBreakdown | undefined
+  previousSalesData: HairMonthlyBreakdown | undefined
+  onSearchChange: (month: string) => void
+}
 
-  const { data: transactionData } = useQuery(trpc.dashboard.transactionStats.queryOptions({ year: currentYear }))
-  const { data: previousTransactionData } = useQuery({
-    ...trpc.dashboard.transactionStats.queryOptions({ year: previousYear ?? currentYear }),
-    enabled: !!previousYear,
-  })
-  const { data: appointmentsData } = useQuery(trpc.dashboard.hairAssignedStats.queryOptions({ year: currentYear }))
-  const { data: previousAppointmentsData } = useQuery({
-    ...trpc.dashboard.hairAssignedStats.queryOptions({ year: previousYear ?? currentYear }),
-    enabled: !!previousYear,
-  })
-  const { data: salesData } = useQuery(trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: currentYear }))
-  const { data: previousSalesData } = useQuery({
-    ...trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: previousYear ?? currentYear }),
-    enabled: !!previousYear,
-  })
+export function DashboardPage({
+  selectedMonthKey,
+  transactionData,
+  previousTransactionData,
+  appointmentsData,
+  previousAppointmentsData,
+  salesData,
+  previousSalesData,
+  onSearchChange,
+}: DashboardPageProps) {
+  const selected = parseMonthKey(selectedMonthKey)
+  const monthDate = dateFromMonthKey(selectedMonthKey)
 
   const goToMonth = (date: Date | null) => {
     if (!date) return
-    navigate({ search: { month: monthKeyFromDate(date) } })
+    onSearchChange(monthKeyFromDate(date))
   }
 
   const changeMonth = (offset: number) => {
-    navigate({
-      search: {
-        month: monthKeyFromDate(new Date(selected.year, selected.month - 1 + offset, 1)),
-      },
-    })
+    onSearchChange(monthKeyFromDate(new Date(selected.year, selected.month - 1 + offset, 1)))
   }
 
   return (

--- a/apps/web/src/routes/_authenticated/-components/profile-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/profile-page.tsx
@@ -16,7 +16,6 @@ import {
 import { useForm } from "@mantine/form"
 import { notifications } from "@mantine/notifications"
 import { IconAlertCircle, IconDeviceLaptop, IconDeviceMobile } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
@@ -25,13 +24,6 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { authClient } from "@/lib/auth-client"
 import { CURRENCY_OPTIONS, type Currency } from "@/lib/currency"
-import { trpc } from "@/utils/trpc"
-
-import {
-  sessionsQueryKey,
-  useRevokeSessionAction,
-  useUpdateUserProfileAction,
-} from "../profile/-actions/profile-actions"
 
 type ParsedUA = { isMobile: boolean; os: string; browser: string }
 
@@ -51,23 +43,43 @@ function parseUA(ua: string): ParsedUA {
   return { isMobile, os, browser }
 }
 
-export function ProfilePage() {
-  const { data: current, isPending } = authClient.useSession()
+type ProfileSession = {
+  id: string
+  token: string
+  userAgent?: string | null
+  ipAddress?: string | null
+}
+type CurrentSession = {
+  user: { name: string; email: string; emailVerified: boolean }
+  session: { id: string }
+}
+
+export function ProfilePage({
+  current,
+  isPending,
+  sessions,
+  preferredCurrency,
+  terminatingId,
+  revokePending,
+  updateProfilePending,
+  onTerminatingIdChange,
+  onRevokeSession,
+  onUpdateProfile,
+}: {
+  current: CurrentSession | null | undefined
+  isPending: boolean
+  sessions: ProfileSession[]
+  preferredCurrency: string
+  terminatingId: string | undefined
+  revokePending: boolean
+  updateProfilePending: boolean
+  onTerminatingIdChange: (id: string | undefined) => void
+  onRevokeSession: (token: string) => Promise<unknown>
+  onUpdateProfile: (values: { name: string; preferredCurrency: Currency }) => Promise<void>
+}) {
   const [editOpen, setEditOpen] = useState(false)
   const [pwOpen, setPwOpen] = useState(false)
   const [verifyPending, setVerifyPending] = useState(false)
-  const [terminatingId, setTerminatingId] = useState<string | undefined>()
-
-  const { data: sessionsResult } = useQuery({
-    queryKey: sessionsQueryKey,
-    queryFn: () => authClient.listSessions(),
-  })
-  const sessions = sessionsResult?.data ?? []
-
-  const userSettingsQueryOptions = trpc.userSettings.get.queryOptions()
-  const { data: settings } = useQuery(userSettingsQueryOptions)
-
-  const revokeSession = useRevokeSessionAction({ onRevoked: () => setTerminatingId(undefined) })
 
   if (isPending || !current) {
     return <Loader2 />
@@ -105,7 +117,7 @@ export function ProfilePage() {
                 {user.email}
               </Text>
               <Text fz="xs" c="dimmed">
-                Preferred currency: {settings?.preferredCurrency ?? "EUR"}
+                Preferred currency: {preferredCurrency}
               </Text>
             </Stack>
           </Group>
@@ -169,13 +181,13 @@ export function ProfilePage() {
                       size="xs"
                       variant="subtle"
                       color="red"
-                      disabled={revokeSession.isPending && terminatingId === s.id}
+                      disabled={revokePending && terminatingId === s.id}
                       onClick={async () => {
-                        setTerminatingId(s.id)
-                        await revokeSession.mutateAsync(s.token)
+                        onTerminatingIdChange(s.id)
+                        await onRevokeSession(s.token)
                       }}
                     >
-                      {revokeSession.isPending && terminatingId === s.id ? (
+                      {revokePending && terminatingId === s.id ? (
                         <Loader size={14} />
                       ) : isCurrent ? (
                         "Sign out"
@@ -192,11 +204,16 @@ export function ProfilePage() {
       </Stack>
 
       <EditUserModal
-        key={settings?.preferredCurrency ?? "loading"}
+        key={preferredCurrency}
         open={editOpen}
         onOpenChange={setEditOpen}
         initialName={user.name}
-        initialCurrency={settings?.preferredCurrency ?? "EUR"}
+        initialCurrency={preferredCurrency}
+        submitting={updateProfilePending}
+        onUpdate={async (values) => {
+          await onUpdateProfile(values)
+          setEditOpen(false)
+        }}
       />
       <ChangePasswordModal open={pwOpen} onOpenChange={setPwOpen} />
     </Container>
@@ -208,19 +225,16 @@ type EditUserModalProps = {
   onOpenChange: (open: boolean) => void
   initialName: string
   initialCurrency: string
+  submitting: boolean
+  onUpdate: (values: { name: string; preferredCurrency: Currency }) => Promise<void>
 }
 
-function EditUserModal({ open, onOpenChange, initialName, initialCurrency }: EditUserModalProps) {
+function EditUserModal({ open, onOpenChange, initialName, initialCurrency, submitting, onUpdate }: EditUserModalProps) {
   const safeInitialCurrency: Currency = initialCurrency === "GBP" || initialCurrency === "EUR" ? initialCurrency : "EUR"
   const form = useForm({ initialValues: { name: initialName, preferredCurrency: safeInitialCurrency } })
-  const { submitting, updateUserProfile } = useUpdateUserProfileAction({
-    initialName,
-    initialCurrency: safeInitialCurrency,
-    onUpdated: () => onOpenChange(false),
-  })
 
   const handleSubmit = async (values: { name: string; preferredCurrency: Currency }) => {
-    await updateUserProfile(values)
+    await onUpdate(values)
   }
 
   return (

--- a/apps/web/src/routes/_authenticated/-components/route-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/route-page.tsx
@@ -3,22 +3,16 @@ import type { ErrorComponentProps } from "@tanstack/react-router"
 import { AppShell, Box, Button, Card, Group, Text } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks"
 import { IconAlertCircle, IconRefresh } from "@tabler/icons-react"
-import { useQuery, useQueryErrorResetBoundary } from "@tanstack/react-query"
+import { useQueryErrorResetBoundary } from "@tanstack/react-query"
 import { Outlet, useRouter } from "@tanstack/react-router"
 
 import { BreadcrumbProvider } from "@/components/breadcrumbs"
-import { trpc } from "@/utils/trpc"
 
 import classes from "../route.module.css"
 import { DesktopTabs, HeaderTop, MobileNavigationDrawer } from "./layout-navigation"
 
-export function AuthenticatedLayout() {
+export function AuthenticatedLayout({ badges }: { badges: { unassigned: number } }) {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false)
-
-  const { data: unassignedAttachments } = useQuery(
-    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
-  )
-  const badges = { unassigned: unassignedAttachments?.totalCount ?? 0 }
 
   return (
     <BreadcrumbProvider>

--- a/apps/web/src/routes/_authenticated/-data/cash-data.ts
+++ b/apps/web/src/routes/_authenticated/-data/cash-data.ts
@@ -1,0 +1,15 @@
+import { type Currency } from "@/lib/currency"
+
+export const CASH_TRANSACTIONS_PAGE_SIZE = 25
+export const defaultCashCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+
+export type CashTransactionDirection = "all" | "received" | "paid"
+export type CashTransactionCurrencyFilter = Currency | ""
+export type CashTransactionFilters = {
+  search: string
+  customerId: string
+  currency: CashTransactionCurrencyFilter
+  direction: CashTransactionDirection
+  dateFrom: string
+  dateTo: string
+}

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -1,15 +1,23 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
 import { trpc } from "@/utils/trpc"
 
-import { AppointmentDetailRoute } from "./-components/appointment-detail-page"
+import { useAppointmentPersonnelActions } from "../-actions/appointment-actions"
+import { useHairAssignmentActions } from "../-actions/hair-assignment-actions"
+import { useAppointmentTransactionActions } from "./-actions/appointment-transaction-actions"
+import { AppointmentDetailPage } from "./-components/appointment-detail-page"
 import {
   APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
   availableHairOrdersListQueryOptions,
+  useAppointmentDetailData,
 } from "./-data/appointment-detail-data"
 
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
-  component: AppointmentDetailRoute,
+  component: routeComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
@@ -32,3 +40,83 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
     ])
   },
 })
+
+function routeComponent() {
+  const { appointmentId } = Route.useParams()
+  const [transactionsPage, setTransactionsPage] = useState(1)
+  const [hairAssignedPage, setHairAssignedPage] = useState(1)
+  const [masterSearch, setMasterSearch] = useState("")
+  const [pickPersonnelSearch, setPickPersonnelSearch] = useState("")
+  const detailData = useAppointmentDetailData({ appointmentId, hairAssignedPage, transactionsPage })
+  const pickPersonnelCustomersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: pickPersonnelSearch.trim() || undefined,
+    }),
+  ).data
+  const masterCustomersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: masterSearch.trim() || undefined,
+    }),
+  ).data
+  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
+    invalidateKeys: [
+      { queryKey: detailData.appointmentQueryOptions.queryKey },
+      ...(detailData.appointment
+        ? [{ queryKey: trpc.customers.summary.queryOptions({ id: detailData.appointment.client.id }).queryKey }]
+        : []),
+    ],
+    selectedEditItem: null,
+    selectedDeleteItem: null,
+  })
+  const { createTransaction, updateTransaction, deleteTransaction } = useAppointmentTransactionActions({
+    appointment: detailData.appointment,
+  })
+  const { updateMaster, linkPersonnel } = useAppointmentPersonnelActions({ appointmentId })
+
+  return (
+    <AppointmentDetailPage
+      appointmentId={appointmentId}
+      detailData={detailData}
+      transactionsPage={transactionsPage}
+      hairAssignedPage={hairAssignedPage}
+      masterSearch={masterSearch}
+      pickPersonnelSearch={pickPersonnelSearch}
+      pickPersonnelCustomersData={pickPersonnelCustomersData}
+      masterCustomersData={masterCustomersData}
+      onTransactionsPageChange={setTransactionsPage}
+      onHairAssignedPageChange={setHairAssignedPage}
+      onMasterSearchChange={setMasterSearch}
+      onPickPersonnelSearchChange={setPickPersonnelSearch}
+      createHairAssignedPending={createHairAssigned.isPending}
+      updateHairAssignedPending={updateHairAssigned.isPending}
+      deleteHairAssignedPending={deleteHairAssigned.isPending}
+      createTransactionPending={createTransaction.isPending}
+      updateTransactionPending={updateTransaction.isPending}
+      deleteTransactionPending={deleteTransaction.isPending}
+      updateMasterPending={updateMaster.isPending}
+      linkPersonnelPending={linkPersonnel.isPending}
+      onCreateHairAssigned={(values) => {
+        createHairAssigned.mutate(values)
+        setHairAssignedPage(1)
+      }}
+      onUpdateHairAssigned={(values) => updateHairAssigned.mutate(values)}
+      onDeleteHairAssigned={(id) => {
+        deleteHairAssigned.mutate({ id })
+        setHairAssignedPage(1)
+      }}
+      onCreateTransaction={(values) => {
+        createTransaction.mutate(values)
+        setTransactionsPage(1)
+      }}
+      onUpdateTransaction={(values) => updateTransaction.mutate(values)}
+      onDeleteTransaction={(id) => {
+        deleteTransaction.mutate({ id })
+        setTransactionsPage(1)
+      }}
+      onUpdateMaster={(values) => updateMaster.mutate(values)}
+      onLinkPersonnel={(values) => linkPersonnel.mutate(values)}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -17,7 +17,7 @@ import {
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 export const Route = createFileRoute("/_authenticated/appointments/$appointmentId")({
-  component: routeComponent,
+  component: RouteComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(trpc.appointments.get.queryOptions({ id: params.appointmentId })),
@@ -41,7 +41,7 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { appointmentId } = Route.useParams()
   const [transactionsPage, setTransactionsPage] = useState(1)
   const [hairAssignedPage, setHairAssignedPage] = useState(1)

--- a/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
+
 import { ActionIcon, Button, Card, Container, Group, Menu, Modal, Select, Stack, Text, Title } from "@mantine/core"
 import { IconCash, IconClock, IconDots, IconPlus, IconUser, IconUsers } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
 
@@ -17,41 +18,85 @@ import { EditTransactionDialog } from "@/components/transactions/edit-transactio
 import { TransactionsTable, type TransactionRow } from "@/components/transactions/transactions-table"
 import { formatMinor } from "@/lib/currency"
 import { formatPageRange, type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
-import { trpc } from "@/utils/trpc"
 
-import { Route } from "../$appointmentId"
-import { useAppointmentTransactionActions } from "../-actions/appointment-transaction-actions"
 import { APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE, useAppointmentDetailData } from "../-data/appointment-detail-data"
-import { useAppointmentPersonnelActions } from "../../-actions/appointment-actions"
-import { useHairAssignmentActions } from "../../-actions/hair-assignment-actions"
 import { PickPersonnelModal } from "./pick-personnel-modal"
 
-const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+type AppointmentDetailData = ReturnType<typeof useAppointmentDetailData>
+type CustomersData = { items: { id: string; name: string }[] }
 
-export function AppointmentDetailRoute() {
-  const { appointmentId } = Route.useParams()
-  return <AppointmentDetailPage key={appointmentId} appointmentId={appointmentId} />
-}
-
-export function AppointmentDetailPage({ appointmentId }: { appointmentId: string }) {
+export function AppointmentDetailPage({
+  appointmentId,
+  detailData,
+  transactionsPage,
+  hairAssignedPage,
+  masterSearch,
+  pickPersonnelSearch,
+  pickPersonnelCustomersData,
+  masterCustomersData,
+  onTransactionsPageChange,
+  onHairAssignedPageChange,
+  onMasterSearchChange,
+  onPickPersonnelSearchChange,
+  createHairAssignedPending,
+  updateHairAssignedPending,
+  deleteHairAssignedPending,
+  createTransactionPending,
+  updateTransactionPending,
+  deleteTransactionPending,
+  updateMasterPending,
+  linkPersonnelPending,
+  onCreateHairAssigned,
+  onUpdateHairAssigned,
+  onDeleteHairAssigned,
+  onCreateTransaction,
+  onUpdateTransaction,
+  onDeleteTransaction,
+  onUpdateMaster,
+  onLinkPersonnel,
+}: {
+  appointmentId: string
+  detailData: AppointmentDetailData
+  transactionsPage: number
+  hairAssignedPage: number
+  masterSearch: string
+  pickPersonnelSearch: string
+  pickPersonnelCustomersData: CustomersData | undefined
+  masterCustomersData: CustomersData | undefined
+  onTransactionsPageChange: (page: number) => void
+  onHairAssignedPageChange: (page: number) => void
+  onMasterSearchChange: (search: string) => void
+  onPickPersonnelSearchChange: (search: string) => void
+  createHairAssignedPending: boolean
+  updateHairAssignedPending: boolean
+  deleteHairAssignedPending: boolean
+  createTransactionPending: boolean
+  updateTransactionPending: boolean
+  deleteTransactionPending: boolean
+  updateMasterPending: boolean
+  linkPersonnelPending: boolean
+  onCreateHairAssigned: ComponentProps<typeof CreateHairAssignedDialog>["onCreate"]
+  onUpdateHairAssigned: ComponentProps<typeof EditHairAssignedDialog>["onUpdate"]
+  onDeleteHairAssigned: (id: string) => void
+  onCreateTransaction: ComponentProps<typeof CreateTransactionDialog>["onCreate"]
+  onUpdateTransaction: ComponentProps<typeof EditTransactionDialog>["onUpdate"]
+  onDeleteTransaction: (id: string) => void
+  onUpdateMaster: (values: { id: string; masterId: string }) => void
+  onLinkPersonnel: (values: { appointmentId: string; personnelIds: string[] }) => void
+}) {
   const [createOpen, setCreateOpen] = useState(false)
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
   const [pickPersonnelOpen, setPickPersonnelOpen] = useState(false)
   const [changeMasterOpen, setChangeMasterOpen] = useState(false)
-  const [masterSearch, setMasterSearch] = useState("")
   const [draftMasterId, setDraftMasterId] = useState<string | null>(null)
   const [selectedMasterOption, setSelectedMasterOption] = useState<SelectOption | null>(null)
-  const [pickPersonnelSearch, setPickPersonnelSearch] = useState("")
   const [createTxOpen, setCreateTxOpen] = useState(false)
   const [createTxCustomerId, setCreateTxCustomerId] = useState<string | null>(null)
   const [editTx, setEditTx] = useState<TransactionRow | null>(null)
   const [deleteTx, setDeleteTx] = useState<TransactionRow | null>(null)
-  const [transactionsPage, setTransactionsPage] = useState(1)
-  const [hairAssignedPage, setHairAssignedPage] = useState(1)
   const {
     appointment,
-    appointmentQueryOptions,
     availableHairOrders,
     availableHairOrdersLoading,
     hairAssigned,
@@ -65,59 +110,7 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
     totalsByCurrency,
     currenciesPresent,
     txDefaultCurrency,
-  } = useAppointmentDetailData({ appointmentId, hairAssignedPage, transactionsPage })
-  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
-    invalidateKeys: [
-      { queryKey: appointmentQueryOptions.queryKey },
-      ...(appointment
-        ? [{ queryKey: trpc.customers.summary.queryOptions({ id: appointment.client.id }).queryKey }]
-        : []),
-    ],
-    selectedEditItem: editItem,
-    selectedDeleteItem: deleteItem,
-    onCreated: () => {
-      setHairAssignedPage(1)
-      setCreateOpen(false)
-    },
-    onUpdated: () => setEditItem(null),
-    onDeleted: () => {
-      setHairAssignedPage(1)
-      setDeleteItem(null)
-    },
-  })
-  const { createTransaction, updateTransaction, deleteTransaction } = useAppointmentTransactionActions({
-    appointment,
-    onCreated: () => {
-      setTransactionsPage(1)
-      setCreateTxOpen(false)
-      setCreateTxCustomerId(null)
-    },
-    onUpdated: () => setEditTx(null),
-    onDeleted: () => {
-      setTransactionsPage(1)
-      setDeleteTx(null)
-    },
-  })
-  const { updateMaster, linkPersonnel } = useAppointmentPersonnelActions({
-    appointmentId,
-    onMasterUpdated: () => {
-      setDraftMasterId(null)
-      setSelectedMasterOption(null)
-      setMasterSearch("")
-      setChangeMasterOpen(false)
-    },
-    onPersonnelLinked: () => {
-      setPickPersonnelSearch("")
-      setPickPersonnelOpen(false)
-    },
-  })
-  const { data: pickPersonnelCustomersData } = useQuery({
-    ...trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: pickPersonnelSearch.trim() || undefined,
-    }),
-    enabled: pickPersonnelOpen,
-  })
+  } = detailData
   const pickPersonnelCustomers = useMemo(
     () => pickPersonnelCustomersData?.items ?? [],
     [pickPersonnelCustomersData?.items],
@@ -131,13 +124,6 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
     [assignedPersonnelIds, pickPersonnelCustomers],
   )
 
-  const { data: masterCustomersData } = useQuery({
-    ...trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: masterSearch.trim() || undefined,
-    }),
-    enabled: changeMasterOpen,
-  })
   const masterCustomers = useMemo(() => masterCustomersData?.items ?? [], [masterCustomersData?.items])
 
   if (!appointment) {
@@ -352,7 +338,7 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
                     pageSize={APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE}
                     itemCount={txRows.length}
                     totalCount={transactionsTotalCount}
-                    onChange={setTransactionsPage}
+                    onChange={onTransactionsPageChange}
                     label={`Page ${Math.min(transactionsPage, transactionsTotalPages)} of ${transactionsTotalPages}`}
                   />
                 ) : null}
@@ -392,7 +378,7 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
                 pageSize={APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE}
                 itemCount={hairAssigned.length}
                 totalCount={hairAssignedTotalCount}
-                onChange={setHairAssignedPage}
+                onChange={onHairAssignedPageChange}
                 label={`Page ${Math.min(hairAssignedPage, hairAssignedTotalPages)} of ${hairAssignedTotalPages}`}
               />
             ) : null}
@@ -426,8 +412,11 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
           onOpenChange={setCreateOpen}
           clientId={appointment.client.id}
           appointmentId={appointmentId}
-          loading={createHairAssigned.isPending}
-          onCreate={(values) => createHairAssigned.mutate(values)}
+          loading={createHairAssignedPending}
+          onCreate={(values) => {
+            onCreateHairAssigned(values)
+            setCreateOpen(false)
+          }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}
         />
@@ -436,8 +425,11 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
             open={!!editItem}
             onOpenChange={(open) => !open && setEditItem(null)}
             hairAssigned={editItem}
-            loading={updateHairAssigned.isPending}
-            onUpdate={(values) => updateHairAssigned.mutate(values)}
+            loading={updateHairAssignedPending}
+            onUpdate={(values) => {
+              onUpdateHairAssigned(values)
+              setEditItem(null)
+            }}
           />
         )}
         {deleteItem && (
@@ -445,8 +437,11 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
             open={!!deleteItem}
             onOpenChange={(open) => !open && setDeleteItem(null)}
             hairAssigned={deleteItem}
-            loading={deleteHairAssigned.isPending}
-            onDelete={(id) => deleteHairAssigned.mutate({ id })}
+            loading={deleteHairAssignedPending}
+            onDelete={(id) => {
+              onDeleteHairAssigned(id)
+              setDeleteItem(null)
+            }}
           />
         )}
         <PickPersonnelModal
@@ -454,9 +449,13 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
           onOpenChange={setPickPersonnelOpen}
           search={pickPersonnelSearch}
           personnel={availablePersonnel}
-          loading={linkPersonnel.isPending}
-          onSearchChange={setPickPersonnelSearch}
-          onConfirm={(personnelIds) => linkPersonnel.mutate({ appointmentId, personnelIds })}
+          loading={linkPersonnelPending}
+          onSearchChange={onPickPersonnelSearchChange}
+          onConfirm={(personnelIds) => {
+            onLinkPersonnel({ appointmentId, personnelIds })
+            onPickPersonnelSearchChange("")
+            setPickPersonnelOpen(false)
+          }}
         />
         {changeMasterOpen && (
           <ChangeMasterModal
@@ -467,14 +466,20 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
             masterId={masterId}
             masterSearch={masterSearch}
             masterOptions={masterOptions}
-            loading={updateMaster.isPending}
-            onMasterSearchChange={setMasterSearch}
+            loading={updateMasterPending}
+            onMasterSearchChange={onMasterSearchChange}
             onMasterChange={(value) => {
               setDraftMasterId(value)
               const option = masterOptions.find((candidate) => candidate.value === value)
               if (option) setSelectedMasterOption(option)
             }}
-            onSubmit={() => updateMaster.mutate({ id: appointmentId, masterId })}
+            onSubmit={() => {
+              onUpdateMaster({ id: appointmentId, masterId })
+              setDraftMasterId(null)
+              setSelectedMasterOption(null)
+              onMasterSearchChange("")
+              setChangeMasterOpen(false)
+            }}
           />
         )}
         <CreateTransactionDialog
@@ -486,16 +491,23 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
           appointmentId={appointmentId}
           customerId={txCustomerId}
           defaultCurrency={txDefaultCurrency}
-          loading={createTransaction.isPending}
-          onCreate={(values) => createTransaction.mutate(values)}
+          loading={createTransactionPending}
+          onCreate={(values) => {
+            onCreateTransaction(values)
+            setCreateTxOpen(false)
+            setCreateTxCustomerId(null)
+          }}
         />
         {editTx && (
           <EditTransactionDialog
             open={!!editTx}
             onOpenChange={(open) => !open && setEditTx(null)}
             transaction={editTx}
-            loading={updateTransaction.isPending}
-            onUpdate={(values) => updateTransaction.mutate(values)}
+            loading={updateTransactionPending}
+            onUpdate={(values) => {
+              onUpdateTransaction(values)
+              setEditTx(null)
+            }}
           />
         )}
         {deleteTx && (
@@ -503,8 +515,11 @@ export function AppointmentDetailPage({ appointmentId }: { appointmentId: string
             open={!!deleteTx}
             onOpenChange={(open) => !open && setDeleteTx(null)}
             transaction={deleteTx}
-            loading={deleteTransaction.isPending}
-            onDelete={(id) => deleteTransaction.mutate({ id })}
+            loading={deleteTransactionPending}
+            onDelete={(id) => {
+              onDeleteTransaction(id)
+              setDeleteTx(null)
+            }}
           />
         )}
       </Stack>

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -1,6 +1,11 @@
+import type { ScheduleViewLevel } from "@mantine/schedule"
+
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import dayjs from "dayjs"
+import { useState } from "react"
 
+import { useCreateAppointmentAction } from "./-actions/appointment-actions"
 import { CalendarPage } from "./-components/calendar-page"
 import {
   appointmentCustomerOptionsQueryOptions,
@@ -9,7 +14,7 @@ import {
 } from "./-data/calendar-data"
 
 export const Route = createFileRoute("/_authenticated/calendar")({
-  component: CalendarPage,
+  component: routeComponent,
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.prefetchQuery(calendarAppointmentsQueryOptions(dayjs().format("YYYY-MM-DD"), "month")),
@@ -18,3 +23,44 @@ export const Route = createFileRoute("/_authenticated/calendar")({
     ])
   },
 })
+
+function routeComponent() {
+  const navigate = Route.useNavigate()
+  const [view, setView] = useState<ScheduleViewLevel>("month")
+  const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))
+  const [clientSearch, setClientSearch] = useState("")
+  const [masterSearch, setMasterSearch] = useState("")
+  const appointmentsQueryOptions = calendarAppointmentsQueryOptions(date, view)
+  const appointmentsData = useQuery(appointmentsQueryOptions).data
+  const clientCustomersData = useQuery(appointmentCustomerOptionsQueryOptions(clientSearch)).data
+  const masterCustomersData = useQuery(appointmentCustomerOptionsQueryOptions(masterSearch)).data
+  const salonsData = useQuery(appointmentSalonOptionsQueryOptions()).data
+  const createAppointment = useCreateAppointmentAction({
+    invalidateKeys: [{ queryKey: appointmentsQueryOptions.queryKey }],
+    onCreated: (created) => {
+      if (created?.id) {
+        navigate({ to: "/appointments/$appointmentId", params: { appointmentId: created.id } })
+      }
+    },
+  })
+
+  return (
+    <CalendarPage
+      view={view}
+      date={date}
+      clientSearch={clientSearch}
+      masterSearch={masterSearch}
+      appointmentsData={appointmentsData}
+      clientCustomersData={clientCustomersData}
+      masterCustomersData={masterCustomersData}
+      salonsData={salonsData}
+      createPending={createAppointment.isPending}
+      onViewChange={setView}
+      onDateChange={setDate}
+      onClientSearchChange={setClientSearch}
+      onMasterSearchChange={setMasterSearch}
+      onCreateAppointment={(values) => createAppointment.mutate(values)}
+      onOpenAppointment={(appointmentId) => navigate({ to: "/appointments/$appointmentId", params: { appointmentId } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -14,7 +14,7 @@ import {
 } from "./-data/calendar-data"
 
 export const Route = createFileRoute("/_authenticated/calendar")({
-  component: routeComponent,
+  component: RouteComponent,
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.prefetchQuery(calendarAppointmentsQueryOptions(dayjs().format("YYYY-MM-DD"), "month")),
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/_authenticated/calendar")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const navigate = Route.useNavigate()
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -5,13 +5,18 @@ import { useState } from "react"
 import { trpc } from "@/utils/trpc"
 
 import { useCashTransactionActions } from "./-actions/cash-transaction-actions"
-import { CashPage, type CashTransactionFilters, PAGE_SIZE, defaultCustomersListInput } from "./-components/cash-page"
+import { CashPage } from "./-components/cash-page"
+import {
+  CASH_TRANSACTIONS_PAGE_SIZE,
+  type CashTransactionFilters,
+  defaultCashCustomersListInput,
+} from "./-data/cash-data"
 
 export const Route = createFileRoute("/_authenticated/cash")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const [page, setPage] = useState(1)
   const [filters, setFilters] = useState<CashTransactionFilters>({
     search: "",
@@ -26,25 +31,25 @@ function routeComponent() {
   const [editCustomerSearch, setEditCustomerSearch] = useState("")
   const customersData = useQuery(
     trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
+      ...defaultCashCustomersListInput,
       search: customerSearch.trim() || undefined,
     }),
   ).data
   const createCustomersData = useQuery(
     trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
+      ...defaultCashCustomersListInput,
       search: createCustomerSearch.trim() || undefined,
     }),
   ).data
   const editCustomersData = useQuery(
     trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
+      ...defaultCashCustomersListInput,
       search: editCustomerSearch.trim() || undefined,
     }),
   ).data
   const queryFilter = {
     page,
-    pageSize: PAGE_SIZE,
+    pageSize: CASH_TRANSACTIONS_PAGE_SIZE,
     search: filters.search.trim() || undefined,
     customerId: filters.customerId || undefined,
     currency: filters.currency || undefined,

--- a/apps/web/src/routes/_authenticated/cash.tsx
+++ b/apps/web/src/routes/_authenticated/cash.tsx
@@ -1,7 +1,90 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
-import { CashPage } from "./-components/cash-page"
+import { trpc } from "@/utils/trpc"
+
+import { useCashTransactionActions } from "./-actions/cash-transaction-actions"
+import { CashPage, type CashTransactionFilters, PAGE_SIZE, defaultCustomersListInput } from "./-components/cash-page"
 
 export const Route = createFileRoute("/_authenticated/cash")({
-  component: CashPage,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const [page, setPage] = useState(1)
+  const [filters, setFilters] = useState<CashTransactionFilters>({
+    search: "",
+    customerId: "",
+    currency: "",
+    direction: "all",
+    dateFrom: "",
+    dateTo: "",
+  })
+  const [customerSearch, setCustomerSearch] = useState("")
+  const [createCustomerSearch, setCreateCustomerSearch] = useState("")
+  const [editCustomerSearch, setEditCustomerSearch] = useState("")
+  const customersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+  ).data
+  const createCustomersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: createCustomerSearch.trim() || undefined,
+    }),
+  ).data
+  const editCustomersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: editCustomerSearch.trim() || undefined,
+    }),
+  ).data
+  const queryFilter = {
+    page,
+    pageSize: PAGE_SIZE,
+    search: filters.search.trim() || undefined,
+    customerId: filters.customerId || undefined,
+    currency: filters.currency || undefined,
+    direction: filters.direction,
+    dateFrom: filters.dateFrom || undefined,
+    dateTo: filters.dateTo || undefined,
+  }
+  const cashTransactionsQuery = useQuery(
+    trpc.cashTransactions.list.queryOptions(queryFilter, { placeholderData: (previousData) => previousData }),
+  )
+  const cashActions = useCashTransactionActions({})
+
+  const updateFilters = (nextFilters: Partial<CashTransactionFilters>) => {
+    setFilters((current) => ({ ...current, ...nextFilters }))
+    setPage(1)
+  }
+
+  return (
+    <CashPage
+      page={page}
+      filters={filters}
+      customersData={customersData}
+      createCustomersData={createCustomersData}
+      editCustomersData={editCustomersData}
+      result={cashTransactionsQuery.data}
+      isFetching={cashTransactionsQuery.isFetching}
+      customerSearch={customerSearch}
+      createCustomerSearch={createCustomerSearch}
+      editCustomerSearch={editCustomerSearch}
+      createPending={cashActions.createCashTransaction.isPending}
+      updatePending={cashActions.updateCashTransaction.isPending}
+      deletePending={cashActions.deleteCashTransaction.isPending}
+      onPageChange={setPage}
+      onFiltersChange={updateFilters}
+      onCustomerSearchChange={setCustomerSearch}
+      onCreateCustomerSearchChange={setCreateCustomerSearch}
+      onEditCustomerSearchChange={setEditCustomerSearch}
+      onCreate={(values) => cashActions.createCashTransaction.mutate(values)}
+      onUpdate={(values) => cashActions.updateCashTransaction.mutate(values)}
+      onDelete={(id) => cashActions.deleteCashTransaction.mutate({ id })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/appointments-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/appointments-page.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
+
 import { Button, Group, Pagination, Stack, Table, Text, TextInput } from "@mantine/core"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
@@ -8,31 +9,42 @@ import { CreateAppointmentDialog } from "@/components/appointments/create-appoin
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { Section } from "@/components/section"
-import { trpc } from "@/utils/trpc"
 
-import {
-  appointmentMasterOptionsQueryOptions,
-  appointmentSalonOptionsQueryOptions,
-  appointmentsQueryOptions,
-  PAGE_SIZE,
-} from "../-data/appointments-data"
-import { useCreateAppointmentAction } from "../../../-actions/appointment-actions"
-import { Route } from "../appointments"
+import { PAGE_SIZE } from "../-data/appointments-data"
 
-export function CustomerAppointmentsRoute() {
-  const { customerId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
+type AppointmentRow = { id: string; name: string; startsAt: string | Date }
+type OptionData = { items: { id: string; name: string }[] }
+
+export function CustomerAppointmentsPage({
+  customerId,
+  page,
+  searchValue,
+  data,
+  masterSearch,
+  masterCustomersData,
+  salonsData,
+  createPending,
+  onCreateAppointment,
+  onMasterSearchChange,
+  onSearchChange,
+  onPageChange,
+}: {
+  customerId: string
+  page: number
+  searchValue: string
+  data: { items: AppointmentRow[]; totalCount: number } | undefined
+  masterSearch: string
+  masterCustomersData: OptionData | undefined
+  salonsData: OptionData | undefined
+  createPending: boolean
+  onCreateAppointment: ComponentProps<typeof CreateAppointmentDialog>["onCreate"]
+  onMasterSearchChange: (search: string) => void
+  onSearchChange: (search: string) => void
+  onPageChange: (page: number) => void
+}) {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [masterSearch, setMasterSearch] = useState("")
 
-  const page = search.page ?? 1
-  const searchValue = search.search ?? ""
   const normalizedSearch = searchValue.trim()
-  const queryOptions = appointmentsQueryOptions(customerId, page, searchValue)
-  const { data } = useQuery(queryOptions)
-  const { data: masterCustomersData } = useQuery(appointmentMasterOptionsQueryOptions(masterSearch))
-  const { data: salonsData } = useQuery(appointmentSalonOptionsQueryOptions())
   const masterOptions = (masterCustomersData?.items ?? []).map((customer) => ({
     value: customer.id,
     label: customer.name,
@@ -43,18 +55,6 @@ export function CustomerAppointmentsRoute() {
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const clampedPage = Math.min(page, totalPages)
   const hasItemsOnCurrentPage = appointments.length > 0
-  const createAppointment = useCreateAppointmentAction({
-    invalidateKeys: [
-      { queryKey: trpc.customers.appointments.list.queryKey() },
-      { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
-    ],
-    onCreated: (created) => {
-      setDialogOpen(false)
-      if (created?.id) {
-        navigate({ to: "/appointments/$appointmentId", params: { appointmentId: created.id } })
-      }
-    },
-  })
 
   return (
     <>
@@ -70,7 +70,7 @@ export function CustomerAppointmentsRoute() {
               leftSection={<IconSearch size={16} />}
               value={searchValue}
               onChange={(event) => {
-                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+                onSearchChange(event.currentTarget.value)
               }}
               w={260}
             />
@@ -129,11 +129,7 @@ export function CustomerAppointmentsRoute() {
             <Text size="sm" c="dimmed">
               {totalCount} appointment{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
             </Text>
-            <Pagination
-              value={clampedPage}
-              total={totalPages}
-              onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-            />
+            <Pagination value={clampedPage} total={totalPages} onChange={onPageChange} />
           </Group>
         </Stack>
 
@@ -141,15 +137,18 @@ export function CustomerAppointmentsRoute() {
           open={dialogOpen}
           onOpenChange={setDialogOpen}
           defaultClientId={customerId}
-          loading={createAppointment.isPending}
-          onCreate={(values) => createAppointment.mutate(values)}
+          loading={createPending}
+          onCreate={(values) => {
+            onCreateAppointment(values)
+            setDialogOpen(false)
+          }}
           clientOptions={[]}
           masterOptions={masterOptions}
           salonOptions={salonOptions}
           clientSearch=""
           masterSearch={masterSearch}
           onClientSearchChange={() => {}}
-          onMasterSearchChange={setMasterSearch}
+          onMasterSearchChange={onMasterSearchChange}
         />
       </Section>
     </>

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from "react"
+
 import { Button, Stack, Text, TextInput } from "@mantine/core"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
 import { useState } from "react"
@@ -8,22 +10,46 @@ import { DeleteHairAssignedDialog } from "@/components/hair-assigned/delete-hair
 import { EditHairAssignedDialog } from "@/components/hair-assigned/edit-hair-assigned-dialog"
 import { HairAssignedTable, type HairAssignedRow } from "@/components/hair-assigned/hair-assigned-table"
 import { Section } from "@/components/section"
-import { trpc } from "@/utils/trpc"
 
 import { HAIR_SALES_PAGE_SIZE, useHairSalesData } from "../-data/hair-sales-data"
-import { useHairAssignmentActions } from "../../../-actions/hair-assignment-actions"
-import { Route } from "../hair-sales"
 
-export function HairSalesRoute() {
-  const { customerId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
+type HairSalesData = ReturnType<typeof useHairSalesData>
+
+export function HairSalesPage({
+  customerId,
+  searchValue,
+  data,
+  hairEditItem,
+  hairDeleteItem,
+  createPending,
+  updatePending,
+  deletePending,
+  onHairEditItemChange,
+  onHairDeleteItemChange,
+  onSearchChange,
+  onPageChange,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: {
+  customerId: string
+  searchValue: string
+  data: HairSalesData
+  hairEditItem: HairAssignedRow | null
+  hairDeleteItem: HairAssignedRow | null
+  createPending: boolean
+  updatePending: boolean
+  deletePending: boolean
+  onHairEditItemChange: (item: HairAssignedRow | null) => void
+  onHairDeleteItemChange: (item: HairAssignedRow | null) => void
+  onSearchChange: (search: string) => void
+  onPageChange: (page: number) => void
+  onCreate: ComponentProps<typeof CreateHairAssignedDialog>["onCreate"]
+  onUpdate: ComponentProps<typeof EditHairAssignedDialog>["onUpdate"]
+  onDelete: (id: string) => void
+}) {
   const [hairCreateOpen, setHairCreateOpen] = useState(false)
-  const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
-  const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
 
-  const page = search.page ?? 1
-  const searchValue = search.search ?? ""
   const normalizedSearch = searchValue.trim()
   const {
     availableHairOrders,
@@ -33,22 +59,7 @@ export function HairSalesRoute() {
     totalPages,
     clampedPage,
     hasItemsOnCurrentPage,
-  } = useHairSalesData({ customerId, page, search: searchValue })
-  const customerSummaryQueryKey = trpc.customers.summary.queryOptions({ id: customerId }).queryKey
-  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
-    invalidateKeys: [{ queryKey: trpc.customers.hairAssigned.list.queryKey() }, { queryKey: customerSummaryQueryKey }],
-    selectedEditItem: hairEditItem,
-    selectedDeleteItem: hairDeleteItem,
-    onCreated: () => {
-      setHairCreateOpen(false)
-      navigate({ search: { page: 1, search: searchValue }, replace: true })
-    },
-    onUpdated: () => setHairEditItem(null),
-    onDeleted: () => {
-      setHairDeleteItem(null)
-      navigate({ search: { page: 1, search: searchValue }, replace: true })
-    },
-  })
+  } = data
 
   return (
     <>
@@ -64,7 +75,7 @@ export function HairSalesRoute() {
               leftSection={<IconSearch size={16} />}
               value={searchValue}
               onChange={(event) => {
-                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+                onSearchChange(event.currentTarget.value)
               }}
               w={260}
             />
@@ -90,13 +101,13 @@ export function HairSalesRoute() {
               <HairAssignedTable.SoldFor />
               <HairAssignedTable.Profit />
               <HairAssignedTable.PricePerGram />
-              <HairAssignedTable.Actions onEdit={setHairEditItem} onDelete={setHairDeleteItem} />
+              <HairAssignedTable.Actions onEdit={onHairEditItemChange} onDelete={onHairDeleteItemChange} />
               <HairAssignedTable.Pagination
                 page={clampedPage}
                 pageSize={HAIR_SALES_PAGE_SIZE}
                 itemCount={hairAssigned.length}
                 totalCount={totalCount}
-                onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+                onChange={onPageChange}
                 label={`${totalCount} hair sale${totalCount === 1 ? "" : "s"} · Page ${clampedPage} of ${totalPages}`}
                 px="md"
                 pb="md"
@@ -114,27 +125,36 @@ export function HairSalesRoute() {
           onOpenChange={setHairCreateOpen}
           clientId={customerId}
           appointmentId={null}
-          loading={createHairAssigned.isPending}
-          onCreate={(values) => createHairAssigned.mutate(values)}
+          loading={createPending}
+          onCreate={(values) => {
+            onCreate(values)
+            setHairCreateOpen(false)
+          }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}
         />
         {hairEditItem && (
           <EditHairAssignedDialog
             open={!!hairEditItem}
-            onOpenChange={(open) => !open && setHairEditItem(null)}
+            onOpenChange={(open) => !open && onHairEditItemChange(null)}
             hairAssigned={hairEditItem}
-            loading={updateHairAssigned.isPending}
-            onUpdate={(values) => updateHairAssigned.mutate(values)}
+            loading={updatePending}
+            onUpdate={(values) => {
+              onUpdate(values)
+              onHairEditItemChange(null)
+            }}
           />
         )}
         {hairDeleteItem && (
           <DeleteHairAssignedDialog
             open={!!hairDeleteItem}
-            onOpenChange={(open) => !open && setHairDeleteItem(null)}
+            onOpenChange={(open) => !open && onHairDeleteItemChange(null)}
             hairAssigned={hairDeleteItem}
-            loading={deleteHairAssigned.isPending}
-            onDelete={(id) => deleteHairAssigned.mutate({ id })}
+            loading={deletePending}
+            onDelete={(id) => {
+              onDelete(id)
+              onHairDeleteItemChange(null)
+            }}
           />
         )}
       </Section>

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/notes-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/notes-page.tsx
@@ -1,16 +1,13 @@
 import { ActionIcon, Button, Card, Group, Modal, Pagination, Stack, Text, Textarea, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { IconPlus, IconSearch, IconTrash } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { Section } from "@/components/section"
 
-import { useCustomerNoteActions } from "../-actions/note-actions"
-import { notesQueryOptions, PAGE_SIZE } from "../-data/notes-data"
-import { Route } from "../notes"
+import { PAGE_SIZE } from "../-data/notes-data"
 
 type CustomerNote = {
   id: string
@@ -19,27 +16,35 @@ type CustomerNote = {
   createdBy?: { name: string | null } | null
 }
 
-export function NotesRoute() {
-  const { customerId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
+export function NotesPage({
+  customerId,
+  page,
+  searchValue,
+  data,
+  createPending,
+  onCreateNote,
+  onDeleteNote,
+  onSearchChange,
+  onPageChange,
+}: {
+  customerId: string
+  page: number
+  searchValue: string
+  data: { items: CustomerNote[]; totalCount: number } | undefined
+  createPending: boolean
+  onCreateNote: (values: { note: string; customerId: string }) => Promise<unknown>
+  onDeleteNote: (id: string) => void
+  onSearchChange: (search: string) => void
+  onPageChange: (page: number) => void
+}) {
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const page = search.page ?? 1
-  const searchValue = search.search ?? ""
   const normalizedSearch = searchValue.trim()
-  const queryOptions = notesQueryOptions(customerId, page, searchValue)
-  const { data } = useQuery(queryOptions)
-  const notes = (data?.items ?? []) as CustomerNote[]
+  const notes = data?.items ?? []
   const totalCount = data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const clampedPage = Math.min(page, totalPages)
   const hasItemsOnCurrentPage = notes.length > 0
-
-  const { createNote, deleteNote } = useCustomerNoteActions({
-    customerId,
-    onCreated: () => navigate({ search: { page: 1, search: searchValue }, replace: true }),
-  })
 
   return (
     <>
@@ -55,7 +60,7 @@ export function NotesRoute() {
               leftSection={<IconSearch size={16} />}
               value={searchValue}
               onChange={(event) => {
-                navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+                onSearchChange(event.currentTarget.value)
               }}
               w={260}
             />
@@ -83,7 +88,7 @@ export function NotesRoute() {
                         {note.createdBy?.name ?? "Unknown"} · <ClientDate date={note.createdAt} />
                       </Text>
                     </Stack>
-                    <ActionIcon variant="subtle" color="red" onClick={() => deleteNote.mutate({ id: note.id })}>
+                    <ActionIcon variant="subtle" color="red" onClick={() => onDeleteNote(note.id)}>
                       <IconTrash size={14} />
                     </ActionIcon>
                   </Group>
@@ -100,11 +105,7 @@ export function NotesRoute() {
             <Text size="sm" c="dimmed">
               {totalCount} note{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
             </Text>
-            <Pagination
-              value={clampedPage}
-              total={totalPages}
-              onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-            />
+            <Pagination value={clampedPage} total={totalPages} onChange={onPageChange} />
           </Group>
         </Stack>
 
@@ -112,8 +113,8 @@ export function NotesRoute() {
           customerId={customerId}
           open={dialogOpen}
           onOpenChange={setDialogOpen}
-          loading={createNote.isPending}
-          onCreate={(values) => createNote.mutateAsync(values)}
+          loading={createPending}
+          onCreate={onCreateNote}
         />
       </Section>
     </>

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/route-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/route-page.tsx
@@ -1,27 +1,45 @@
 import { Button, Card, Container, Group, Modal, SimpleGrid, Stack, Tabs, Text, TextInput, Title } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { IconPencil, IconPhone } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Outlet, useLocation } from "@tanstack/react-router"
-import { useState } from "react"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { CURRENCIES, formatMinor } from "@/lib/currency"
-import { trpc } from "@/utils/trpc"
 
-import { useUpdateCustomerAction } from "../-actions/customer-detail-actions"
-import { Route } from "../route"
+type CustomerDetail = { id: string; name: string; phoneNumber: string | null }
+type CustomerSummary = {
+  appointmentCount: number
+  transactionSumsMinor: Record<(typeof CURRENCIES)[number], number>
+  hairAssignedProfitSum: number
+  hairAssignedSoldForSum: number
+  hairAssignedWeightInGramsSum: number
+  noteCount: number
+  customerCreatedAt: string | Date
+}
+type CustomerUpdateValues = { id: string; name: string; phoneNumber: string | null }
 
-export function CustomerDetailRoute() {
-  const { customerId } = Route.useParams()
-  const navigate = Route.useNavigate()
+export function CustomerDetailPage({
+  customerId,
+  customer,
+  summary,
+  editOpen,
+  updatePending,
+  onEditOpenChange,
+  onUpdateCustomer,
+  onTabChange,
+}: {
+  customerId: string
+  customer: CustomerDetail | undefined
+  summary: CustomerSummary | undefined
+  editOpen: boolean
+  updatePending: boolean
+  onEditOpenChange: (open: boolean) => void
+  onUpdateCustomer: (values: CustomerUpdateValues) => Promise<unknown>
+  onTabChange: (activeTab: string, value: string | null) => void
+}) {
   const location = useLocation()
-
-  const { data: customer } = useQuery(trpc.customers.get.queryOptions({ id: customerId }))
-  const { data: summary } = useQuery(trpc.customers.summary.queryOptions({ id: customerId }))
-  const [editOpen, setEditOpen] = useState(false)
 
   const activeTab = location.pathname.endsWith("/notes")
     ? "notes"
@@ -38,18 +56,7 @@ export function CustomerDetailRoute() {
   }
 
   const handleTabChange = (value: string | null) => {
-    if (!value || value === activeTab) return
-    if (value === "appointments") {
-      navigate({ to: "/customers/$customerId/appointments", params: { customerId } })
-      return
-    }
-    if (value === "notes") {
-      navigate({ to: "/customers/$customerId/notes", params: { customerId } })
-      return
-    }
-    if (value === "hair-sales") {
-      navigate({ to: "/customers/$customerId/hair-sales", params: { customerId } })
-    }
+    onTabChange(activeTab, value)
   }
 
   return (
@@ -68,7 +75,7 @@ export function CustomerDetailRoute() {
           ) : undefined
         }
         actions={
-          <Button variant="default" leftSection={<IconPencil size={14} />} onClick={() => setEditOpen(true)}>
+          <Button variant="default" leftSection={<IconPencil size={14} />} onClick={() => onEditOpenChange(true)}>
             Edit
           </Button>
         }
@@ -115,7 +122,13 @@ export function CustomerDetailRoute() {
 
         <Outlet />
 
-        <EditCustomerDialog customer={customer} open={editOpen} onOpenChange={setEditOpen} />
+        <EditCustomerDialog
+          customer={customer}
+          open={editOpen}
+          onOpenChange={onEditOpenChange}
+          loading={updatePending}
+          onUpdate={onUpdateCustomer}
+        />
       </Stack>
     </Container>
   )
@@ -136,13 +149,15 @@ function EditCustomerDialog({
   customer,
   open,
   onOpenChange,
+  loading,
+  onUpdate,
 }: {
   customer: { id: string; name: string; phoneNumber: string | null }
   open: boolean
   onOpenChange: (open: boolean) => void
+  loading: boolean
+  onUpdate: (values: CustomerUpdateValues) => Promise<unknown>
 }) {
-  const mutation = useUpdateCustomerAction({ customerId: customer.id, onUpdated: () => onOpenChange(false) })
-
   const form = useForm({
     initialValues: {
       name: customer.name,
@@ -151,7 +166,7 @@ function EditCustomerDialog({
   })
 
   const handleSubmit = async (values: { name: string; phoneNumber: string }) => {
-    await mutation.mutateAsync({
+    await onUpdate({
       id: customer.id,
       name: values.name,
       phoneNumber: values.phoneNumber || null,
@@ -164,7 +179,7 @@ function EditCustomerDialog({
         <Stack>
           <TextInput label="Name" {...form.getInputProps("name")} />
           <TextInput label="Phone Number" placeholder="+1234567890" {...form.getInputProps("phoneNumber")} />
-          <Button type="submit" loading={mutation.isPending}>
+          <Button type="submit" loading={loading}>
             Save Changes
           </Button>
         </Stack>

--- a/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
@@ -1,6 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useState } from "react"
 
-import { CustomerAppointmentsRoute } from "./-components/appointments-page"
+import { trpc } from "@/utils/trpc"
+
+import { useCreateAppointmentAction } from "../../-actions/appointment-actions"
+import { CustomerAppointmentsPage } from "./-components/appointments-page"
 import {
   PAGE_SIZE,
   appointmentMasterOptionsQueryOptions,
@@ -30,5 +35,45 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/appo
       })
     }
   },
-  component: CustomerAppointmentsRoute,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { customerId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const [masterSearch, setMasterSearch] = useState("")
+  const data = useQuery(appointmentsQueryOptions(customerId, page, searchValue)).data
+  const masterCustomersData = useQuery(appointmentMasterOptionsQueryOptions(masterSearch)).data
+  const salonsData = useQuery(appointmentSalonOptionsQueryOptions()).data
+  const createAppointment = useCreateAppointmentAction({
+    invalidateKeys: [
+      { queryKey: trpc.customers.appointments.list.queryKey() },
+      { queryKey: trpc.customers.summary.queryOptions({ id: customerId }).queryKey },
+    ],
+    onCreated: (created) => {
+      if (created?.id) {
+        navigate({ to: "/appointments/$appointmentId", params: { appointmentId: created.id } })
+      }
+    },
+  })
+
+  return (
+    <CustomerAppointmentsPage
+      customerId={customerId}
+      page={page}
+      searchValue={searchValue}
+      data={data}
+      masterSearch={masterSearch}
+      masterCustomersData={masterCustomersData}
+      salonsData={salonsData}
+      createPending={createAppointment.isPending}
+      onCreateAppointment={(values) => createAppointment.mutate(values)}
+      onMasterSearchChange={setMasterSearch}
+      onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
@@ -35,10 +35,10 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/appo
       })
     }
   },
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { customerId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
@@ -1,15 +1,21 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useState } from "react"
 
-import { HairSalesRoute } from "./-components/hair-sales-page"
+import { type HairAssignedRow } from "@/components/hair-assigned/hair-assigned-table"
+import { trpc } from "@/utils/trpc"
+
+import { useHairAssignmentActions } from "../../-actions/hair-assignment-actions"
+import { HairSalesPage } from "./-components/hair-sales-page"
 import {
   HAIR_SALES_PAGE_SIZE,
   availableHairOrdersListQueryOptions,
   hairSalesQueryOptions,
   searchSchema,
+  useHairSalesData,
 } from "./-data/hair-sales-data"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId/hair-sales")({
-  component: HairSalesRoute,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -30,3 +36,46 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/hair
     }
   },
 })
+
+function routeComponent() {
+  const { customerId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
+  const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const data = useHairSalesData({ customerId, page, search: searchValue })
+  const customerSummaryQueryKey = trpc.customers.summary.queryOptions({ id: customerId }).queryKey
+  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
+    invalidateKeys: [{ queryKey: trpc.customers.hairAssigned.list.queryKey() }, { queryKey: customerSummaryQueryKey }],
+    selectedEditItem: hairEditItem,
+    selectedDeleteItem: hairDeleteItem,
+  })
+
+  return (
+    <HairSalesPage
+      customerId={customerId}
+      searchValue={searchValue}
+      data={data}
+      hairEditItem={hairEditItem}
+      hairDeleteItem={hairDeleteItem}
+      createPending={createHairAssigned.isPending}
+      updatePending={updateHairAssigned.isPending}
+      deletePending={deleteHairAssigned.isPending}
+      onHairEditItemChange={setHairEditItem}
+      onHairDeleteItemChange={setHairDeleteItem}
+      onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+      onCreate={(values) => {
+        createHairAssigned.mutate(values)
+        navigate({ search: { page: 1, search: searchValue }, replace: true })
+      }}
+      onUpdate={(values) => updateHairAssigned.mutate(values)}
+      onDelete={(id) => {
+        deleteHairAssigned.mutate({ id })
+        navigate({ search: { page: 1, search: searchValue }, replace: true })
+      }}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
@@ -15,7 +15,7 @@ import {
 } from "./-data/hair-sales-data"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId/hair-sales")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -37,7 +37,7 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/hair
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { customerId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
@@ -1,10 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
-import { NotesRoute } from "./-components/notes-page"
+import { useCustomerNoteActions } from "./-actions/note-actions"
+import { NotesPage } from "./-components/notes-page"
 import { PAGE_SIZE, notesQueryOptions, searchSchema } from "./-data/notes-data"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId/notes")({
-  component: NotesRoute,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -22,3 +24,30 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/note
     }
   },
 })
+
+function routeComponent() {
+  const { customerId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const data = useQuery(notesQueryOptions(customerId, page, searchValue)).data
+  const { createNote, deleteNote } = useCustomerNoteActions({
+    customerId,
+    onCreated: () => navigate({ search: { page: 1, search: searchValue }, replace: true }),
+  })
+
+  return (
+    <NotesPage
+      customerId={customerId}
+      page={page}
+      searchValue={searchValue}
+      data={data}
+      createPending={createNote.isPending}
+      onCreateNote={(values) => createNote.mutateAsync(values)}
+      onDeleteNote={(id) => deleteNote.mutate({ id })}
+      onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/notes.tsx
@@ -6,7 +6,7 @@ import { NotesPage } from "./-components/notes-page"
 import { PAGE_SIZE, notesQueryOptions, searchSchema } from "./-data/notes-data"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId/notes")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -25,7 +25,7 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/note
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { customerId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
@@ -8,7 +8,7 @@ import { useUpdateCustomerAction } from "./-actions/customer-detail-actions"
 import { CustomerDetailPage } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
-  component: routeComponent,
+  component: RouteComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(trpc.customers.get.queryOptions({ id: params.customerId })),
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { customerId } = Route.useParams()
   const navigate = Route.useNavigate()
   const customer = useQuery(trpc.customers.get.queryOptions({ id: customerId })).data

--- a/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/route.tsx
@@ -1,11 +1,14 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
 import { trpc } from "@/utils/trpc"
 
-import { CustomerDetailRoute } from "./-components/route-page"
+import { useUpdateCustomerAction } from "./-actions/customer-detail-actions"
+import { CustomerDetailPage } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId")({
-  component: CustomerDetailRoute,
+  component: routeComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(trpc.customers.get.queryOptions({ id: params.customerId })),
@@ -13,3 +16,38 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId")({
     ])
   },
 })
+
+function routeComponent() {
+  const { customerId } = Route.useParams()
+  const navigate = Route.useNavigate()
+  const customer = useQuery(trpc.customers.get.queryOptions({ id: customerId })).data
+  const summary = useQuery(trpc.customers.summary.queryOptions({ id: customerId })).data
+  const [editOpen, setEditOpen] = useState(false)
+  const updateCustomer = useUpdateCustomerAction({ customerId, onUpdated: () => setEditOpen(false) })
+
+  return (
+    <CustomerDetailPage
+      customerId={customerId}
+      customer={customer}
+      summary={summary}
+      editOpen={editOpen}
+      updatePending={updateCustomer.isPending}
+      onEditOpenChange={setEditOpen}
+      onUpdateCustomer={(values) => updateCustomer.mutateAsync(values)}
+      onTabChange={(activeTab, value) => {
+        if (!value || value === activeTab) return
+        if (value === "appointments") {
+          navigate({ to: "/customers/$customerId/appointments", params: { customerId } })
+          return
+        }
+        if (value === "notes") {
+          navigate({ to: "/customers/$customerId/notes", params: { customerId } })
+          return
+        }
+        if (value === "hair-sales") {
+          navigate({ to: "/customers/$customerId/hair-sales", params: { customerId } })
+        }
+      }}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/-components/index-page.tsx
@@ -1,7 +1,6 @@
 import { Button, Container, Group, Modal, Pagination, Stack, Table, Text, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
@@ -9,24 +8,39 @@ import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 
-import { useCreateCustomerAction } from "../-actions/customer-actions"
-import { customersListQueryOptions } from "../-data/index-data"
-import { Route } from "../index"
-
 const PAGE_SIZE = 10
+type CustomerListData = {
+  items: {
+    id: string
+    name: string
+    phoneNumber: string | null
+    createdAt: Date | string
+  }[]
+  totalCount: number
+}
+type CustomerCreateValues = { name: string; phoneNumber: string | null }
 
-function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
-  const mutation = useCreateCustomerAction({ onCreated: () => onOpenChange(false) })
-
+function CustomerFormDialog({
+  open,
+  onOpenChange,
+  loading,
+  onCreate,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  loading: boolean
+  onCreate: (values: CustomerCreateValues) => Promise<unknown>
+}) {
   const form = useForm({
     initialValues: { name: "", phoneNumber: "" },
   })
 
   const handleSubmit = async (values: { name: string; phoneNumber: string }) => {
-    await mutation.mutateAsync({
+    await onCreate({
       name: values.name,
       phoneNumber: values.phoneNumber || null,
     })
+    onOpenChange(false)
   }
 
   return (
@@ -35,7 +49,7 @@ function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChang
         <Stack>
           <TextInput label="Name" {...form.getInputProps("name")} />
           <TextInput label="Phone Number" placeholder="+1234567890" {...form.getInputProps("phoneNumber")} />
-          <Button type="submit" loading={mutation.isPending}>
+          <Button type="submit" loading={loading}>
             Create Customer
           </Button>
         </Stack>
@@ -44,12 +58,25 @@ function CustomerFormDialog({ open, onOpenChange }: { open: boolean; onOpenChang
   )
 }
 
-export function CustomersPage() {
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const page = search.page ?? 1
-  const searchValue = search.search ?? ""
-  const { data } = useQuery(customersListQueryOptions(page, searchValue))
+type CustomersPageProps = {
+  page: number
+  searchValue: string
+  data: CustomerListData | undefined
+  createCustomerPending: boolean
+  onCreateCustomer: (values: CustomerCreateValues) => Promise<unknown>
+  onSearchChange: (search: string) => void
+  onPageChange: (page: number) => void
+}
+
+export function CustomersPage({
+  page,
+  searchValue,
+  data,
+  createCustomerPending,
+  onCreateCustomer,
+  onSearchChange,
+  onPageChange,
+}: CustomersPageProps) {
   const customers = data?.items ?? []
   const totalCount = data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
@@ -74,7 +101,7 @@ export function CustomersPage() {
             leftSection={<IconSearch size={16} />}
             value={searchValue}
             onChange={(event) => {
-              navigate({ search: { page: 1, search: event.currentTarget.value }, replace: true })
+              onSearchChange(event.currentTarget.value)
             }}
             miw={260}
             flex={1}
@@ -128,15 +155,16 @@ export function CustomersPage() {
           <Text size="sm" c="dimmed">
             Page {Math.min(page, totalPages)} of {totalPages}
           </Text>
-          <Pagination
-            total={totalPages}
-            value={Math.min(page, totalPages)}
-            onChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
-          />
+          <Pagination total={totalPages} value={Math.min(page, totalPages)} onChange={onPageChange} />
         </Group>
       </Section>
 
-      <CustomerFormDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      <CustomerFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        loading={createCustomerPending}
+        onCreate={onCreateCustomer}
+      />
     </Container>
   )
 }

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -1,10 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 
+import { useCreateCustomerAction } from "./-actions/customer-actions"
 import { CustomersPage } from "./-components/index-page"
 import { customersListQueryOptions, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/customers/")({
-  component: CustomersPage,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -14,3 +16,24 @@ export const Route = createFileRoute("/_authenticated/customers/")({
     await context.queryClient.ensureQueryData(customersListQueryOptions(deps.page, deps.search))
   },
 })
+
+function routeComponent() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const data = useQuery(customersListQueryOptions(page, searchValue)).data
+  const createCustomer = useCreateCustomerAction({})
+
+  return (
+    <CustomersPage
+      page={page}
+      searchValue={searchValue}
+      data={data}
+      createCustomerPending={createCustomer.isPending}
+      onCreateCustomer={(values) => createCustomer.mutateAsync(values)}
+      onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/customers/index.tsx
+++ b/apps/web/src/routes/_authenticated/customers/index.tsx
@@ -6,7 +6,7 @@ import { CustomersPage } from "./-components/index-page"
 import { customersListQueryOptions, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/customers/")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/_authenticated/customers/")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const page = search.page ?? 1

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -13,7 +13,7 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute("/_authenticated/dashboard")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => {
     const selected = parseMonthKey(search.month ?? monthKeyFromDate(new Date()))
@@ -42,7 +42,7 @@ export const Route = createFileRoute("/_authenticated/dashboard")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const selectedMonthKey = search.month ?? monthKeyFromDate(new Date())

--- a/apps/web/src/routes/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
@@ -12,7 +13,7 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute("/_authenticated/dashboard")({
-  component: DashboardPage,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => {
     const selected = parseMonthKey(search.month ?? monthKeyFromDate(new Date()))
@@ -40,3 +41,39 @@ export const Route = createFileRoute("/_authenticated/dashboard")({
     await Promise.all(queries)
   },
 })
+
+function routeComponent() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const selectedMonthKey = search.month ?? monthKeyFromDate(new Date())
+  const selected = parseMonthKey(selectedMonthKey)
+  const { currentYear, previousYear } = selectedYearInputs(selected)
+  const transactionData = useQuery(trpc.dashboard.transactionStats.queryOptions({ year: currentYear })).data
+  const previousTransactionData = useQuery({
+    ...trpc.dashboard.transactionStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  }).data
+  const appointmentsData = useQuery(trpc.dashboard.hairAssignedStats.queryOptions({ year: currentYear })).data
+  const previousAppointmentsData = useQuery({
+    ...trpc.dashboard.hairAssignedStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  }).data
+  const salesData = useQuery(trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: currentYear })).data
+  const previousSalesData = useQuery({
+    ...trpc.dashboard.hairAssignedThroughSaleStats.queryOptions({ year: previousYear ?? currentYear }),
+    enabled: !!previousYear,
+  }).data
+
+  return (
+    <DashboardPage
+      selectedMonthKey={selectedMonthKey}
+      transactionData={transactionData}
+      previousTransactionData={previousTransactionData}
+      appointmentsData={appointmentsData}
+      previousAppointmentsData={previousAppointmentsData}
+      salesData={salesData}
+      previousSalesData={previousSalesData}
+      onSearchChange={(month) => navigate({ search: { month } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/documents/$documentId/-components/match-page.tsx
+++ b/apps/web/src/routes/_authenticated/documents/$documentId/-components/match-page.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react"
+
 import {
   Anchor,
   Badge,
@@ -16,7 +18,6 @@ import {
 } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { IconArrowLeft } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
@@ -32,15 +33,39 @@ import {
   type DocumentMatchCandidateFilters,
 } from "@/lib/document-match-candidates"
 
-import { useDocumentMatchActions } from "../-actions/document-match-actions"
-import { documentQueryOptions, MATCH_CANDIDATES_PAGE_SIZE, matchCandidatesQueryOptions } from "../-data/match-data"
-import { Route } from "../match"
+import { MATCH_CANDIDATES_PAGE_SIZE } from "../-data/match-data"
 
-export function DocumentMatchPage() {
-  const { documentId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const page = search.page ?? 1
+type DocumentQuery = {
+  data:
+    | {
+        id: string
+        originalName: string
+        contentType: string
+        uploadedAt: string | Date
+        bankStatementEntryId: string | null
+      }
+    | undefined
+  isPending: boolean
+  isError: boolean
+}
+
+export function DocumentMatchPage({
+  page,
+  documentQuery,
+  matchCandidatesData,
+  matchCandidatesIsError,
+  assignPending,
+  onAssign,
+  onPageChange,
+}: {
+  page: number
+  documentQuery: DocumentQuery
+  matchCandidatesData: { items: DocumentMatchCandidate[]; totalCount: number } | undefined
+  matchCandidatesIsError: boolean
+  assignPending: boolean
+  onAssign: (entryId: string) => void
+  onPageChange: (page: number) => void
+}) {
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
   const [filters, setFilters] = useState<DocumentMatchCandidateFilters>({
     legalEntityId: "",
@@ -50,10 +75,8 @@ export function DocumentMatchPage() {
     amount: "",
   })
 
-  const documentQuery = useQuery(documentQueryOptions(documentId))
   const document = documentQuery.data
 
-  const { data: matchCandidatesData, isError: matchCandidatesIsError } = useQuery(matchCandidatesQueryOptions(page))
   const candidates = matchCandidatesData?.items ?? []
   const candidatesTotalCount = matchCandidatesData?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(candidatesTotalCount / MATCH_CANDIDATES_PAGE_SIZE))
@@ -65,11 +88,6 @@ export function DocumentMatchPage() {
   const updateFilters = (nextFilters: Partial<DocumentMatchCandidateFilters>) => {
     setFilters((currentFilters) => ({ ...currentFilters, ...nextFilters }))
   }
-
-  const { assign } = useDocumentMatchActions({
-    documentId,
-    onAssigned: () => navigate({ to: "/documents" }),
-  })
 
   const pageIsLoading = documentQuery.isPending
 
@@ -206,9 +224,9 @@ export function DocumentMatchPage() {
                             <CandidateCard
                               key={candidate.id}
                               candidate={candidate}
-                              assignPending={assign.isPending}
+                              assignPending={assignPending}
                               disabled={!!document.bankStatementEntryId}
-                              onMatch={() => assign.mutate({ id: document.id, entryId: candidate.id })}
+                              onMatch={() => onAssign(candidate.id)}
                             />
                           ))}
                         </Stack>
@@ -226,9 +244,7 @@ export function DocumentMatchPage() {
                             size="sm"
                             total={totalPages}
                             value={Math.min(page, totalPages)}
-                            onChange={(nextPage) =>
-                              navigate({ search: (currentSearch) => ({ ...currentSearch, page: nextPage }) })
-                            }
+                            onChange={onPageChange}
                           />
                         </Group>
                       ) : null}
@@ -246,7 +262,7 @@ export function DocumentMatchPage() {
   )
 }
 
-function BoxWithLoader({ visible, children }: { visible: boolean; children: React.ReactNode }) {
+function BoxWithLoader({ visible, children }: { visible: boolean; children: ReactNode }) {
   return (
     <div style={{ position: "relative" }}>
       <LoadingOverlay visible={visible} />

--- a/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
+++ b/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
+import { useDocumentMatchActions } from "./-actions/document-match-actions"
 import { DocumentMatchPage } from "./-components/match-page"
 import {
   MATCH_CANDIDATES_PAGE_SIZE,
@@ -9,7 +11,7 @@ import {
 } from "./-data/match-data"
 
 export const Route = createFileRoute("/_authenticated/documents/$documentId/match")({
-  component: DocumentMatchPage,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -29,3 +31,28 @@ export const Route = createFileRoute("/_authenticated/documents/$documentId/matc
     }
   },
 })
+
+function routeComponent() {
+  const { documentId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const documentQuery = useQuery(documentQueryOptions(documentId))
+  const matchCandidatesQuery = useQuery(matchCandidatesQueryOptions(page))
+  const { assign } = useDocumentMatchActions({
+    documentId,
+    onAssigned: () => navigate({ to: "/documents" }),
+  })
+
+  return (
+    <DocumentMatchPage
+      page={page}
+      documentQuery={documentQuery}
+      matchCandidatesData={matchCandidatesQuery.data}
+      matchCandidatesIsError={matchCandidatesQuery.isError}
+      assignPending={assign.isPending}
+      onAssign={(entryId) => assign.mutate({ id: documentId, entryId })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
+++ b/apps/web/src/routes/_authenticated/documents/$documentId/match.tsx
@@ -11,7 +11,7 @@ import {
 } from "./-data/match-data"
 
 export const Route = createFileRoute("/_authenticated/documents/$documentId/match")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/_authenticated/documents/$documentId/matc
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { documentId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/documents/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/documents/-components/index-page.tsx
@@ -16,7 +16,6 @@ import {
 } from "@mantine/core"
 import { notifications } from "@mantine/notifications"
 import { IconLinkOff, IconTrash } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
@@ -26,25 +25,47 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { type Currency, formatMinor } from "@/lib/currency"
 
-import { useDocumentActions } from "../-actions/document-actions"
-import { type DocumentStatus, documentsQueryOptions, PAGE_SIZE } from "../-data/index-data"
-import { Route } from "../index"
+import { type DocumentStatus, PAGE_SIZE } from "../-data/index-data"
 
-export function DocumentsPage() {
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const status = search.status ?? "unassigned"
-  const page = search.page ?? 1
+type DocumentsQueryResult = {
+  data: DocumentsData | undefined
+  isFetching: boolean
+  isError: boolean
+}
+type DocumentsData = {
+  items: Parameters<typeof DocumentsTable>[0]["documents"]
+  totalCount: number
+}
+
+export function DocumentsPage({
+  status,
+  page,
+  documentsQuery,
+  uploadDocument,
+  unassignPending,
+  removePending,
+  onUnassign,
+  onRemove,
+  onStatusChange,
+  onPageChange,
+}: {
+  status: DocumentStatus
+  page: number
+  documentsQuery: DocumentsQueryResult
+  uploadDocument: (file: File) => Promise<unknown>
+  unassignPending: boolean
+  removePending: boolean
+  onUnassign: (id: string) => void
+  onRemove: (id: string) => void
+  onStatusChange: (status: DocumentStatus) => void
+  onPageChange: (page: number) => void
+}) {
   const [busy, setBusy] = useState(false)
   const [fileInputKey, setFileInputKey] = useState(0)
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
-
-  const documentsQuery = useQuery(documentsQueryOptions({ status, page }))
   const documents = documentsQuery.data?.items ?? []
   const totalCount = documentsQuery.data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
-
-  const { upload: uploadDocument, unassign, remove } = useDocumentActions()
 
   const upload = async (file: File) => {
     setBusy(true)
@@ -84,12 +105,7 @@ export function DocumentsPage() {
           <Group px={documents.length > 0 ? "md" : 0} pt={documents.length > 0 ? "md" : 0} justify="space-between">
             <SegmentedControl
               value={status}
-              onChange={(value) =>
-                navigate({
-                  search: { page: 1, status: value as DocumentStatus },
-                  replace: true,
-                })
-              }
+              onChange={(value) => onStatusChange(value as DocumentStatus)}
               data={[
                 { label: "Unassigned", value: "unassigned" },
                 { label: "Assigned", value: "assigned" },
@@ -109,10 +125,10 @@ export function DocumentsPage() {
               <Table.ScrollContainer minWidth={980}>
                 <DocumentsTable
                   documents={documents}
-                  unassignPending={unassign.isPending}
-                  removePending={remove.isPending}
-                  onUnassign={(id) => unassign.mutate({ id })}
-                  onRemove={(id) => remove.mutate({ id })}
+                  unassignPending={unassignPending}
+                  removePending={removePending}
+                  onUnassign={onUnassign}
+                  onRemove={onRemove}
                   onPreview={setPreviewAttachment}
                 />
               </Table.ScrollContainer>
@@ -128,12 +144,7 @@ export function DocumentsPage() {
               <Text size="sm" c="dimmed">
                 {totalCount} document{totalCount === 1 ? "" : "s"} · Page {Math.min(page, totalPages)} of {totalPages}
               </Text>
-              <Pagination
-                size="sm"
-                total={totalPages}
-                value={Math.min(page, totalPages)}
-                onChange={(nextPage) => navigate({ search: { page: nextPage, status }, replace: true })}
-              />
+              <Pagination size="sm" total={totalPages} value={Math.min(page, totalPages)} onChange={onPageChange} />
             </Group>
           ) : null}
         </Stack>

--- a/apps/web/src/routes/_authenticated/documents/index.tsx
+++ b/apps/web/src/routes/_authenticated/documents/index.tsx
@@ -6,7 +6,7 @@ import { DocumentsPage } from "./-components/index-page"
 import { documentsQueryOptions, PAGE_SIZE, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/documents/")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/_authenticated/documents/")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const status = search.status ?? "unassigned"

--- a/apps/web/src/routes/_authenticated/documents/index.tsx
+++ b/apps/web/src/routes/_authenticated/documents/index.tsx
@@ -1,10 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
+import { useDocumentActions } from "./-actions/document-actions"
 import { DocumentsPage } from "./-components/index-page"
 import { documentsQueryOptions, PAGE_SIZE, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/documents/")({
-  component: DocumentsPage,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -21,3 +23,27 @@ export const Route = createFileRoute("/_authenticated/documents/")({
     }
   },
 })
+
+function routeComponent() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const status = search.status ?? "unassigned"
+  const page = search.page ?? 1
+  const documentsQuery = useQuery(documentsQueryOptions({ status, page }))
+  const { upload, unassign, remove } = useDocumentActions()
+
+  return (
+    <DocumentsPage
+      status={status}
+      page={page}
+      documentsQuery={documentsQuery}
+      uploadDocument={upload}
+      unassignPending={unassign.isPending}
+      removePending={remove.isPending}
+      onUnassign={(id) => unassign.mutate({ id })}
+      onRemove={(id) => remove.mutate({ id })}
+      onStatusChange={(nextStatus) => navigate({ search: { page: 1, status: nextStatus }, replace: true })}
+      onPageChange={(nextPage) => navigate({ search: { page: nextPage, status }, replace: true })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -13,7 +13,7 @@ import {
 } from "./-data/hair-order-detail-data"
 
 export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")({
-  component: routeComponent,
+  component: RouteComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(hairOrderDetailQueryOptions(params.hairOrderId)),
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { hairOrderId } = Route.useParams()
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -1,10 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
+import { type HairAssignedRow } from "@/components/hair-assigned/hair-assigned-table"
+
+import { useHairAssignmentActions } from "../-actions/hair-assignment-actions"
+import { useHairOrderDetailActions } from "./-actions/hair-order-actions"
 import { HairOrderDetailPage } from "./-components/hair-order-id-page"
-import { availableHairOrdersListQueryOptions, hairOrderDetailQueryOptions } from "./-data/hair-order-detail-data"
+import {
+  availableHairOrdersListQueryOptions,
+  hairOrderDetailQueryOptions,
+  useHairOrderDetailData,
+} from "./-data/hair-order-detail-data"
 
 export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")({
-  component: HairOrderDetailPage,
+  component: routeComponent,
   loader: async ({ context, params }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(hairOrderDetailQueryOptions(params.hairOrderId)),
@@ -12,3 +21,43 @@ export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")
     ])
   },
 })
+
+function routeComponent() {
+  const { hairOrderId } = Route.useParams()
+  const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
+  const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
+  const detailData = useHairOrderDetailData(hairOrderId)
+  const relatedQueryKeys = [
+    { queryKey: detailData.hairOrderQueryOptions.queryKey },
+    ...detailData.assignedClientSummaryKeys,
+  ]
+  const { recalculatePrices, updateHairOrder } = useHairOrderDetailActions({
+    hairOrderId,
+    invalidateKeys: relatedQueryKeys,
+  })
+  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
+    invalidateKeys: relatedQueryKeys,
+    selectedEditItem: editItem,
+    selectedDeleteItem: deleteItem,
+  })
+
+  return (
+    <HairOrderDetailPage
+      detailData={detailData}
+      editItem={editItem}
+      deleteItem={deleteItem}
+      recalculatePending={recalculatePrices.isPending}
+      updateOrderPending={updateHairOrder.isPending}
+      createPending={createHairAssigned.isPending}
+      updatePending={updateHairAssigned.isPending}
+      deletePending={deleteHairAssigned.isPending}
+      onEditItemChange={setEditItem}
+      onDeleteItemChange={setDeleteItem}
+      onRecalculate={() => recalculatePrices.mutate({ hairOrderId })}
+      onUpdateOrder={(values) => updateHairOrder.mutate(values)}
+      onCreate={(values) => createHairAssigned.mutate(values)}
+      onUpdate={(values) => updateHairAssigned.mutate(values)}
+      onDelete={(id) => deleteHairAssigned.mutate({ id })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from "react"
+
 import {
   Badge,
   Button,
@@ -27,40 +29,47 @@ import { HairAssignedTable, type HairAssignedRow } from "@/components/hair-assig
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 
-import { Route } from "../$hairOrderId"
-import { useHairOrderDetailActions } from "../-actions/hair-order-actions"
 import { useHairOrderDetailData } from "../-data/hair-order-detail-data"
-import { useHairAssignmentActions } from "../../-actions/hair-assignment-actions"
 
 const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
+type HairOrderDetailData = ReturnType<typeof useHairOrderDetailData>
 
-export function HairOrderDetailPage() {
-  const { hairOrderId } = Route.useParams()
+export function HairOrderDetailPage({
+  detailData,
+  editItem,
+  deleteItem,
+  recalculatePending,
+  updateOrderPending,
+  createPending,
+  updatePending,
+  deletePending,
+  onEditItemChange,
+  onDeleteItemChange,
+  onRecalculate,
+  onUpdateOrder,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: {
+  detailData: HairOrderDetailData
+  editItem: HairAssignedRow | null
+  deleteItem: HairAssignedRow | null
+  recalculatePending: boolean
+  updateOrderPending: boolean
+  createPending: boolean
+  updatePending: boolean
+  deletePending: boolean
+  onEditItemChange: (item: HairAssignedRow | null) => void
+  onDeleteItemChange: (item: HairAssignedRow | null) => void
+  onRecalculate: () => void
+  onUpdateOrder: ComponentProps<typeof EditHairOrderModal>["onSave"]
+  onCreate: ComponentProps<typeof CreateHairAssignedDialog>["onCreate"]
+  onUpdate: ComponentProps<typeof EditHairAssignedDialog>["onUpdate"]
+  onDelete: (id: string) => void
+}) {
   const [createOpen, setCreateOpen] = useState(false)
-  const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
-  const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
   const [editOrderOpen, setEditOrderOpen] = useState(false)
-  const {
-    hairOrder,
-    hairOrderQueryOptions,
-    availableHairOrders,
-    availableHairOrdersLoading,
-    assignedClientSummaryKeys,
-  } = useHairOrderDetailData(hairOrderId)
-
-  const { recalculatePrices, updateHairOrder } = useHairOrderDetailActions({
-    hairOrderId,
-    invalidateKeys: [{ queryKey: hairOrderQueryOptions.queryKey }, ...assignedClientSummaryKeys],
-    onUpdated: () => setEditOrderOpen(false),
-  })
-  const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
-    invalidateKeys: [{ queryKey: hairOrderQueryOptions.queryKey }, ...assignedClientSummaryKeys],
-    selectedEditItem: editItem,
-    selectedDeleteItem: deleteItem,
-    onCreated: () => setCreateOpen(false),
-    onUpdated: () => setEditItem(null),
-    onDeleted: () => setDeleteItem(null),
-  })
+  const { hairOrder, availableHairOrders, availableHairOrdersLoading } = detailData
 
   if (!hairOrder) {
     return (
@@ -110,8 +119,8 @@ export function HairOrderDetailPage() {
             <Button
               variant="default"
               leftSection={<IconCalculator size={14} />}
-              loading={recalculatePrices.isPending}
-              onClick={() => recalculatePrices.mutate({ hairOrderId })}
+              loading={recalculatePending}
+              onClick={onRecalculate}
             >
               Recalculate
             </Button>
@@ -170,7 +179,7 @@ export function HairOrderDetailPage() {
               <HairAssignedTable.SoldFor />
               <HairAssignedTable.Profit />
               <HairAssignedTable.PricePerGram />
-              <HairAssignedTable.Actions onEdit={setEditItem} onDelete={setDeleteItem} />
+              <HairAssignedTable.Actions onEdit={onEditItemChange} onDelete={onDeleteItemChange} />
             </HairAssignedTable>
           </Section>
 
@@ -198,35 +207,47 @@ export function HairOrderDetailPage() {
           open={createOpen}
           onOpenChange={setCreateOpen}
           clientId={hairOrder.customer.id}
-          loading={createHairAssigned.isPending}
-          onCreate={(values) => createHairAssigned.mutate(values)}
+          loading={createPending}
+          onCreate={(values) => {
+            onCreate(values)
+            setCreateOpen(false)
+          }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}
         />
         {editItem && (
           <EditHairAssignedDialog
             open={!!editItem}
-            onOpenChange={(open) => !open && setEditItem(null)}
+            onOpenChange={(open) => !open && onEditItemChange(null)}
             hairAssigned={editItem}
-            loading={updateHairAssigned.isPending}
-            onUpdate={(values) => updateHairAssigned.mutate(values)}
+            loading={updatePending}
+            onUpdate={(values) => {
+              onUpdate(values)
+              onEditItemChange(null)
+            }}
           />
         )}
         {deleteItem && (
           <DeleteHairAssignedDialog
             open={!!deleteItem}
-            onOpenChange={(open) => !open && setDeleteItem(null)}
+            onOpenChange={(open) => !open && onDeleteItemChange(null)}
             hairAssigned={deleteItem}
-            loading={deleteHairAssigned.isPending}
-            onDelete={(id) => deleteHairAssigned.mutate({ id })}
+            loading={deletePending}
+            onDelete={(id) => {
+              onDelete(id)
+              onDeleteItemChange(null)
+            }}
           />
         )}
         <EditHairOrderModal
           open={editOrderOpen}
           onOpenChange={setEditOrderOpen}
           hairOrder={hairOrder}
-          loading={updateHairOrder.isPending}
-          onSave={(values) => updateHairOrder.mutate(values)}
+          loading={updateOrderPending}
+          onSave={(values) => {
+            onUpdateOrder(values)
+            setEditOrderOpen(false)
+          }}
         />
       </Stack>
     </Container>

--- a/apps/web/src/routes/_authenticated/hair-orders/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/-components/index-page.tsx
@@ -1,38 +1,55 @@
+import type { ComponentProps } from "react"
+
 import { Button, Container, Group, Modal, NumberInput, Select, Stack, Table, Text } from "@mantine/core"
 import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
 import { IconPlus } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { HairOrdersTable } from "@/components/hair-orders-table"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { type SelectOption, withPinnedOption } from "@/lib/resource-pagination"
-import { trpc } from "@/utils/trpc"
 
-import { useCreateHairOrderAction } from "../-actions/hair-order-actions"
+type CustomerOptionsData = { items: { id: string; name: string }[] }
+type HairOrderListData = {
+  items: ComponentProps<typeof HairOrdersTable>["hairOrders"]
+  totalCount: number
+}
+type HairOrderCreateValues = {
+  customerId: string
+  placedAt: string | null
+  arrivedAt: string | null
+  status: "PENDING"
+  weightReceived: number
+  weightUsed: number
+  total: number
+}
 
-const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
-const HAIR_ORDERS_PAGE_SIZE = 25
-
-function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
-  const [customerSearch, setCustomerSearch] = useState("")
+function CreateHairOrderDialog({
+  open,
+  onOpenChange,
+  customerSearch,
+  customersData,
+  loading,
+  onCustomerSearchChange,
+  onCreate,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  customerSearch: string
+  customersData: CustomerOptionsData | undefined
+  loading: boolean
+  onCustomerSearchChange: (search: string) => void
+  onCreate: (values: HairOrderCreateValues) => Promise<unknown>
+}) {
   const [selectedCustomerOption, setSelectedCustomerOption] = useState<SelectOption | null>(null)
 
-  const { data: customersData } = useQuery(
-    trpc.customers.list.queryOptions({
-      ...defaultCustomersListInput,
-      search: customerSearch.trim() || undefined,
-    }),
-  )
   const customers = customersData?.items ?? []
   const customerOptions = withPinnedOption(
     customers.map((c) => ({ value: c.id, label: c.name })),
     selectedCustomerOption,
   )
-  const mutation = useCreateHairOrderAction({ onCreated: () => onOpenChange(false) })
-
   const form = useForm({
     initialValues: { customerId: "", placedAt: "", weightReceived: 0, total: 0 },
   })
@@ -43,7 +60,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
     weightReceived: number
     total: number
   }) => {
-    await mutation.mutateAsync({
+    await onCreate({
       customerId: values.customerId,
       placedAt: values.placedAt || null,
       arrivedAt: null,
@@ -52,6 +69,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
       weightUsed: 0,
       total: Math.round(values.total * 100),
     })
+    onOpenChange(false)
   }
 
   return (
@@ -63,7 +81,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
             placeholder="Select a customer..."
             searchable
             searchValue={customerSearch}
-            onSearchChange={setCustomerSearch}
+            onSearchChange={onCustomerSearchChange}
             data={customerOptions}
             value={form.values.customerId}
             onChange={(value) => {
@@ -78,7 +96,7 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
             <NumberInput label="Weight (g)" min={0} {...form.getInputProps("weightReceived")} />
             <NumberInput label="Total" min={0} decimalScale={2} step={0.01} {...form.getInputProps("total")} />
           </Group>
-          <Button type="submit" loading={mutation.isPending}>
+          <Button type="submit" loading={loading}>
             Create Hair Order
           </Button>
         </Stack>
@@ -87,16 +105,34 @@ function CreateHairOrderDialog({ open, onOpenChange }: { open: boolean; onOpenCh
   )
 }
 
-export function HairOrdersPage() {
+export function HairOrdersPage({
+  page,
+  pageSize,
+  hairOrdersData,
+  isLoading,
+  customerSearch,
+  customersData,
+  createPending,
+  onPageChange,
+  onCustomerSearchChange,
+  onCreateHairOrder,
+}: {
+  page: number
+  pageSize: number
+  hairOrdersData: HairOrderListData | undefined
+  isLoading: boolean
+  customerSearch: string
+  customersData: CustomerOptionsData | undefined
+  createPending: boolean
+  onPageChange: (page: number) => void
+  onCustomerSearchChange: (search: string) => void
+  onCreateHairOrder: (values: HairOrderCreateValues) => Promise<unknown>
+}) {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [page, setPage] = useState(1)
-  const { data: hairOrdersData, isLoading } = useQuery(
-    trpc.hairOrders.list.queryOptions({ page, pageSize: HAIR_ORDERS_PAGE_SIZE }),
-  )
   const hairOrders = hairOrdersData?.items ?? []
   const totalCount = hairOrdersData?.totalCount ?? 0
-  const totalPages = Math.max(1, Math.ceil(totalCount / HAIR_ORDERS_PAGE_SIZE))
-  const showPagination = totalCount > HAIR_ORDERS_PAGE_SIZE
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+  const showPagination = totalCount > pageSize
 
   return (
     <Container size="xl">
@@ -119,14 +155,10 @@ export function HairOrdersPage() {
               {totalCount} hair order{totalCount === 1 ? "" : "s"} · Page {Math.min(page, totalPages)} of {totalPages}
             </Text>
             <Group gap="xs">
-              <Button
-                variant="default"
-                disabled={page <= 1}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-              >
+              <Button variant="default" disabled={page <= 1} onClick={() => onPageChange(Math.max(1, page - 1))}>
                 Previous
               </Button>
-              <Button variant="default" disabled={page >= totalPages} onClick={() => setPage((current) => current + 1)}>
+              <Button variant="default" disabled={page >= totalPages} onClick={() => onPageChange(page + 1)}>
                 Next
               </Button>
             </Group>
@@ -134,7 +166,15 @@ export function HairOrdersPage() {
         )}
       </Section>
 
-      <CreateHairOrderDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      <CreateHairOrderDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        customerSearch={customerSearch}
+        customersData={customersData}
+        loading={createPending}
+        onCustomerSearchChange={onCustomerSearchChange}
+        onCreate={onCreateHairOrder}
+      />
     </Container>
   )
 }

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -11,10 +11,10 @@ const hairOrdersPageSize = 25
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
 export const Route = createFileRoute("/_authenticated/hair-orders/")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const [page, setPage] = useState(1)
   const [customerSearch, setCustomerSearch] = useState("")
   const hairOrdersQuery = useQuery(trpc.hairOrders.list.queryOptions({ page, pageSize: hairOrdersPageSize }))

--- a/apps/web/src/routes/_authenticated/hair-orders/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/index.tsx
@@ -1,7 +1,43 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
+import { trpc } from "@/utils/trpc"
+
+import { useCreateHairOrderAction } from "./-actions/hair-order-actions"
 import { HairOrdersPage } from "./-components/index-page"
 
+const hairOrdersPageSize = 25
+const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
+
 export const Route = createFileRoute("/_authenticated/hair-orders/")({
-  component: HairOrdersPage,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const [page, setPage] = useState(1)
+  const [customerSearch, setCustomerSearch] = useState("")
+  const hairOrdersQuery = useQuery(trpc.hairOrders.list.queryOptions({ page, pageSize: hairOrdersPageSize }))
+  const customersData = useQuery(
+    trpc.customers.list.queryOptions({
+      ...defaultCustomersListInput,
+      search: customerSearch.trim() || undefined,
+    }),
+  ).data
+  const createHairOrder = useCreateHairOrderAction({})
+
+  return (
+    <HairOrdersPage
+      page={page}
+      pageSize={hairOrdersPageSize}
+      hairOrdersData={hairOrdersQuery.data}
+      isLoading={hairOrdersQuery.isLoading}
+      customerSearch={customerSearch}
+      customersData={customersData}
+      createPending={createHairOrder.isPending}
+      onPageChange={setPage}
+      onCustomerSearchChange={setCustomerSearch}
+      onCreateHairOrder={(values) => createHairOrder.mutateAsync(values)}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
@@ -6,13 +6,13 @@ import { trpc } from "@/utils/trpc"
 import { HairSaleDetailPage } from "./-components/hair-sale-id-page"
 
 export const Route = createFileRoute("/_authenticated/hair-sales/$hairSaleId")({
-  component: routeComponent,
+  component: RouteComponent,
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData(trpc.hairAssigned.get.queryOptions({ id: params.hairSaleId }))
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { hairSaleId } = Route.useParams()
   const sale = useQuery(trpc.hairAssigned.get.queryOptions({ id: hairSaleId })).data
 

--- a/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/$hairSaleId.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 
 import { trpc } from "@/utils/trpc"
@@ -5,8 +6,15 @@ import { trpc } from "@/utils/trpc"
 import { HairSaleDetailPage } from "./-components/hair-sale-id-page"
 
 export const Route = createFileRoute("/_authenticated/hair-sales/$hairSaleId")({
-  component: HairSaleDetailPage,
+  component: routeComponent,
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData(trpc.hairAssigned.get.queryOptions({ id: params.hairSaleId }))
   },
 })
+
+function routeComponent() {
+  const { hairSaleId } = Route.useParams()
+  const sale = useQuery(trpc.hairAssigned.get.queryOptions({ id: hairSaleId })).data
+
+  return <HairSaleDetailPage sale={sale} />
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/-components/hair-sale-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/-components/hair-sale-id-page.tsx
@@ -1,22 +1,29 @@
 import { Anchor, Badge, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
 import { IconCalendar, IconScissors, IconUser } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { ClientDate } from "@/components/client-date"
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
-import { trpc } from "@/utils/trpc"
-
-import { Route } from "../$hairSaleId"
 
 const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 
-export function HairSaleDetailPage() {
-  const { hairSaleId } = Route.useParams()
-  const { data: sale } = useQuery(trpc.hairAssigned.get.queryOptions({ id: hairSaleId }))
+type HairSaleDetail = {
+  id: string
+  appointmentId: string | null
+  createdAt: string | Date
+  weightInGrams: number
+  soldFor: number
+  profit: number
+  pricePerGram: number
+  client: { id: string; name: string }
+  createdBy?: { name: string | null } | null
+  hairOrder: { id: string; uid: number }
+  appointment?: { startsAt: string | Date } | null
+}
 
+export function HairSaleDetailPage({ sale }: { sale: HairSaleDetail | undefined }) {
   if (!sale) {
     return (
       <Container size="xl">

--- a/apps/web/src/routes/_authenticated/hair-sales/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/-components/index-page.tsx
@@ -13,7 +13,6 @@ import {
 } from "@mantine/core"
 import { MonthPickerInput } from "@mantine/dates"
 import { IconEye, IconSearch } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { ClientDate } from "@/components/client-date"
@@ -21,8 +20,7 @@ import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { dateFromMonthKey, monthKeyFromDate } from "@/lib/dashboard-monthly-stats"
 
-import { hairSalesQueryOptions, type HairSalesSource, PAGE_SIZE } from "../-data/index-data"
-import { Route } from "../index"
+import { type HairSalesSource, PAGE_SIZE } from "../-data/index-data"
 
 type HairSale = {
   id: string
@@ -39,32 +37,28 @@ type HairSale = {
 
 const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 
-export function HairSalesPage() {
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const page = search.page ?? 1
-  const searchValue = search.search ?? ""
-  const source = search.source ?? "all"
-  const month = search.month
+export function HairSalesPage({
+  page,
+  searchValue,
+  source,
+  month,
+  data,
+  isLoading,
+  onSearchChange,
+}: {
+  page: number
+  searchValue: string
+  source: HairSalesSource
+  month: string | undefined
+  data: { items: HairSale[]; totalCount: number } | undefined
+  isLoading: boolean
+  onSearchChange: (next: Partial<{ page: number; search: string; source: HairSalesSource; month?: string }>) => void
+}) {
   const monthDate = month ? dateFromMonthKey(month) : null
-  const queryOptions = hairSalesQueryOptions({ page, search: searchValue, source, month })
-  const { data, isLoading } = useQuery(queryOptions)
-  const hairSales = (data?.items ?? []) as HairSale[]
+  const hairSales = data?.items ?? []
   const totalCount = data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const clampedPage = Math.min(page, totalPages)
-
-  const setSearch = (next: Partial<{ page: number; search: string; source: HairSalesSource; month?: string }>) =>
-    navigate({
-      search: {
-        page,
-        search: searchValue,
-        source,
-        month,
-        ...next,
-      },
-      replace: true,
-    })
 
   return (
     <Container size="xl">
@@ -77,7 +71,7 @@ export function HairSalesPage() {
           <Group p="md" gap="sm" wrap="wrap">
             <SegmentedControl
               value={source}
-              onChange={(value) => setSearch({ page: 1, source: value as HairSalesSource })}
+              onChange={(value) => onSearchChange({ page: 1, source: value as HairSalesSource })}
               data={[
                 { value: "all", label: "All" },
                 { value: "appointment", label: "Appointment" },
@@ -88,7 +82,9 @@ export function HairSalesPage() {
               aria-label="Filter hair sales by month"
               placeholder="All months"
               value={monthDate}
-              onChange={(value) => setSearch({ page: 1, month: value ? monthKeyFromDate(new Date(value)) : undefined })}
+              onChange={(value) =>
+                onSearchChange({ page: 1, month: value ? monthKeyFromDate(new Date(value)) : undefined })
+              }
               valueFormat="MMMM YYYY"
               clearable
               popoverProps={{ withinPortal: false }}
@@ -99,7 +95,7 @@ export function HairSalesPage() {
               placeholder="Search client or order"
               leftSection={<IconSearch size={16} />}
               value={searchValue}
-              onChange={(event) => setSearch({ page: 1, search: event.currentTarget.value })}
+              onChange={(event) => onSearchChange({ page: 1, search: event.currentTarget.value })}
               w={260}
             />
           </Group>
@@ -187,7 +183,11 @@ export function HairSalesPage() {
             <Text size="sm" c="dimmed">
               {totalCount} hair sale{totalCount === 1 ? "" : "s"} · Page {clampedPage} of {totalPages}
             </Text>
-            <Pagination value={clampedPage} total={totalPages} onChange={(nextPage) => setSearch({ page: nextPage })} />
+            <Pagination
+              value={clampedPage}
+              total={totalPages}
+              onChange={(nextPage) => onSearchChange({ page: nextPage })}
+            />
           </Group>
         </Stack>
       </Section>

--- a/apps/web/src/routes/_authenticated/hair-sales/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/index.tsx
@@ -1,10 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { HairSalesPage } from "./-components/index-page"
-import { hairSalesQueryOptions, PAGE_SIZE, searchSchema } from "./-data/index-data"
+import { type HairSalesSource, hairSalesQueryOptions, PAGE_SIZE, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/hair-sales/")({
-  component: HairSalesPage,
+  component: routeComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -23,3 +24,37 @@ export const Route = createFileRoute("/_authenticated/hair-sales/")({
     }
   },
 })
+
+function routeComponent() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const page = search.page ?? 1
+  const searchValue = search.search ?? ""
+  const source = search.source ?? "all"
+  const month = search.month
+  const query = useQuery(hairSalesQueryOptions({ page, search: searchValue, source, month }))
+
+  const setSearch = (next: Partial<{ page: number; search: string; source: HairSalesSource; month?: string }>) =>
+    navigate({
+      search: {
+        page,
+        search: searchValue,
+        source,
+        month,
+        ...next,
+      },
+      replace: true,
+    })
+
+  return (
+    <HairSalesPage
+      page={page}
+      searchValue={searchValue}
+      source={source}
+      month={month}
+      data={query.data}
+      isLoading={query.isLoading}
+      onSearchChange={setSearch}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/hair-sales/index.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/index.tsx
@@ -5,7 +5,7 @@ import { HairSalesPage } from "./-components/index-page"
 import { type HairSalesSource, hairSalesQueryOptions, PAGE_SIZE, searchSchema } from "./-data/index-data"
 
 export const Route = createFileRoute("/_authenticated/hair-sales/")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({
     page: search.page ?? 1,
@@ -25,7 +25,7 @@ export const Route = createFileRoute("/_authenticated/hair-sales/")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const page = search.page ?? 1

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/overview-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/overview-page.tsx
@@ -1,25 +1,23 @@
+import type { ComponentProps } from "react"
+
 import { Group, NumberInput, Stack, Text, Title } from "@mantine/core"
-import { useQuery } from "@tanstack/react-query"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { BankAccountReportBlock } from "@/components/reports-cards"
-import { trpc } from "@/utils/trpc"
 
-import { Route } from "../overview"
+type BankAccountReport = ComponentProps<typeof BankAccountReportBlock>["a"]
 
-export function OverviewTab() {
-  const { legalEntityId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
-  const currentYear = new Date().getFullYear()
-  const year = search.year ?? currentYear
-
-  const setYear = (next: number) => navigate({ search: { year: next } })
-
-  const { data: bankAccounts = [] } = useQuery(
-    trpc.reports.bankAccountMonthlyBreakdown.queryOptions({ year, legalEntityId }),
-  )
-
+export function OverviewTab({
+  year,
+  currentYear,
+  bankAccounts,
+  onYearChange,
+}: {
+  year: number
+  currentYear: number
+  bankAccounts: BankAccountReport[]
+  onYearChange: (year: number) => void
+}) {
   return (
     <Stack gap="lg">
       <BreadcrumbItem label="Overview" order={30} />
@@ -34,7 +32,7 @@ export function OverviewTab() {
         </Stack>
         <NumberInput
           value={year}
-          onChange={(v) => setYear(typeof v === "number" ? v : Number(v) || currentYear)}
+          onChange={(v) => onYearChange(typeof v === "number" ? v : Number(v) || currentYear)}
           min={2000}
           max={3000}
           allowDecimal={false}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/route-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/route-page.tsx
@@ -2,7 +2,6 @@ import { Anchor, Box, Button, Container, Group, Modal, Select, Stack, Tabs, Text
 import { useForm } from "@mantine/form"
 import { useDisclosure } from "@mantine/hooks"
 import { IconArrowLeft, IconPencil } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
 import { Link, Outlet, useLocation } from "@tanstack/react-router"
 import { TRPCClientError } from "@trpc/client"
 import { zodResolver } from "mantine-form-zod-resolver"
@@ -17,25 +16,42 @@ import {
   getLegalEntitySectionPath,
 } from "@/lib/legal-entity-navigation"
 import { legalEntityUpdateSchema } from "@/lib/schemas"
-import { trpc } from "@/utils/trpc"
 
-import { useUpdateLegalEntityAction } from "../-actions/legal-entity-actions"
 import { Route } from "../route"
 
-export function LegalEntityLayout() {
+type LegalEntity = {
+  id: string
+  name: string
+  type: string
+  country: string
+  defaultCurrency: string
+  registrationNumber: string | null
+  vatNumber: string | null
+}
+type LegalEntityQuery = {
+  data: LegalEntity | undefined
+  isError: boolean
+  error: unknown
+}
+
+export function LegalEntityLayout({
+  legalEntityQuery,
+  legalEntities,
+  savePending,
+  onSaveLegalEntity,
+}: {
+  legalEntityQuery: LegalEntityQuery
+  legalEntities: Pick<LegalEntity, "id" | "name">[]
+  savePending: boolean
+  onSaveLegalEntity: (values: EditValues & { id: string }) => Promise<unknown>
+}) {
   const { legalEntityId } = Route.useParams()
   const navigate = Route.useNavigate()
   const location = useLocation()
   const activeSection = getLegalEntitySectionFromPath(location.pathname)
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
 
-  const legalEntityQuery = useQuery({
-    ...trpc.legalEntities.get.queryOptions({ id: legalEntityId }),
-    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
-  })
   const legalEntity = legalEntityQuery.data
-  const { data: legalEntitiesData } = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
-  const legalEntities = legalEntitiesData?.items ?? []
   const country = legalEntity?.country as Country | undefined
   const description = legalEntity
     ? `${legalEntity.type}${country ? ` · ${COUNTRY_FLAGS[country]} ${COUNTRY_LABELS[country]}` : ""} · ${legalEntity.defaultCurrency}`
@@ -152,6 +168,8 @@ export function LegalEntityLayout() {
               }
             : null
         }
+        savePending={savePending}
+        onSave={onSaveLegalEntity}
       />
     </Container>
   )
@@ -172,17 +190,28 @@ function EditLegalEntityModal({
   onClose,
   legalEntityId,
   initial,
+  savePending,
+  onSave,
 }: {
   opened: boolean
   onClose: () => void
   legalEntityId: string
   initial: EditValues | null
+  savePending: boolean
+  onSave: (values: EditValues & { id: string }) => Promise<unknown>
 }) {
   const initialValues = initial && { id: legalEntityId, ...initial }
 
   return (
     <Modal opened={opened} onClose={onClose} title="Edit legal entity">
-      {opened && initialValues && <EditLegalEntityForm initialValues={initialValues} onClose={onClose} />}
+      {opened && initialValues && (
+        <EditLegalEntityForm
+          initialValues={initialValues}
+          onClose={onClose}
+          savePending={savePending}
+          onSave={onSave}
+        />
+      )}
     </Modal>
   )
 }
@@ -190,19 +219,26 @@ function EditLegalEntityModal({
 function EditLegalEntityForm({
   initialValues,
   onClose,
+  savePending,
+  onSave,
 }: {
   initialValues: EditValues & { id: string }
   onClose: () => void
+  savePending: boolean
+  onSave: (values: EditValues & { id: string }) => Promise<unknown>
 }) {
   const form = useForm<EditValues & { id: string }>({
     initialValues,
     validate: zodResolver(legalEntityUpdateSchema),
   })
 
-  const save = useUpdateLegalEntityAction({ legalEntityId: initialValues.id, onUpdated: onClose })
-
   return (
-    <form onSubmit={form.onSubmit((values) => save.mutate(values))}>
+    <form
+      onSubmit={form.onSubmit(async (values) => {
+        await onSave(values)
+        onClose()
+      })}
+    >
       <Stack>
         <TextInput label="Name" required {...form.getInputProps("name")} />
         <TextInput
@@ -215,7 +251,7 @@ function EditLegalEntityForm({
           <Button variant="subtle" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" loading={save.isPending}>
+          <Button type="submit" loading={savePending}>
             Save
           </Button>
         </Group>

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/salons-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/-components/salons-page.tsx
@@ -1,16 +1,13 @@
+import type { ComponentProps } from "react"
+
 import { Button } from "@mantine/core"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { SalonsTable } from "@/components/salons-table"
 import { Section } from "@/components/section"
-import { trpc } from "@/utils/trpc"
 
-export function SalonsTab() {
-  const { data: salonsData } = useQuery(trpc.salons.list.queryOptions({ pageSize: 100 }))
-  const salons = salonsData?.items ?? []
-
+export function SalonsTab({ salons }: { salons: ComponentProps<typeof SalonsTable>["salons"] }) {
   return (
     <>
       <BreadcrumbItem label="Salons" order={30} />

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -12,10 +12,10 @@ import {
 import { BankAccountPage, STATEMENT_ENTRIES_PAGE_SIZE, type StatusFilter } from "./-components/bank-account-id-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { bankAccountId, legalEntityId } = Route.useParams()
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("PENDING")
   const [openAttachmentEntryId, setOpenAttachmentEntryId] = useState<string | null>(null)

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId.tsx
@@ -1,7 +1,100 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
 
-import { BankAccountRoute } from "./-components/bank-account-id-page"
+import { trpc } from "@/utils/trpc"
+
+import {
+  useBankAccountActions,
+  useBankEntryAttachmentActions,
+  useBankStatementEntryActions,
+} from "./-actions/bank-account-actions"
+import { BankAccountPage, STATEMENT_ENTRIES_PAGE_SIZE, type StatusFilter } from "./-components/bank-account-id-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId")({
-  component: BankAccountRoute,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { bankAccountId, legalEntityId } = Route.useParams()
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("PENDING")
+  const [openAttachmentEntryId, setOpenAttachmentEntryId] = useState<string | null>(null)
+  const [entriesPage, setEntriesPage] = useState(1)
+  const legalEntitiesData = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 })).data
+  const bankAccount = useQuery({
+    ...trpc.bankAccounts.get.queryOptions({ id: bankAccountId }),
+    enabled: bankAccountId !== "new",
+  }).data
+  const statementEntriesData = useQuery({
+    ...trpc.bankStatementEntries.list.queryOptions({
+      bankAccountId,
+      status: statusFilter === "ALL" ? undefined : statusFilter,
+      page: entriesPage,
+      pageSize: STATEMENT_ENTRIES_PAGE_SIZE,
+    }),
+    enabled: bankAccountId !== "new",
+  }).data
+  const attachmentCounts = useQuery(trpc.bankStatementAttachments.counts.queryOptions()).data
+  const attachmentsQuery = useQuery({
+    ...trpc.bankStatementAttachments.list.queryOptions({ entryId: openAttachmentEntryId ?? "", pageSize: 100 }),
+    enabled: !!openAttachmentEntryId,
+  })
+  const unassignedAttachmentsData = useQuery({
+    ...trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned", pageSize: 100 }),
+    enabled: !!openAttachmentEntryId,
+  }).data
+  const navigate = Route.useNavigate()
+  const { create, update } = useBankAccountActions({
+    bankAccountId: bankAccountId === "new" ? undefined : bankAccountId,
+    onCreated: (values) => {
+      navigate({
+        to: "/legal-entities/$legalEntityId/bank-accounts",
+        params: { legalEntityId: values.legalEntityId },
+      })
+    },
+  })
+  const { importCsv, ignore, undo } = useBankStatementEntryActions({
+    onStatusChanged: () => setEntriesPage(1),
+  })
+  const { assign, remove, unassign, upload } = useBankEntryAttachmentActions()
+
+  return (
+    <BankAccountPage
+      bankAccountId={bankAccountId}
+      legalEntityId={legalEntityId}
+      legalEntities={legalEntitiesData?.items ?? []}
+      bankAccount={bankAccount}
+      statementEntriesData={statementEntriesData}
+      attachmentCounts={attachmentCounts}
+      attachmentsData={attachmentsQuery.data}
+      attachmentsLoading={attachmentsQuery.isLoading}
+      unassignedAttachmentsData={unassignedAttachmentsData}
+      statusFilter={statusFilter}
+      openAttachmentEntryId={openAttachmentEntryId}
+      entriesPage={entriesPage}
+      onStatusFilterChange={(nextStatus) => {
+        setStatusFilter(nextStatus)
+        setEntriesPage(1)
+      }}
+      onOpenAttachmentEntryChange={setOpenAttachmentEntryId}
+      onEntriesPageChange={setEntriesPage}
+      createPending={create.isPending}
+      updatePending={update.isPending}
+      importPending={importCsv.isPending}
+      ignorePending={ignore.isPending}
+      undoPending={undo.isPending}
+      assignPending={assign.isPending}
+      removePending={remove.isPending}
+      unassignPending={unassign.isPending}
+      onCreate={(values) => create.mutate(values)}
+      onUpdate={(values) => update.mutate(values)}
+      onImportCsv={(csv) => importCsv.mutateAsync({ csv })}
+      onIgnore={(id) => ignore.mutate({ id })}
+      onUndo={(id) => undo.mutate({ id })}
+      onAssign={(id, entryId) => assign.mutate({ id, entryId })}
+      onRemove={(id) => remove.mutate({ id })}
+      onUnassign={(id) => unassign.mutate({ id })}
+      onUploadAttachment={(file, entryId) => upload(file, entryId)}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/-components/bank-account-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/-components/bank-account-id-page.tsx
@@ -19,57 +19,219 @@ import { MonthPickerInput } from "@mantine/dates"
 import { useDisclosure } from "@mantine/hooks"
 import { notifications } from "@mantine/notifications"
 import { IconDotsVertical, IconDownload } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
 import { AttachmentPreviewDialog, type AttachmentPreview } from "@/components/attachment-preview-dialog"
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { type Currency, formatMinor } from "@/lib/currency"
-import { trpc } from "@/utils/trpc"
 
-import { Route } from "../$bankAccountId"
-import {
-  useBankAccountActions,
-  useBankEntryAttachmentActions,
-  useBankStatementEntryActions,
-} from "../-actions/bank-account-actions"
+import { type BankAccountFormValues } from "../-actions/bank-account-actions"
 import { AttachmentsCell } from "./attachments-cell"
 import { Field } from "./bank-account-fields"
 import { BankAccountNewForm, EditBankAccountModal } from "./bank-account-form-modals"
 
-const STATEMENT_ENTRIES_PAGE_SIZE = 25
+export const STATEMENT_ENTRIES_PAGE_SIZE = 25
 
-export function BankAccountRoute() {
-  const { bankAccountId, legalEntityId } = Route.useParams()
-  const navigate = useNavigate()
-  const { data: legalEntitiesData } = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
-  const legalEntities = legalEntitiesData?.items ?? []
-  const { create } = useBankAccountActions({
-    onCreated: (values) => {
-      navigate({
-        to: "/legal-entities/$legalEntityId/bank-accounts",
-        params: { legalEntityId: values.legalEntityId },
-      })
-    },
-  })
+type LegalEntityOption = { id: string; name: string }
+type AttachmentRow = { attachment: AttachmentPreview }
+type StatementEntry = {
+  id: string
+  date: string
+  amount: number
+  currency: string
+  direction: string
+  counterpartyName: string | null
+  purpose: string | null
+  status: string
+  bankAccount?: { displayName: string | null } | null
+}
+type BankAccount = {
+  id: string
+  legalEntityId: string
+  iban: string
+  currency: string
+  bankName: string | null
+  swift: string | null
+  displayName: string
+  legalEntity?: { id: string; name: string } | null
+}
+export type StatusFilter = "PENDING" | "IGNORED" | "ALL"
 
+export function BankAccountPage({
+  bankAccountId,
+  legalEntityId,
+  legalEntities,
+  bankAccount,
+  statementEntriesData,
+  attachmentCounts,
+  attachmentsData,
+  attachmentsLoading,
+  unassignedAttachmentsData,
+  statusFilter,
+  openAttachmentEntryId,
+  entriesPage,
+  onStatusFilterChange,
+  onOpenAttachmentEntryChange,
+  onEntriesPageChange,
+  createPending,
+  updatePending,
+  importPending,
+  ignorePending,
+  undoPending,
+  assignPending,
+  removePending,
+  unassignPending,
+  onCreate,
+  onUpdate,
+  onImportCsv,
+  onIgnore,
+  onUndo,
+  onAssign,
+  onRemove,
+  onUnassign,
+  onUploadAttachment,
+}: {
+  bankAccountId: string
+  legalEntityId: string
+  legalEntities: LegalEntityOption[]
+  bankAccount: BankAccount | undefined
+  statementEntriesData: { items: StatementEntry[]; totalCount: number } | undefined
+  attachmentCounts: Record<string, number> | undefined
+  attachmentsData: { items: AttachmentRow[] } | undefined
+  attachmentsLoading: boolean
+  unassignedAttachmentsData: { items: AttachmentRow[] } | undefined
+  statusFilter: StatusFilter
+  openAttachmentEntryId: string | null
+  entriesPage: number
+  onStatusFilterChange: (status: StatusFilter) => void
+  onOpenAttachmentEntryChange: (entryId: string | null) => void
+  onEntriesPageChange: (page: number) => void
+  createPending: boolean
+  updatePending: boolean
+  importPending: boolean
+  ignorePending: boolean
+  undoPending: boolean
+  assignPending: boolean
+  removePending: boolean
+  unassignPending: boolean
+  onCreate: (values: BankAccountFormValues) => void
+  onUpdate: (values: BankAccountFormValues & { id: string }) => void
+  onImportCsv: (csv: string) => Promise<{ accountIban: string; total: number; inserted: number; skipped: number }>
+  onIgnore: (id: string) => void
+  onUndo: (id: string) => void
+  onAssign: (id: string, entryId: string) => void
+  onRemove: (id: string) => void
+  onUnassign: (id: string) => void
+  onUploadAttachment: (file: File, entryId: string) => Promise<unknown>
+}) {
   return bankAccountId === "new" ? (
     <BankAccountNewForm
       pathLegalEntityId={legalEntityId}
       legalEntities={legalEntities}
-      loading={create.isPending}
-      onSubmit={(values) => create.mutate(values)}
+      loading={createPending}
+      onSubmit={onCreate}
     />
   ) : (
-    <BankAccountShow key={bankAccountId} id={bankAccountId} legalEntities={legalEntities} />
+    <BankAccountShow
+      key={bankAccountId}
+      id={bankAccountId}
+      legalEntityId={legalEntityId}
+      legalEntities={legalEntities}
+      bankAccount={bankAccount}
+      statementEntriesData={statementEntriesData}
+      attachmentCounts={attachmentCounts}
+      attachmentsData={attachmentsData}
+      attachmentsLoading={attachmentsLoading}
+      unassignedAttachmentsData={unassignedAttachmentsData}
+      statusFilter={statusFilter}
+      openAttachmentEntryId={openAttachmentEntryId}
+      entriesPage={entriesPage}
+      onStatusFilterChange={onStatusFilterChange}
+      onOpenAttachmentEntryChange={onOpenAttachmentEntryChange}
+      onEntriesPageChange={onEntriesPageChange}
+      updatePending={updatePending}
+      importPending={importPending}
+      ignorePending={ignorePending}
+      undoPending={undoPending}
+      assignPending={assignPending}
+      removePending={removePending}
+      unassignPending={unassignPending}
+      onUpdate={onUpdate}
+      onImportCsv={onImportCsv}
+      onIgnore={onIgnore}
+      onUndo={onUndo}
+      onAssign={onAssign}
+      onRemove={onRemove}
+      onUnassign={onUnassign}
+      onUploadAttachment={onUploadAttachment}
+    />
   )
 }
 
-type StatusFilter = "PENDING" | "IGNORED" | "ALL"
-
-function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Array<{ id: string; name: string }> }) {
-  const { legalEntityId } = Route.useParams()
+function BankAccountShow({
+  id,
+  legalEntityId,
+  legalEntities,
+  bankAccount,
+  statementEntriesData,
+  attachmentCounts,
+  attachmentsData,
+  attachmentsLoading,
+  unassignedAttachmentsData,
+  statusFilter,
+  openAttachmentEntryId,
+  entriesPage,
+  onStatusFilterChange,
+  onOpenAttachmentEntryChange,
+  onEntriesPageChange,
+  updatePending,
+  importPending,
+  ignorePending,
+  undoPending,
+  assignPending,
+  removePending,
+  unassignPending,
+  onUpdate,
+  onImportCsv,
+  onIgnore,
+  onUndo,
+  onAssign,
+  onRemove,
+  onUnassign,
+  onUploadAttachment,
+}: {
+  id: string
+  legalEntityId: string
+  legalEntities: LegalEntityOption[]
+  bankAccount: BankAccount | undefined
+  statementEntriesData: { items: StatementEntry[]; totalCount: number } | undefined
+  attachmentCounts: Record<string, number> | undefined
+  attachmentsData: { items: AttachmentRow[] } | undefined
+  attachmentsLoading: boolean
+  unassignedAttachmentsData: { items: AttachmentRow[] } | undefined
+  statusFilter: StatusFilter
+  openAttachmentEntryId: string | null
+  entriesPage: number
+  onStatusFilterChange: (status: StatusFilter) => void
+  onOpenAttachmentEntryChange: (entryId: string | null) => void
+  onEntriesPageChange: (page: number) => void
+  updatePending: boolean
+  importPending: boolean
+  ignorePending: boolean
+  undoPending: boolean
+  assignPending: boolean
+  removePending: boolean
+  unassignPending: boolean
+  onUpdate: (values: BankAccountFormValues & { id: string }) => void
+  onImportCsv: (csv: string) => Promise<{ accountIban: string; total: number; inserted: number; skipped: number }>
+  onIgnore: (id: string) => void
+  onUndo: (id: string) => void
+  onAssign: (id: string, entryId: string) => void
+  onRemove: (id: string) => void
+  onUnassign: (id: string) => void
+  onUploadAttachment: (file: File, entryId: string) => Promise<unknown>
+}) {
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false)
   const [file, setFile] = useState<File | null>(null)
   const [importResult, setImportResult] = useState<{
@@ -78,64 +240,33 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
     inserted: number
     skipped: number
   } | null>(null)
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("PENDING")
   const [exportMonth, setExportMonth] = useState<Date | null>(() => {
     const d = new Date()
     return new Date(d.getFullYear(), d.getMonth(), 1)
   })
   const [previewAttachment, setPreviewAttachment] = useState<AttachmentPreview | null>(null)
-  const [openAttachmentEntryId, setOpenAttachmentEntryId] = useState<string | null>(null)
   const [uploadingAttachmentEntryId, setUploadingAttachmentEntryId] = useState<string | null>(null)
-  const [entriesPage, setEntriesPage] = useState(1)
-
-  const bankAccountQueryOptions = trpc.bankAccounts.get.queryOptions({ id })
-  const statementEntriesQueryOptions = trpc.bankStatementEntries.list.queryOptions({
-    bankAccountId: id,
-    status: statusFilter === "ALL" ? undefined : statusFilter,
-    page: entriesPage,
-    pageSize: STATEMENT_ENTRIES_PAGE_SIZE,
-  })
-  const { data: bankAccount } = useQuery(bankAccountQueryOptions)
-
-  const { data: statementEntriesData } = useQuery(statementEntriesQueryOptions)
   const entries = statementEntriesData?.items ?? []
   const entriesTotalCount = statementEntriesData?.totalCount ?? 0
   const entriesTotalPages = Math.max(1, Math.ceil(entriesTotalCount / STATEMENT_ENTRIES_PAGE_SIZE))
   const showEntriesPagination = entriesTotalCount > STATEMENT_ENTRIES_PAGE_SIZE
 
-  const { data: attachmentCounts } = useQuery(trpc.bankStatementAttachments.counts.queryOptions())
-  const { data: attachmentsData, isLoading: attachmentsLoading } = useQuery({
-    ...trpc.bankStatementAttachments.list.queryOptions({ entryId: openAttachmentEntryId ?? "", pageSize: 100 }),
-    enabled: !!openAttachmentEntryId,
-  })
   const attachments = attachmentsData?.items.map((row) => row.attachment) ?? []
-  const { data: unassignedAttachmentsData } = useQuery({
-    ...trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned", pageSize: 100 }),
-    enabled: !!openAttachmentEntryId,
-  })
   const unassignedAttachments = unassignedAttachmentsData?.items.map((row) => row.attachment) ?? []
-
-  const { importCsv, ignore, undo } = useBankStatementEntryActions({
-    onImported: (result) => {
-      setImportResult(result)
-      setFile(null)
-      setEntriesPage(1)
-    },
-    onStatusChanged: () => setEntriesPage(1),
-  })
-  const { update } = useBankAccountActions({ bankAccountId: id, onUpdated: closeEdit })
-  const { assign, remove, unassign, upload: uploadAttachment } = useBankEntryAttachmentActions()
 
   const handleUpload = async () => {
     if (!file) return
     const text = await file.text()
-    importCsv.mutate({ csv: text })
+    const result = await onImportCsv(text)
+    setImportResult(result)
+    setFile(null)
+    onEntriesPageChange(1)
   }
 
   const handleAttachmentUpload = async (file: File, entryId: string) => {
     setUploadingAttachmentEntryId(entryId)
     try {
-      await uploadAttachment(file, entryId)
+      await onUploadAttachment(file, entryId)
     } catch (err) {
       notifications.show({ color: "red", message: (err as Error).message })
     } finally {
@@ -196,7 +327,7 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
                 accept=".csv,text/csv"
                 w={400}
               />
-              <Button onClick={handleUpload} loading={importCsv.isPending} disabled={!file}>
+              <Button onClick={handleUpload} loading={importPending} disabled={!file}>
                 Import
               </Button>
             </Group>
@@ -219,8 +350,7 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
             ]}
             value={statusFilter}
             onChange={(v) => {
-              setStatusFilter((v as StatusFilter) ?? "PENDING")
-              setEntriesPage(1)
+              onStatusFilterChange((v as StatusFilter) ?? "PENDING")
             }}
             w={180}
           />
@@ -306,15 +436,15 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
                         attachments={openAttachmentEntryId === e.id ? attachments : []}
                         attachmentsLoading={openAttachmentEntryId === e.id && attachmentsLoading}
                         unassignedAttachments={openAttachmentEntryId === e.id ? unassignedAttachments : []}
-                        assignLoading={assign.isPending}
-                        removeLoading={remove.isPending}
-                        unassignLoading={unassign.isPending}
+                        assignLoading={assignPending}
+                        removeLoading={removePending}
+                        unassignLoading={unassignPending}
                         uploadLoading={uploadingAttachmentEntryId === e.id}
-                        onOpenChange={(opened) => setOpenAttachmentEntryId(opened ? e.id : null)}
+                        onOpenChange={(opened) => onOpenAttachmentEntryChange(opened ? e.id : null)}
                         onPreview={setPreviewAttachment}
-                        onAssign={(attachmentId) => assign.mutate({ id: attachmentId, entryId: e.id })}
-                        onRemove={(attachmentId) => remove.mutate({ id: attachmentId })}
-                        onUnassign={(attachmentId) => unassign.mutate({ id: attachmentId })}
+                        onAssign={(attachmentId) => onAssign(attachmentId, e.id)}
+                        onRemove={onRemove}
+                        onUnassign={onUnassign}
                         onUpload={(file) => void handleAttachmentUpload(file, e.id)}
                       />
                     </Table.Td>
@@ -327,11 +457,13 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
                         </Menu.Target>
                         <Menu.Dropdown>
                           {e.status === "PENDING" ? (
-                            <Menu.Item color="gray" onClick={() => ignore.mutate({ id: e.id })}>
+                            <Menu.Item color="gray" disabled={ignorePending} onClick={() => onIgnore(e.id)}>
                               Ignore
                             </Menu.Item>
                           ) : (
-                            <Menu.Item onClick={() => undo.mutate({ id: e.id })}>Undo ({e.status})</Menu.Item>
+                            <Menu.Item disabled={undoPending} onClick={() => onUndo(e.id)}>
+                              Undo ({e.status})
+                            </Menu.Item>
                           )}
                         </Menu.Dropdown>
                       </Menu>
@@ -357,7 +489,7 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
               <Pagination
                 total={entriesTotalPages}
                 value={Math.min(entriesPage, entriesTotalPages)}
-                onChange={setEntriesPage}
+                onChange={onEntriesPageChange}
               />
             </Group>
           )}
@@ -371,7 +503,7 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
           onClose={closeEdit}
           bankAccountId={id}
           legalEntities={legalEntities}
-          loading={update.isPending}
+          loading={updatePending}
           initial={{
             legalEntityId: bankAccount.legalEntityId,
             iban: bankAccount.iban,
@@ -380,7 +512,10 @@ function BankAccountShow({ id, legalEntities }: { id: string; legalEntities: Arr
             swift: bankAccount.swift ?? "",
             displayName: bankAccount.displayName,
           }}
-          onSubmit={(values) => update.mutate(values)}
+          onSubmit={(values) => {
+            onUpdate(values)
+            closeEdit()
+          }}
         />
       )}
       <AttachmentPreviewDialog attachment={previewAttachment} onClose={() => setPreviewAttachment(null)} />

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/-components/index-page.tsx
@@ -1,16 +1,24 @@
 import { Anchor, Button, Table } from "@mantine/core"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { Section } from "@/components/section"
-import { trpc } from "@/utils/trpc"
 
-import { Route } from "../index"
+type BankAccount = {
+  id: string
+  displayName: string
+  iban: string
+  currency: string
+  bankName: string | null
+}
 
-export function BankAccountsTab() {
-  const { legalEntityId } = Route.useParams()
-  const { data: legalEntity } = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId }))
+export function BankAccountsTab({
+  legalEntityId,
+  legalEntity,
+}: {
+  legalEntityId: string
+  legalEntity: { bankAccounts: BankAccount[] } | undefined
+}) {
   const bankAccounts = legalEntity?.bankAccounts ?? []
 
   return (

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
@@ -6,10 +6,10 @@ import { trpc } from "@/utils/trpc"
 import { BankAccountsTab } from "./-components/index-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/bank-accounts/")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { legalEntityId } = Route.useParams()
   const legalEntity = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId })).data
 

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index.tsx
@@ -1,7 +1,17 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+
+import { trpc } from "@/utils/trpc"
 
 import { BankAccountsTab } from "./-components/index-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/bank-accounts/")({
-  component: BankAccountsTab,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { legalEntityId } = Route.useParams()
+  const legalEntity = useQuery(trpc.legalEntities.get.queryOptions({ id: legalEntityId })).data
+
+  return <BankAccountsTab legalEntityId={legalEntityId} legalEntity={legalEntity} />
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
@@ -1,5 +1,8 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
+
+import { trpc } from "@/utils/trpc"
 
 import { OverviewTab } from "./-components/overview-page"
 
@@ -8,6 +11,25 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/overview")({
-  component: OverviewTab,
+  component: routeComponent,
   validateSearch: searchSchema,
 })
+
+function routeComponent() {
+  const { legalEntityId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const currentYear = new Date().getFullYear()
+  const year = search.year ?? currentYear
+  const bankAccounts =
+    useQuery(trpc.reports.bankAccountMonthlyBreakdown.queryOptions({ year, legalEntityId })).data ?? []
+
+  return (
+    <OverviewTab
+      year={year}
+      currentYear={currentYear}
+      bankAccounts={bankAccounts}
+      onYearChange={(next) => navigate({ search: { year: next } })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/overview.tsx
@@ -11,11 +11,11 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/overview")({
-  component: routeComponent,
+  component: RouteComponent,
   validateSearch: searchSchema,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { legalEntityId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -1,7 +1,35 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { TRPCClientError } from "@trpc/client"
 
+import { trpc } from "@/utils/trpc"
+
+import { useUpdateLegalEntityAction } from "./-actions/legal-entity-actions"
 import { LegalEntityLayout } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId")({
-  component: LegalEntityLayout,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { legalEntityId } = Route.useParams()
+  const legalEntityQuery = useQuery({
+    ...trpc.legalEntities.get.queryOptions({ id: legalEntityId }),
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  })
+  const legalEntitiesData = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 })).data
+  const save = useUpdateLegalEntityAction({ legalEntityId })
+
+  return (
+    <LegalEntityLayout
+      legalEntityQuery={legalEntityQuery}
+      legalEntities={legalEntitiesData?.items ?? []}
+      savePending={save.isPending}
+      onSaveLegalEntity={(values) => save.mutateAsync(values)}
+    />
+  )
+}
+
+function isNotFoundError(error: unknown) {
+  return error instanceof TRPCClientError && error.data?.code === "NOT_FOUND"
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/route.tsx
@@ -8,10 +8,10 @@ import { useUpdateLegalEntityAction } from "./-actions/legal-entity-actions"
 import { LegalEntityLayout } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { legalEntityId } = Route.useParams()
   const legalEntityQuery = useQuery({
     ...trpc.legalEntities.get.queryOptions({ id: legalEntityId }),

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
@@ -6,10 +6,10 @@ import { trpc } from "@/utils/trpc"
 import { SalonsTab } from "./-components/salons-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/salons")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const salonsData = useQuery(trpc.salons.list.queryOptions({ pageSize: 100 })).data
 
   return <SalonsTab salons={salonsData?.items ?? []} />

--- a/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/$legalEntityId/salons.tsx
@@ -1,7 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+
+import { trpc } from "@/utils/trpc"
 
 import { SalonsTab } from "./-components/salons-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/$legalEntityId/salons")({
-  component: SalonsTab,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const salonsData = useQuery(trpc.salons.list.queryOptions({ pageSize: 100 })).data
+
+  return <SalonsTab salons={salonsData?.items ?? []} />
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/-components/index-page.tsx
@@ -1,20 +1,35 @@
 import { Badge, Button, Card, Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { PageHeader } from "@/components/page-header"
 import { COUNTRY_FLAGS, COUNTRY_LABELS, type Country } from "@/lib/legal-entity"
 import { LEGAL_ENTITY_SECTIONS, getLegalEntitySectionPath } from "@/lib/legal-entity-navigation"
-import { trpc } from "@/utils/trpc"
 
-export function LegalEntitiesIndex() {
-  const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+type LegalEntityListQuery = {
+  data:
+    | {
+        items: {
+          id: string
+          name: string
+          country: string
+          type: string
+          defaultCurrency: string
+        }[]
+      }
+    | undefined
+  isPending: boolean
+  isError: boolean
+}
+
+export function LegalEntitiesIndex({
+  legalEntitiesQuery,
+  unassignedCount,
+}: {
+  legalEntitiesQuery: LegalEntityListQuery
+  unassignedCount: number
+}) {
   const legalEntities = legalEntitiesQuery.data?.items ?? []
-  const { data: unassignedAttachments } = useQuery(
-    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
-  )
-  const unassignedCount = unassignedAttachments?.totalCount ?? 0
 
   return (
     <Container size="xl">

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -1,7 +1,24 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+
+import { trpc } from "@/utils/trpc"
 
 import { LegalEntitiesIndex } from "./-components/index-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/")({
-  component: LegalEntitiesIndex,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
+  const unassignedAttachments = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
+  ).data
+
+  return (
+    <LegalEntitiesIndex
+      legalEntitiesQuery={legalEntitiesQuery}
+      unassignedCount={unassignedAttachments?.totalCount ?? 0}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/legal-entities/index.tsx
+++ b/apps/web/src/routes/_authenticated/legal-entities/index.tsx
@@ -6,10 +6,10 @@ import { trpc } from "@/utils/trpc"
 import { LegalEntitiesIndex } from "./-components/index-page"
 
 export const Route = createFileRoute("/_authenticated/legal-entities/")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const legalEntitiesQuery = useQuery(trpc.legalEntities.list.queryOptions({ pageSize: 100 }))
   const unassignedAttachments = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),

--- a/apps/web/src/routes/_authenticated/profile.tsx
+++ b/apps/web/src/routes/_authenticated/profile.tsx
@@ -1,7 +1,50 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { authClient } from "@/lib/auth-client"
+import { type Currency } from "@/lib/currency"
+import { trpc } from "@/utils/trpc"
 
 import { ProfilePage } from "./-components/profile-page"
+import {
+  sessionsQueryKey,
+  useRevokeSessionAction,
+  useUpdateUserProfileAction,
+} from "./profile/-actions/profile-actions"
 
 export const Route = createFileRoute("/_authenticated/profile")({
-  component: ProfilePage,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { data: current, isPending } = authClient.useSession()
+  const [terminatingId, setTerminatingId] = useState<string | undefined>()
+  const sessionsResult = useQuery({
+    queryKey: sessionsQueryKey,
+    queryFn: () => authClient.listSessions(),
+  }).data
+  const userSettingsQueryOptions = trpc.userSettings.get.queryOptions()
+  const settings = useQuery(userSettingsQueryOptions).data
+  const initialCurrency: Currency = settings?.preferredCurrency === "GBP" ? "GBP" : "EUR"
+  const revokeSession = useRevokeSessionAction({ onRevoked: () => setTerminatingId(undefined) })
+  const updateProfile = useUpdateUserProfileAction({
+    initialName: current?.user.name ?? "",
+    initialCurrency,
+  })
+
+  return (
+    <ProfilePage
+      current={current}
+      isPending={isPending}
+      sessions={sessionsResult?.data ?? []}
+      preferredCurrency={settings?.preferredCurrency ?? "EUR"}
+      terminatingId={terminatingId}
+      revokePending={revokeSession.isPending}
+      updateProfilePending={updateProfile.submitting}
+      onTerminatingIdChange={setTerminatingId}
+      onRevokeSession={(token) => revokeSession.mutateAsync(token)}
+      onUpdateProfile={(values) => updateProfile.updateUserProfile(values)}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/profile.tsx
+++ b/apps/web/src/routes/_authenticated/profile.tsx
@@ -14,10 +14,10 @@ import {
 } from "./profile/-actions/profile-actions"
 
 export const Route = createFileRoute("/_authenticated/profile")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { data: current, isPending } = authClient.useSession()
   const [terminatingId, setTerminatingId] = useState<string | undefined>()
   const sessionsResult = useQuery({

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -1,11 +1,13 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { authClient } from "@/lib/auth-client"
+import { trpc } from "@/utils/trpc"
 
 import { AuthenticatedErrorComponent, AuthenticatedLayout } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated")({
-  component: AuthenticatedLayout,
+  component: routeComponent,
   errorComponent: AuthenticatedErrorComponent,
   beforeLoad: async ({ location }) => {
     const session = await authClient.getSession()
@@ -21,3 +23,11 @@ export const Route = createFileRoute("/_authenticated")({
     return { session: session.data }
   },
 })
+
+function routeComponent() {
+  const unassignedAttachments = useQuery(
+    trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
+  ).data
+
+  return <AuthenticatedLayout badges={{ unassigned: unassignedAttachments?.totalCount ?? 0 }} />
+}

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -7,7 +7,7 @@ import { trpc } from "@/utils/trpc"
 import { AuthenticatedErrorComponent, AuthenticatedLayout } from "./-components/route-page"
 
 export const Route = createFileRoute("/_authenticated")({
-  component: routeComponent,
+  component: RouteComponent,
   errorComponent: AuthenticatedErrorComponent,
   beforeLoad: async ({ location }) => {
     const session = await authClient.getSession()
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/_authenticated")({
   },
 })
 
-function routeComponent() {
+function RouteComponent() {
   const unassignedAttachments = useQuery(
     trpc.bankStatementAttachments.list.queryOptions({ assignmentStatus: "unassigned" }),
   ).data

--- a/apps/web/src/routes/_authenticated/salons/$salonId.tsx
+++ b/apps/web/src/routes/_authenticated/salons/$salonId.tsx
@@ -1,7 +1,33 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 
+import { trpc } from "@/utils/trpc"
+
+import { useSalonActions } from "./-actions/salon-actions"
 import { SalonEdit } from "./-components/salon-id-page"
 
 export const Route = createFileRoute("/_authenticated/salons/$salonId")({
-  component: SalonEdit,
+  component: routeComponent,
 })
+
+function routeComponent() {
+  const { salonId } = Route.useParams()
+  const isNew = salonId === "new"
+  const navigate = Route.useNavigate()
+  const salon = useQuery({
+    ...trpc.salons.get.queryOptions({ id: salonId }),
+    enabled: !isNew,
+  }).data
+  const { create, update } = useSalonActions({ salonId, onSaved: () => navigate({ to: "/salons" }) })
+
+  return (
+    <SalonEdit
+      salonId={salonId}
+      salon={salon}
+      createPending={create.isPending}
+      updatePending={update.isPending}
+      onCreate={(values) => create.mutate(values)}
+      onUpdate={(values) => update.mutate({ ...values, id: salonId })}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/salons/$salonId.tsx
+++ b/apps/web/src/routes/_authenticated/salons/$salonId.tsx
@@ -7,10 +7,10 @@ import { useSalonActions } from "./-actions/salon-actions"
 import { SalonEdit } from "./-components/salon-id-page"
 
 export const Route = createFileRoute("/_authenticated/salons/$salonId")({
-  component: routeComponent,
+  component: RouteComponent,
 })
 
-function routeComponent() {
+function RouteComponent() {
   const { salonId } = Route.useParams()
   const isNew = salonId === "new"
   const navigate = Route.useNavigate()

--- a/apps/web/src/routes/_authenticated/salons/-components/salon-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/salons/-components/salon-id-page.tsx
@@ -1,28 +1,32 @@
 import { Button, Container, Group, Stack, TextInput } from "@mantine/core"
 import { useForm } from "@mantine/form"
-import { useQuery } from "@tanstack/react-query"
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { zodResolver } from "mantine-form-zod-resolver"
 import { useEffect } from "react"
 
 import { PageHeader } from "@/components/page-header"
 import { Section } from "@/components/section"
 import { salonSchema } from "@/lib/schemas"
-import { trpc } from "@/utils/trpc"
 
-import { Route } from "../$salonId"
-import { useSalonActions } from "../-actions/salon-actions"
+type SalonValues = { id?: string; name: string; address: string }
+type SalonRecord = { id: string; name: string; address: string | null }
 
-export function SalonEdit() {
-  const { salonId } = Route.useParams()
+export function SalonEdit({
+  salonId,
+  salon,
+  createPending,
+  updatePending,
+  onCreate,
+  onUpdate,
+}: {
+  salonId: string
+  salon: SalonRecord | undefined
+  createPending: boolean
+  updatePending: boolean
+  onCreate: (values: SalonValues) => void
+  onUpdate: (values: SalonValues) => void
+}) {
   const isNew = salonId === "new"
-  const navigate = useNavigate()
-  const salonQueryOptions = trpc.salons.get.queryOptions({ id: salonId })
-
-  const { data: salon } = useQuery({
-    ...salonQueryOptions,
-    enabled: !isNew,
-  })
 
   const form = useForm({
     initialValues: { id: undefined as string | undefined, name: "", address: "" },
@@ -40,17 +44,15 @@ export function SalonEdit() {
     }
   }, [form.setValues, form.resetDirty, isNew, salon])
 
-  const { create, update } = useSalonActions({ salonId, onSaved: () => navigate({ to: "/salons" }) })
-
   const handleSubmit = (values: typeof form.values) => {
     if (isNew) {
-      create.mutate(values)
+      onCreate(values)
       return
     }
-    update.mutate({ ...values, id: salonId })
+    onUpdate({ ...values, id: salonId })
   }
 
-  const isSaving = create.isPending || update.isPending
+  const isSaving = createPending || updatePending
 
   return (
     <Container size="md">


### PR DESCRIPTION
## Summary
- move route-local component reads and mutations into route/page owner containers
- pass data, pending state, and explicit callbacks into presentational components
- tighten architecture tests and AGENTS.md to enforce server-state ownership boundaries

## Verification
- vp test
- vp run check-types
- vp check