### PR TITLE
refactor: lazy load route dialog data

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/calendar-page.tsx
+++ b/apps/web/src/routes/_authenticated/-components/calendar-page.tsx
@@ -24,6 +24,7 @@ type AppointmentData = {
 export function CalendarPage({
   view,
   date,
+  createOpen,
   clientSearch,
   masterSearch,
   appointmentsData,
@@ -33,6 +34,7 @@ export function CalendarPage({
   createPending,
   onViewChange,
   onDateChange,
+  onCreateOpenChange,
   onClientSearchChange,
   onMasterSearchChange,
   onCreateAppointment,
@@ -40,6 +42,7 @@ export function CalendarPage({
 }: {
   view: ScheduleViewLevel
   date: string
+  createOpen: boolean
   clientSearch: string
   masterSearch: string
   appointmentsData: AppointmentData | undefined
@@ -49,12 +52,12 @@ export function CalendarPage({
   createPending: boolean
   onViewChange: (view: ScheduleViewLevel) => void
   onDateChange: (date: string) => void
+  onCreateOpenChange: (open: boolean) => void
   onClientSearchChange: (search: string) => void
   onMasterSearchChange: (search: string) => void
   onCreateAppointment: ComponentProps<typeof CreateAppointmentDialog>["onCreate"]
   onOpenAppointment: (appointmentId: string) => void
 }) {
-  const [createOpen, setCreateOpen] = useState(false)
   const [defaultStartsAt, setDefaultStartsAt] = useState<string | null>(null)
   const clientOptions = (clientCustomersData?.items ?? []).map((customer) => ({
     value: customer.id,
@@ -69,10 +72,13 @@ export function CalendarPage({
   const appointmentTotalCount = appointmentsData?.totalCount ?? 0
   const hasHiddenAppointments = appointmentTotalCount > visibleAppointmentCount
 
-  const openCreate = useCallback((startsAt: string | null) => {
-    setDefaultStartsAt(startsAt)
-    setCreateOpen(true)
-  }, [])
+  const openCreate = useCallback(
+    (startsAt: string | null) => {
+      setDefaultStartsAt(startsAt)
+      onCreateOpenChange(true)
+    },
+    [onCreateOpenChange],
+  )
 
   const events = useMemo<ScheduleEventData[]>(() => {
     const appointments = appointmentsData?.items ?? []
@@ -131,12 +137,12 @@ export function CalendarPage({
         </Section>
         <CreateAppointmentDialog
           open={createOpen}
-          onOpenChange={setCreateOpen}
+          onOpenChange={onCreateOpenChange}
           defaultStartsAt={defaultStartsAt}
           loading={createPending}
           onCreate={(values) => {
             onCreateAppointment(values)
-            setCreateOpen(false)
+            onCreateOpenChange(false)
           }}
           clientOptions={clientOptions}
           masterOptions={masterOptions}

--- a/apps/web/src/routes/_authenticated/-route-data-organization.test.ts
+++ b/apps/web/src/routes/_authenticated/-route-data-organization.test.ts
@@ -28,4 +28,13 @@ describe("route data organization", () => {
     expect(source, routePath).not.toContain("useMutation({")
     expect(source, routePath).not.toMatch(/const\s+\w*invalidate\w*\s*=/)
   })
+
+  it.each(routePageFiles(routesDir))("keeps dialog option prefetches out of route loaders %s", (path) => {
+    const source = readFileSync(path, "utf8")
+    const routePath = relative(routesDir, path)
+
+    expect(source, routePath).not.toMatch(
+      /queryClient\.prefetchQuery\((appointment(Customer|Master|Salon)OptionsQueryOptions|availableHairOrdersListQueryOptions)/,
+    )
+  })
 })

--- a/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/$appointmentId.tsx
@@ -8,11 +8,7 @@ import { useAppointmentPersonnelActions } from "../-actions/appointment-actions"
 import { useHairAssignmentActions } from "../-actions/hair-assignment-actions"
 import { useAppointmentTransactionActions } from "./-actions/appointment-transaction-actions"
 import { AppointmentDetailPage } from "./-components/appointment-detail-page"
-import {
-  APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE,
-  availableHairOrdersListQueryOptions,
-  useAppointmentDetailData,
-} from "./-data/appointment-detail-data"
+import { APPOINTMENT_DETAIL_RESOURCE_PAGE_SIZE, useAppointmentDetailData } from "./-data/appointment-detail-data"
 
 const defaultCustomersListInput = { page: 1, pageSize: 100, search: undefined as string | undefined }
 
@@ -36,7 +32,6 @@ export const Route = createFileRoute("/_authenticated/appointments/$appointmentI
         }),
       ),
       context.queryClient.ensureQueryData(trpc.userSettings.get.queryOptions()),
-      context.queryClient.prefetchQuery(availableHairOrdersListQueryOptions()),
     ])
   },
 })
@@ -45,21 +40,31 @@ function RouteComponent() {
   const { appointmentId } = Route.useParams()
   const [transactionsPage, setTransactionsPage] = useState(1)
   const [hairAssignedPage, setHairAssignedPage] = useState(1)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [pickPersonnelOpen, setPickPersonnelOpen] = useState(false)
+  const [changeMasterOpen, setChangeMasterOpen] = useState(false)
   const [masterSearch, setMasterSearch] = useState("")
   const [pickPersonnelSearch, setPickPersonnelSearch] = useState("")
-  const detailData = useAppointmentDetailData({ appointmentId, hairAssignedPage, transactionsPage })
-  const pickPersonnelCustomersData = useQuery(
-    trpc.customers.list.queryOptions({
+  const detailData = useAppointmentDetailData({
+    appointmentId,
+    hairAssignedPage,
+    transactionsPage,
+    availableHairOrdersEnabled: createOpen,
+  })
+  const pickPersonnelCustomersData = useQuery({
+    ...trpc.customers.list.queryOptions({
       ...defaultCustomersListInput,
       search: pickPersonnelSearch.trim() || undefined,
     }),
-  ).data
-  const masterCustomersData = useQuery(
-    trpc.customers.list.queryOptions({
+    enabled: pickPersonnelOpen,
+  }).data
+  const masterCustomersData = useQuery({
+    ...trpc.customers.list.queryOptions({
       ...defaultCustomersListInput,
       search: masterSearch.trim() || undefined,
     }),
-  ).data
+    enabled: changeMasterOpen,
+  }).data
   const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
     invalidateKeys: [
       { queryKey: detailData.appointmentQueryOptions.queryKey },
@@ -81,12 +86,18 @@ function RouteComponent() {
       detailData={detailData}
       transactionsPage={transactionsPage}
       hairAssignedPage={hairAssignedPage}
+      createOpen={createOpen}
+      pickPersonnelOpen={pickPersonnelOpen}
+      changeMasterOpen={changeMasterOpen}
       masterSearch={masterSearch}
       pickPersonnelSearch={pickPersonnelSearch}
       pickPersonnelCustomersData={pickPersonnelCustomersData}
       masterCustomersData={masterCustomersData}
       onTransactionsPageChange={setTransactionsPage}
       onHairAssignedPageChange={setHairAssignedPage}
+      onCreateOpenChange={setCreateOpen}
+      onPickPersonnelOpenChange={setPickPersonnelOpen}
+      onChangeMasterOpenChange={setChangeMasterOpen}
       onMasterSearchChange={setMasterSearch}
       onPickPersonnelSearchChange={setPickPersonnelSearch}
       createHairAssignedPending={createHairAssigned.isPending}

--- a/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
@@ -30,12 +30,18 @@ export function AppointmentDetailPage({
   detailData,
   transactionsPage,
   hairAssignedPage,
+  createOpen,
+  pickPersonnelOpen,
+  changeMasterOpen,
   masterSearch,
   pickPersonnelSearch,
   pickPersonnelCustomersData,
   masterCustomersData,
   onTransactionsPageChange,
   onHairAssignedPageChange,
+  onCreateOpenChange,
+  onPickPersonnelOpenChange,
+  onChangeMasterOpenChange,
   onMasterSearchChange,
   onPickPersonnelSearchChange,
   createHairAssignedPending,
@@ -59,12 +65,18 @@ export function AppointmentDetailPage({
   detailData: AppointmentDetailData
   transactionsPage: number
   hairAssignedPage: number
+  createOpen: boolean
+  pickPersonnelOpen: boolean
+  changeMasterOpen: boolean
   masterSearch: string
   pickPersonnelSearch: string
   pickPersonnelCustomersData: CustomersData | undefined
   masterCustomersData: CustomersData | undefined
   onTransactionsPageChange: (page: number) => void
   onHairAssignedPageChange: (page: number) => void
+  onCreateOpenChange: (open: boolean) => void
+  onPickPersonnelOpenChange: (open: boolean) => void
+  onChangeMasterOpenChange: (open: boolean) => void
   onMasterSearchChange: (search: string) => void
   onPickPersonnelSearchChange: (search: string) => void
   createHairAssignedPending: boolean
@@ -84,11 +96,8 @@ export function AppointmentDetailPage({
   onUpdateMaster: (values: { id: string; masterId: string }) => void
   onLinkPersonnel: (values: { appointmentId: string; personnelIds: string[] }) => void
 }) {
-  const [createOpen, setCreateOpen] = useState(false)
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
-  const [pickPersonnelOpen, setPickPersonnelOpen] = useState(false)
-  const [changeMasterOpen, setChangeMasterOpen] = useState(false)
   const [draftMasterId, setDraftMasterId] = useState<string | null>(null)
   const [selectedMasterOption, setSelectedMasterOption] = useState<SelectOption | null>(null)
   const [createTxOpen, setCreateTxOpen] = useState(false)
@@ -184,7 +193,7 @@ export function AppointmentDetailPage({
                 variant="subtle"
                 size="xs"
                 leftSection={<IconUser size={12} />}
-                onClick={() => setChangeMasterOpen(true)}
+                onClick={() => onChangeMasterOpenChange(true)}
               >
                 Change
               </Button>
@@ -226,7 +235,7 @@ export function AppointmentDetailPage({
                 variant="subtle"
                 size="xs"
                 leftSection={<IconUsers size={12} />}
-                onClick={() => setPickPersonnelOpen(true)}
+                onClick={() => onPickPersonnelOpenChange(true)}
               >
                 Pick
               </Button>
@@ -360,7 +369,12 @@ export function AppointmentDetailPage({
                 })}
               </Text>
             </Stack>
-            <Button variant="subtle" size="xs" leftSection={<IconPlus size={12} />} onClick={() => setCreateOpen(true)}>
+            <Button
+              variant="subtle"
+              size="xs"
+              leftSection={<IconPlus size={12} />}
+              onClick={() => onCreateOpenChange(true)}
+            >
               Add
             </Button>
           </Group>
@@ -409,13 +423,13 @@ export function AppointmentDetailPage({
 
         <CreateHairAssignedDialog
           open={createOpen}
-          onOpenChange={setCreateOpen}
+          onOpenChange={onCreateOpenChange}
           clientId={appointment.client.id}
           appointmentId={appointmentId}
           loading={createHairAssignedPending}
           onCreate={(values) => {
             onCreateHairAssigned(values)
-            setCreateOpen(false)
+            onCreateOpenChange(false)
           }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}
@@ -446,7 +460,7 @@ export function AppointmentDetailPage({
         )}
         <PickPersonnelModal
           open={pickPersonnelOpen}
-          onOpenChange={setPickPersonnelOpen}
+          onOpenChange={onPickPersonnelOpenChange}
           search={pickPersonnelSearch}
           personnel={availablePersonnel}
           loading={linkPersonnelPending}
@@ -454,14 +468,14 @@ export function AppointmentDetailPage({
           onConfirm={(personnelIds) => {
             onLinkPersonnel({ appointmentId, personnelIds })
             onPickPersonnelSearchChange("")
-            setPickPersonnelOpen(false)
+            onPickPersonnelOpenChange(false)
           }}
         />
         {changeMasterOpen && (
           <ChangeMasterModal
             key={`${appointmentId}-${appointment.master.id}`}
             open={changeMasterOpen}
-            onOpenChange={setChangeMasterOpen}
+            onOpenChange={onChangeMasterOpenChange}
             currentMasterId={appointment.master.id}
             masterId={masterId}
             masterSearch={masterSearch}
@@ -478,7 +492,7 @@ export function AppointmentDetailPage({
               setDraftMasterId(null)
               setSelectedMasterOption(null)
               onMasterSearchChange("")
-              setChangeMasterOpen(false)
+              onChangeMasterOpenChange(false)
             }}
           />
         )}

--- a/apps/web/src/routes/_authenticated/appointments/-data/appointment-detail-data.ts
+++ b/apps/web/src/routes/_authenticated/appointments/-data/appointment-detail-data.ts
@@ -44,10 +44,12 @@ export function useAppointmentDetailData({
   appointmentId,
   hairAssignedPage,
   transactionsPage,
+  availableHairOrdersEnabled,
 }: {
   appointmentId: string
   hairAssignedPage: number
   transactionsPage: number
+  availableHairOrdersEnabled: boolean
 }) {
   const appointmentQueryOptions = appointmentDetailQueryOptions(appointmentId)
   const availableHairOrdersQueryOptions = availableHairOrdersListQueryOptions()
@@ -55,9 +57,10 @@ export function useAppointmentDetailData({
   const transactionsQueryOptions = appointmentTransactionsQueryOptions(appointmentId, transactionsPage)
 
   const { data: appointment } = useQuery(appointmentQueryOptions)
-  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery(
-    availableHairOrdersQueryOptions,
-  )
+  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery({
+    ...availableHairOrdersQueryOptions,
+    enabled: availableHairOrdersEnabled,
+  })
   const { data: hairAssignedData } = useQuery(hairAssignedQueryOptions)
   const { data: transactionsData } = useQuery(transactionsQueryOptions)
   const { data: userSettings } = useQuery(trpc.userSettings.get.queryOptions())

--- a/apps/web/src/routes/_authenticated/calendar.tsx
+++ b/apps/web/src/routes/_authenticated/calendar.tsx
@@ -16,11 +16,7 @@ import {
 export const Route = createFileRoute("/_authenticated/calendar")({
   component: RouteComponent,
   loader: async ({ context }) => {
-    await Promise.all([
-      context.queryClient.prefetchQuery(calendarAppointmentsQueryOptions(dayjs().format("YYYY-MM-DD"), "month")),
-      context.queryClient.prefetchQuery(appointmentCustomerOptionsQueryOptions("")),
-      context.queryClient.prefetchQuery(appointmentSalonOptionsQueryOptions()),
-    ])
+    await context.queryClient.prefetchQuery(calendarAppointmentsQueryOptions(dayjs().format("YYYY-MM-DD"), "month"))
   },
 })
 
@@ -28,13 +24,23 @@ function RouteComponent() {
   const navigate = Route.useNavigate()
   const [view, setView] = useState<ScheduleViewLevel>("month")
   const [date, setDate] = useState<string>(() => dayjs().format("YYYY-MM-DD"))
+  const [createOpen, setCreateOpen] = useState(false)
   const [clientSearch, setClientSearch] = useState("")
   const [masterSearch, setMasterSearch] = useState("")
   const appointmentsQueryOptions = calendarAppointmentsQueryOptions(date, view)
   const appointmentsData = useQuery(appointmentsQueryOptions).data
-  const clientCustomersData = useQuery(appointmentCustomerOptionsQueryOptions(clientSearch)).data
-  const masterCustomersData = useQuery(appointmentCustomerOptionsQueryOptions(masterSearch)).data
-  const salonsData = useQuery(appointmentSalonOptionsQueryOptions()).data
+  const clientCustomersData = useQuery({
+    ...appointmentCustomerOptionsQueryOptions(clientSearch),
+    enabled: createOpen,
+  }).data
+  const masterCustomersData = useQuery({
+    ...appointmentCustomerOptionsQueryOptions(masterSearch),
+    enabled: createOpen,
+  }).data
+  const salonsData = useQuery({
+    ...appointmentSalonOptionsQueryOptions(),
+    enabled: createOpen,
+  }).data
   const createAppointment = useCreateAppointmentAction({
     invalidateKeys: [{ queryKey: appointmentsQueryOptions.queryKey }],
     onCreated: (created) => {
@@ -48,6 +54,7 @@ function RouteComponent() {
     <CalendarPage
       view={view}
       date={date}
+      createOpen={createOpen}
       clientSearch={clientSearch}
       masterSearch={masterSearch}
       appointmentsData={appointmentsData}
@@ -57,6 +64,7 @@ function RouteComponent() {
       createPending={createAppointment.isPending}
       onViewChange={setView}
       onDateChange={setDate}
+      onCreateOpenChange={setCreateOpen}
       onClientSearchChange={setClientSearch}
       onMasterSearchChange={setMasterSearch}
       onCreateAppointment={(values) => createAppointment.mutate(values)}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/appointments-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/appointments-page.tsx
@@ -3,7 +3,6 @@ import type { ComponentProps } from "react"
 import { Button, Group, Pagination, Stack, Table, Text, TextInput } from "@mantine/core"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
-import { useState } from "react"
 
 import { CreateAppointmentDialog } from "@/components/appointments/create-appointment-dialog"
 import { BreadcrumbItem } from "@/components/breadcrumbs"
@@ -20,11 +19,13 @@ export function CustomerAppointmentsPage({
   page,
   searchValue,
   data,
+  createDialogOpen,
   masterSearch,
   masterCustomersData,
   salonsData,
   createPending,
   onCreateAppointment,
+  onCreateDialogOpenChange,
   onMasterSearchChange,
   onSearchChange,
   onPageChange,
@@ -33,17 +34,17 @@ export function CustomerAppointmentsPage({
   page: number
   searchValue: string
   data: { items: AppointmentRow[]; totalCount: number } | undefined
+  createDialogOpen: boolean
   masterSearch: string
   masterCustomersData: OptionData | undefined
   salonsData: OptionData | undefined
   createPending: boolean
   onCreateAppointment: ComponentProps<typeof CreateAppointmentDialog>["onCreate"]
+  onCreateDialogOpenChange: (open: boolean) => void
   onMasterSearchChange: (search: string) => void
   onSearchChange: (search: string) => void
   onPageChange: (page: number) => void
 }) {
-  const [dialogOpen, setDialogOpen] = useState(false)
-
   const normalizedSearch = searchValue.trim()
   const masterOptions = (masterCustomersData?.items ?? []).map((customer) => ({
     value: customer.id,
@@ -78,7 +79,7 @@ export function CustomerAppointmentsPage({
               variant="default"
               size="sm"
               leftSection={<IconPlus size={12} />}
-              onClick={() => setDialogOpen(true)}
+              onClick={() => onCreateDialogOpenChange(true)}
             >
               New
             </Button>
@@ -134,13 +135,13 @@ export function CustomerAppointmentsPage({
         </Stack>
 
         <CreateAppointmentDialog
-          open={dialogOpen}
-          onOpenChange={setDialogOpen}
+          open={createDialogOpen}
+          onOpenChange={onCreateDialogOpenChange}
           defaultClientId={customerId}
           loading={createPending}
           onCreate={(values) => {
             onCreateAppointment(values)
-            setDialogOpen(false)
+            onCreateDialogOpenChange(false)
           }}
           clientOptions={[]}
           masterOptions={masterOptions}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
@@ -2,7 +2,6 @@ import type { ComponentProps } from "react"
 
 import { Button, Stack, Text, TextInput } from "@mantine/core"
 import { IconPlus, IconSearch } from "@tabler/icons-react"
-import { useState } from "react"
 
 import { BreadcrumbItem } from "@/components/breadcrumbs"
 import { CreateHairAssignedDialog } from "@/components/hair-assigned/create-hair-assigned-dialog"
@@ -19,11 +18,13 @@ export function HairSalesPage({
   customerId,
   searchValue,
   data,
+  hairCreateOpen,
   hairEditItem,
   hairDeleteItem,
   createPending,
   updatePending,
   deletePending,
+  onHairCreateOpenChange,
   onHairEditItemChange,
   onHairDeleteItemChange,
   onSearchChange,
@@ -35,11 +36,13 @@ export function HairSalesPage({
   customerId: string
   searchValue: string
   data: HairSalesData
+  hairCreateOpen: boolean
   hairEditItem: HairAssignedRow | null
   hairDeleteItem: HairAssignedRow | null
   createPending: boolean
   updatePending: boolean
   deletePending: boolean
+  onHairCreateOpenChange: (open: boolean) => void
   onHairEditItemChange: (item: HairAssignedRow | null) => void
   onHairDeleteItemChange: (item: HairAssignedRow | null) => void
   onSearchChange: (search: string) => void
@@ -48,8 +51,6 @@ export function HairSalesPage({
   onUpdate: ComponentProps<typeof EditHairAssignedDialog>["onUpdate"]
   onDelete: (id: string) => void
 }) {
-  const [hairCreateOpen, setHairCreateOpen] = useState(false)
-
   const normalizedSearch = searchValue.trim()
   const {
     availableHairOrders,
@@ -83,7 +84,7 @@ export function HairSalesPage({
               variant="default"
               size="sm"
               leftSection={<IconPlus size={12} />}
-              onClick={() => setHairCreateOpen(true)}
+              onClick={() => onHairCreateOpenChange(true)}
             >
               New
             </Button>
@@ -122,13 +123,13 @@ export function HairSalesPage({
 
         <CreateHairAssignedDialog
           open={hairCreateOpen}
-          onOpenChange={setHairCreateOpen}
+          onOpenChange={onHairCreateOpenChange}
           clientId={customerId}
           appointmentId={null}
           loading={createPending}
           onCreate={(values) => {
             onCreate(values)
-            setHairCreateOpen(false)
+            onHairCreateOpenChange(false)
           }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-data/hair-sales-data.ts
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-data/hair-sales-data.ts
@@ -28,13 +28,24 @@ export function availableHairOrdersListQueryOptions() {
   })
 }
 
-export function useHairSalesData({ customerId, page, search }: { customerId: string; page: number; search: string }) {
+export function useHairSalesData({
+  customerId,
+  page,
+  search,
+  availableHairOrdersEnabled,
+}: {
+  customerId: string
+  page: number
+  search: string
+  availableHairOrdersEnabled: boolean
+}) {
   const queryOptions = hairSalesQueryOptions(customerId, page, search)
   const availableHairOrdersQueryOptions = availableHairOrdersListQueryOptions()
   const { data } = useQuery(queryOptions)
-  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery(
-    availableHairOrdersQueryOptions,
-  )
+  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery({
+    ...availableHairOrdersQueryOptions,
+    enabled: availableHairOrdersEnabled,
+  })
   const hairAssigned = (data?.items ?? []) as HairAssignedRow[]
   const totalCount = data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / HAIR_SALES_PAGE_SIZE))

--- a/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/appointments.tsx
@@ -21,11 +21,9 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/appo
     search: search.search ?? "",
   }),
   loader: async ({ context, deps, params }) => {
-    const [data] = await Promise.all([
-      context.queryClient.ensureQueryData(appointmentsQueryOptions(params.customerId, deps.page, deps.search)),
-      context.queryClient.prefetchQuery(appointmentMasterOptionsQueryOptions("")),
-      context.queryClient.prefetchQuery(appointmentSalonOptionsQueryOptions()),
-    ])
+    const data = await context.queryClient.ensureQueryData(
+      appointmentsQueryOptions(params.customerId, deps.page, deps.search),
+    )
     const totalPages = Math.max(1, Math.ceil(data.totalCount / PAGE_SIZE))
     if (deps.page > totalPages) {
       throw redirect({
@@ -44,10 +42,17 @@ function RouteComponent() {
   const navigate = Route.useNavigate()
   const page = search.page ?? 1
   const searchValue = search.search ?? ""
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [masterSearch, setMasterSearch] = useState("")
   const data = useQuery(appointmentsQueryOptions(customerId, page, searchValue)).data
-  const masterCustomersData = useQuery(appointmentMasterOptionsQueryOptions(masterSearch)).data
-  const salonsData = useQuery(appointmentSalonOptionsQueryOptions()).data
+  const masterCustomersData = useQuery({
+    ...appointmentMasterOptionsQueryOptions(masterSearch),
+    enabled: createDialogOpen,
+  }).data
+  const salonsData = useQuery({
+    ...appointmentSalonOptionsQueryOptions(),
+    enabled: createDialogOpen,
+  }).data
   const createAppointment = useCreateAppointmentAction({
     invalidateKeys: [
       { queryKey: trpc.customers.appointments.list.queryKey() },
@@ -66,11 +71,13 @@ function RouteComponent() {
       page={page}
       searchValue={searchValue}
       data={data}
+      createDialogOpen={createDialogOpen}
       masterSearch={masterSearch}
       masterCustomersData={masterCustomersData}
       salonsData={salonsData}
       createPending={createAppointment.isPending}
       onCreateAppointment={(values) => createAppointment.mutate(values)}
+      onCreateDialogOpenChange={setCreateDialogOpen}
       onMasterSearchChange={setMasterSearch}
       onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}
       onPageChange={(nextPage) => navigate({ search: { page: nextPage, search: searchValue } })}

--- a/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/hair-sales.tsx
@@ -6,13 +6,7 @@ import { trpc } from "@/utils/trpc"
 
 import { useHairAssignmentActions } from "../../-actions/hair-assignment-actions"
 import { HairSalesPage } from "./-components/hair-sales-page"
-import {
-  HAIR_SALES_PAGE_SIZE,
-  availableHairOrdersListQueryOptions,
-  hairSalesQueryOptions,
-  searchSchema,
-  useHairSalesData,
-} from "./-data/hair-sales-data"
+import { HAIR_SALES_PAGE_SIZE, hairSalesQueryOptions, searchSchema, useHairSalesData } from "./-data/hair-sales-data"
 
 export const Route = createFileRoute("/_authenticated/customers/$customerId/hair-sales")({
   component: RouteComponent,
@@ -22,10 +16,9 @@ export const Route = createFileRoute("/_authenticated/customers/$customerId/hair
     search: search.search ?? "",
   }),
   loader: async ({ context, deps, params }) => {
-    const [data] = await Promise.all([
-      context.queryClient.ensureQueryData(hairSalesQueryOptions(params.customerId, deps.page, deps.search)),
-      context.queryClient.prefetchQuery(availableHairOrdersListQueryOptions()),
-    ])
+    const data = await context.queryClient.ensureQueryData(
+      hairSalesQueryOptions(params.customerId, deps.page, deps.search),
+    )
     const totalPages = Math.max(1, Math.ceil(data.totalCount / HAIR_SALES_PAGE_SIZE))
     if (deps.page > totalPages) {
       throw redirect({
@@ -41,11 +34,12 @@ function RouteComponent() {
   const { customerId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
+  const [hairCreateOpen, setHairCreateOpen] = useState(false)
   const [hairEditItem, setHairEditItem] = useState<HairAssignedRow | null>(null)
   const [hairDeleteItem, setHairDeleteItem] = useState<HairAssignedRow | null>(null)
   const page = search.page ?? 1
   const searchValue = search.search ?? ""
-  const data = useHairSalesData({ customerId, page, search: searchValue })
+  const data = useHairSalesData({ customerId, page, search: searchValue, availableHairOrdersEnabled: hairCreateOpen })
   const customerSummaryQueryKey = trpc.customers.summary.queryOptions({ id: customerId }).queryKey
   const { createHairAssigned, updateHairAssigned, deleteHairAssigned } = useHairAssignmentActions({
     invalidateKeys: [{ queryKey: trpc.customers.hairAssigned.list.queryKey() }, { queryKey: customerSummaryQueryKey }],
@@ -58,11 +52,13 @@ function RouteComponent() {
       customerId={customerId}
       searchValue={searchValue}
       data={data}
+      hairCreateOpen={hairCreateOpen}
       hairEditItem={hairEditItem}
       hairDeleteItem={hairDeleteItem}
       createPending={createHairAssigned.isPending}
       updatePending={updateHairAssigned.isPending}
       deletePending={deleteHairAssigned.isPending}
+      onHairCreateOpenChange={setHairCreateOpen}
       onHairEditItemChange={setHairEditItem}
       onHairDeleteItemChange={setHairDeleteItem}
       onSearchChange={(nextSearch) => navigate({ search: { page: 1, search: nextSearch }, replace: true })}

--- a/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/$hairOrderId.tsx
@@ -6,27 +6,21 @@ import { type HairAssignedRow } from "@/components/hair-assigned/hair-assigned-t
 import { useHairAssignmentActions } from "../-actions/hair-assignment-actions"
 import { useHairOrderDetailActions } from "./-actions/hair-order-actions"
 import { HairOrderDetailPage } from "./-components/hair-order-id-page"
-import {
-  availableHairOrdersListQueryOptions,
-  hairOrderDetailQueryOptions,
-  useHairOrderDetailData,
-} from "./-data/hair-order-detail-data"
+import { hairOrderDetailQueryOptions, useHairOrderDetailData } from "./-data/hair-order-detail-data"
 
 export const Route = createFileRoute("/_authenticated/hair-orders/$hairOrderId")({
   component: RouteComponent,
   loader: async ({ context, params }) => {
-    await Promise.all([
-      context.queryClient.ensureQueryData(hairOrderDetailQueryOptions(params.hairOrderId)),
-      context.queryClient.prefetchQuery(availableHairOrdersListQueryOptions()),
-    ])
+    await context.queryClient.ensureQueryData(hairOrderDetailQueryOptions(params.hairOrderId))
   },
 })
 
 function RouteComponent() {
   const { hairOrderId } = Route.useParams()
+  const [createOpen, setCreateOpen] = useState(false)
   const [editItem, setEditItem] = useState<HairAssignedRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<HairAssignedRow | null>(null)
-  const detailData = useHairOrderDetailData(hairOrderId)
+  const detailData = useHairOrderDetailData(hairOrderId, createOpen)
   const relatedQueryKeys = [
     { queryKey: detailData.hairOrderQueryOptions.queryKey },
     ...detailData.assignedClientSummaryKeys,
@@ -44,6 +38,7 @@ function RouteComponent() {
   return (
     <HairOrderDetailPage
       detailData={detailData}
+      createOpen={createOpen}
       editItem={editItem}
       deleteItem={deleteItem}
       recalculatePending={recalculatePrices.isPending}
@@ -51,6 +46,7 @@ function RouteComponent() {
       createPending={createHairAssigned.isPending}
       updatePending={updateHairAssigned.isPending}
       deletePending={deleteHairAssigned.isPending}
+      onCreateOpenChange={setCreateOpen}
       onEditItemChange={setEditItem}
       onDeleteItemChange={setDeleteItem}
       onRecalculate={() => recalculatePrices.mutate({ hairOrderId })}

--- a/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
@@ -36,6 +36,7 @@ type HairOrderDetailData = ReturnType<typeof useHairOrderDetailData>
 
 export function HairOrderDetailPage({
   detailData,
+  createOpen,
   editItem,
   deleteItem,
   recalculatePending,
@@ -43,6 +44,7 @@ export function HairOrderDetailPage({
   createPending,
   updatePending,
   deletePending,
+  onCreateOpenChange,
   onEditItemChange,
   onDeleteItemChange,
   onRecalculate,
@@ -52,6 +54,7 @@ export function HairOrderDetailPage({
   onDelete,
 }: {
   detailData: HairOrderDetailData
+  createOpen: boolean
   editItem: HairAssignedRow | null
   deleteItem: HairAssignedRow | null
   recalculatePending: boolean
@@ -59,6 +62,7 @@ export function HairOrderDetailPage({
   createPending: boolean
   updatePending: boolean
   deletePending: boolean
+  onCreateOpenChange: (open: boolean) => void
   onEditItemChange: (item: HairAssignedRow | null) => void
   onDeleteItemChange: (item: HairAssignedRow | null) => void
   onRecalculate: () => void
@@ -67,7 +71,6 @@ export function HairOrderDetailPage({
   onUpdate: ComponentProps<typeof EditHairAssignedDialog>["onUpdate"]
   onDelete: (id: string) => void
 }) {
-  const [createOpen, setCreateOpen] = useState(false)
   const [editOrderOpen, setEditOrderOpen] = useState(false)
   const { hairOrder, availableHairOrders, availableHairOrdersLoading } = detailData
 
@@ -166,7 +169,7 @@ export function HairOrderDetailPage({
                 variant="default"
                 size="sm"
                 leftSection={<IconPlus size={12} />}
-                onClick={() => setCreateOpen(true)}
+                onClick={() => onCreateOpenChange(true)}
               >
                 Add
               </Button>
@@ -205,12 +208,12 @@ export function HairOrderDetailPage({
 
         <CreateHairAssignedDialog
           open={createOpen}
-          onOpenChange={setCreateOpen}
+          onOpenChange={onCreateOpenChange}
           clientId={hairOrder.customer.id}
           loading={createPending}
           onCreate={(values) => {
             onCreate(values)
-            setCreateOpen(false)
+            onCreateOpenChange(false)
           }}
           availableOrders={availableHairOrders}
           availableOrdersLoading={availableHairOrdersLoading}

--- a/apps/web/src/routes/_authenticated/hair-orders/-data/hair-order-detail-data.ts
+++ b/apps/web/src/routes/_authenticated/hair-orders/-data/hair-order-detail-data.ts
@@ -15,13 +15,14 @@ export function availableHairOrdersListQueryOptions() {
   })
 }
 
-export function useHairOrderDetailData(hairOrderId: string) {
+export function useHairOrderDetailData(hairOrderId: string, availableHairOrdersEnabled: boolean) {
   const hairOrderQueryOptions = hairOrderDetailQueryOptions(hairOrderId)
   const availableHairOrdersQueryOptions = availableHairOrdersListQueryOptions()
   const { data: hairOrder } = useQuery(hairOrderQueryOptions)
-  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery(
-    availableHairOrdersQueryOptions,
-  )
+  const { data: availableHairOrdersData, isLoading: availableHairOrdersLoading } = useQuery({
+    ...availableHairOrdersQueryOptions,
+    enabled: availableHairOrdersEnabled,
+  })
   const assignedClientSummaryKeys = Array.from(
     new Set([
       ...(hairOrder?.hairAssigned ?? []).map((ha) => ha.client.id),


### PR DESCRIPTION
## Summary
- move dialog open state to route owners for calendar, appointment, customer hair sales, and hair order detail pages
- enable dialog option queries only while the relevant dialog or modal is open
- add an architecture test preventing dialog option prefetches from route loaders

## Verification
- vp install
- vp check
- vp test
- vp run check-types