### PR TITLE
ci: exempt mantine from dependency maturity period

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -41,7 +41,7 @@ jobs:
           command: |
             set -eo pipefail
             log=$(mktemp)
-            vp dlx taze major -r -w --maturity-period 7 --concurrency 3 2>&1 | tee "$log"
+            vp dlx taze major -r -w --maturity-period 7 --maturity-period-exclude '@mantine/*' --concurrency 3 2>&1 | tee "$log"
             if grep -q 'Timeout requesting' "$log"; then
               echo "::warning::taze hit registry timeouts for one or more packages; continuing with resolved updates"
             fi


### PR DESCRIPTION
## Summary
- Exclude @mantine/* packages from the taze maturity-period filter in the nightly dependency update workflow
- Keep the 7-day maturity period for all other dependency updates

## Verification
- vp check
- vp test