### PR TITLE
fix: run react doctor on changed web files

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,2 +1,15 @@
 vp staged
-vp dlx react-doctor@latest --staged --blocking warning
+react_doctor_output="$(vp dlx react-doctor@latest apps/web --scope changed --blocking warning 2>&1)"
+react_doctor_status=$?
+printf "%s\n" "$react_doctor_output"
+
+if [ "$react_doctor_status" -ne 0 ]; then
+  exit "$react_doctor_status"
+fi
+
+case "$react_doctor_output" in
+  *"React rules were gated off"* | *"No React project detected"*)
+    printf "%s\n" "React Doctor did not detect the web React project; refusing to pass pre-commit without React rules."
+    exit 1
+    ;;
+esac

--- a/apps/web/src/routes/-react-doctor-hook.test.ts
+++ b/apps/web/src/routes/-react-doctor-hook.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vite-plus/test"
+
+const preCommitHook = resolve(import.meta.dirname, "../../../../.vite-hooks/pre-commit")
+
+describe("React Doctor pre-commit hook", () => {
+  it("runs from the web app so React rules are not gated off", () => {
+    const hook = readFileSync(preCommitHook, "utf8")
+
+    expect(hook).toMatch(/react-doctor@latest apps\/web --scope changed --blocking warning/)
+    expect(hook).toContain("React rules were gated off")
+    expect(hook).toContain("No React project detected")
+  })
+})

--- a/apps/web/src/routes/-route-helper-folder-organization.test.ts
+++ b/apps/web/src/routes/-route-helper-folder-organization.test.ts
@@ -8,6 +8,7 @@ const allowedHelperDirectories = new Set(["-actions", "-components", "-data"])
 const allowedFlatHelperFiles = new Set([
   "-route-component-organization.test.ts",
   "-route-helper-folder-organization.test.ts",
+  "-react-doctor-hook.test.ts",
   "_authenticated/-route-data-organization.test.ts",
 ])
 


### PR DESCRIPTION
## Summary
- run local React Doctor against the web app with changed-scope scanning
- fail pre-commit if React Doctor reports React rules were gated off
- add a route governance test covering the pre-commit invocation

## Verification
- vp test
- vp run check-types
- vp check