### PR TITLE
ci: disable git hooks in dependency updater

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -9,6 +9,8 @@ jobs:
   taze:
     name: Run taze major
     runs-on: ubuntu-latest
+    env:
+      VITE_GIT_HOOKS: "0"
 
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Set VITE_GIT_HOOKS=0 for the nightly dependency update job
- Prevent Vite+ from installing local git hooks during the updater's vp install steps
- Allows peter-evans/create-pull-request to push the generated dependency branch; PR checks remain responsible for validating dependency changes

## Root Cause
The manual run reached the create-pull-request step, but its internal git push ran .vite-hooks/pre-push. After taze updated dependencies, that hook ran vp test in the updater job and failed on env validation before the branch could be pushed.

Failed run: https://github.com/moreorover/prive-admin/actions/runs/30656436378

## Verification
- vp check
- vp test