### PR TITLE
chore: enable UI oxlint plugins

### DIFF
--- a/apps/web/src/components/appointments/create-appointment-dialog.test.ts
+++ b/apps/web/src/components/appointments/create-appointment-dialog.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
-import { join, relative } from "node:path"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vite-plus/test"
 
@@ -17,18 +17,14 @@ function componentSourceFiles(dir: string): string[] {
 describe("component data ownership", () => {
   it.each(componentSourceFiles(componentsDir))("does not fetch route data inside %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const componentPath = relative(componentsDir, path)
-
-    expect(source, componentPath).not.toContain("useQuery(")
-    expect(source, componentPath).not.toContain("fetch(")
+    expect(source).not.toContain("useQuery(")
+    expect(source).not.toContain("fetch(")
   })
 
   it.each(componentSourceFiles(componentsDir))("does not mutate server data inside %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const componentPath = relative(componentsDir, path)
-
-    expect(source, componentPath).not.toContain("useMutation(")
-    expect(source, componentPath).not.toContain("mutationOptions(")
-    expect(source, componentPath).not.toContain(".mutate(")
+    expect(source).not.toContain("useMutation(")
+    expect(source).not.toContain("mutationOptions(")
+    expect(source).not.toContain(".mutate(")
   })
 })

--- a/apps/web/src/components/server-state-ownership.test.ts
+++ b/apps/web/src/components/server-state-ownership.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
-import { join, relative } from "node:path"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vite-plus/test"
 
@@ -18,10 +18,8 @@ function componentFiles(dir: string): string[] {
 describe("shared component server-state ownership", () => {
   it.each(componentFiles(componentsDir))("keeps server reads and writes out of %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const componentPath = relative(componentsDir, path)
-
-    expect(source, componentPath).not.toContain("useQuery(")
-    expect(source, componentPath).not.toContain("useSuspenseQuery(")
-    expect(source, componentPath).not.toContain("useMutation(")
+    expect(source).not.toContain("useQuery(")
+    expect(source).not.toContain("useSuspenseQuery(")
+    expect(source).not.toContain("useMutation(")
   })
 })

--- a/apps/web/src/routes/-route-component-organization.test.ts
+++ b/apps/web/src/routes/-route-component-organization.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
-import { join, relative } from "node:path"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vite-plus/test"
 
@@ -23,9 +23,7 @@ function publicRouteFiles(dir: string): string[] {
 describe("route component organization", () => {
   it.each(publicRouteFiles(routesDir))("keeps custom components outside route file %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const routePath = relative(routesDir, path)
-
-    expect(source, routePath).not.toMatch(/function\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*/)
-    expect(source, routePath).not.toMatch(/(?:const|let|var)\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*\s*=/)
+    expect(source).not.toMatch(/function\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*/)
+    expect(source).not.toMatch(/(?:const|let|var)\s+(?!Route\b|RouteComponent\b)[A-Z][A-Za-z0-9_]*\s*=/)
   })
 })

--- a/apps/web/src/routes/-route-helper-folder-organization.test.ts
+++ b/apps/web/src/routes/-route-helper-folder-organization.test.ts
@@ -12,14 +12,22 @@ const allowedFlatHelperFiles = new Set([
   "_authenticated/-route-data-organization.test.ts",
 ])
 
+function invalidHelperDirectories(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry)
+    if (!statSync(path).isDirectory()) return []
+    if (entry.startsWith("-")) {
+      return allowedHelperDirectories.has(entry) ? [] : [relative(routesDir, path)]
+    }
+    return invalidHelperDirectories(path)
+  })
+}
+
 function flatHelperFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
     const path = join(dir, entry)
     if (statSync(path).isDirectory()) {
-      if (entry.startsWith("-")) {
-        expect(allowedHelperDirectories.has(entry), relative(routesDir, path)).toBe(true)
-        return []
-      }
+      if (entry.startsWith("-")) return []
       return flatHelperFiles(path)
     }
 
@@ -44,6 +52,7 @@ function componentFiles(dir: string): string[] {
 
 describe("route helper folder organization", () => {
   it("keeps route-local helpers inside concern folders", () => {
+    expect(invalidHelperDirectories(routesDir)).toEqual([])
     expect(flatHelperFiles(routesDir)).toEqual([])
   })
 
@@ -51,16 +60,14 @@ describe("route helper folder organization", () => {
     const source = readFileSync(path, "utf8")
     const declarations = source.match(/function\s+[A-Z][A-Za-z0-9_]*|const\s+[A-Z][A-Za-z0-9_]*\s*=/g) ?? []
 
-    expect(declarations.length, relative(routesDir, path)).toBeLessThanOrEqual(4)
+    expect(declarations.length).toBeLessThanOrEqual(4)
   })
 
   it.each(componentFiles(routesDir))("keeps route-local components server-state free %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const routePath = relative(routesDir, path)
-
-    expect(source, routePath).not.toContain("useQuery(")
-    expect(source, routePath).not.toContain("useSuspenseQuery(")
-    expect(source, routePath).not.toContain("useMutation(")
-    expect(source, routePath).not.toMatch(/use[A-Z][A-Za-z0-9]*(Action|Actions)\(/)
+    expect(source).not.toContain("useQuery(")
+    expect(source).not.toContain("useSuspenseQuery(")
+    expect(source).not.toContain("useMutation(")
+    expect(source).not.toMatch(/use[A-Z][A-Za-z0-9]*(Action|Actions)\(/)
   })
 })

--- a/apps/web/src/routes/_authenticated/-route-data-organization.test.ts
+++ b/apps/web/src/routes/_authenticated/-route-data-organization.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
-import { join, relative } from "node:path"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vite-plus/test"
 
@@ -23,9 +23,7 @@ function routePageFiles(dir: string): string[] {
 describe("route data organization", () => {
   it.each(routePageFiles(routesDir))("keeps mutation orchestration outside %s", (path) => {
     const source = readFileSync(path, "utf8")
-    const routePath = relative(routesDir, path)
-
-    expect(source, routePath).not.toContain("useMutation({")
-    expect(source, routePath).not.toMatch(/const\s+\w*invalidate\w*\s*=/)
+    expect(source).not.toContain("useMutation({")
+    expect(source).not.toMatch(/const\s+\w*invalidate\w*\s*=/)
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,9 +34,29 @@ export default defineConfig({
     ignorePatterns: [".agents", "**/*.html", "docs", "routeTree.gen.ts", "packages/db/src/migrations"],
   },
   lint: {
+    plugins: ["typescript", "unicorn"],
     rules: {
       "vite-plus/prefer-vite-plus-imports": "error",
     },
+    overrides: [
+      {
+        files: ["**/*.test.ts", "**/*.test.tsx"],
+        plugins: ["typescript", "unicorn", "vitest"],
+      },
+      {
+        files: ["apps/web/**", "packages/ui/**"],
+        plugins: ["typescript", "unicorn", "react", "jsx-a11y"],
+      },
+      {
+        files: [
+          "apps/web/**/*.test.ts",
+          "apps/web/**/*.test.tsx",
+          "packages/ui/**/*.test.ts",
+          "packages/ui/**/*.test.tsx",
+        ],
+        plugins: ["typescript", "unicorn", "react", "jsx-a11y", "vitest"],
+      },
+    ],
     env: {
       builtin: true,
     },


### PR DESCRIPTION
## Summary
- Enable TypeScript and Unicorn Oxlint plugins globally in Vite+ config
- Enable React and JSX a11y Oxlint plugins for web/UI packages
- Enable Vitest Oxlint rules for test files
- Clean up architecture tests that passed ignored message arguments to Vitest expect

## Verification
- vp check
- vp test