### PR TITLE
feat: add hair sale event dates

### DIFF
--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -1,4 +1,6 @@
 import { Button, Group, Modal, Radio, Stack, Table, Text } from "@mantine/core"
+import { DateInput } from "@mantine/dates"
+import dayjs from "dayjs"
 import { useState } from "react"
 
 type CreateHairAssignedDialogProps = {
@@ -22,6 +24,7 @@ type CreateHairAssignedSubmit = {
   hairOrderId: string
   clientId: string
   appointmentId: string | null
+  soldAt?: Date
 }
 
 export function CreateHairAssignedDialog({
@@ -35,9 +38,12 @@ export function CreateHairAssignedDialog({
   availableOrdersLoading = false,
 }: CreateHairAssignedDialogProps) {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
+  const [soldAt, setSoldAt] = useState(() => dayjs().format("YYYY-MM-DD"))
+  const isIndividualSale = !appointmentId
 
   const handleClose = () => {
     setSelectedOrderId(null)
+    setSoldAt(dayjs().format("YYYY-MM-DD"))
     onOpenChange(false)
   }
 
@@ -47,6 +53,15 @@ export function CreateHairAssignedDialog({
         <Text size="sm" c="dimmed">
           Select a hair order with available stock.
         </Text>
+        {isIndividualSale && (
+          <DateInput
+            label="Date"
+            valueFormat="DD MMM YYYY"
+            value={soldAt}
+            onChange={(value) => setSoldAt(value ?? "")}
+            required
+          />
+        )}
         {availableOrdersLoading ? (
           <Text size="sm" c="dimmed">
             Loading…
@@ -88,11 +103,16 @@ export function CreateHairAssignedDialog({
             Cancel
           </Button>
           <Button
-            disabled={!selectedOrderId}
+            disabled={!selectedOrderId || (isIndividualSale && !soldAt)}
             loading={loading}
             onClick={() =>
               selectedOrderId &&
-              onCreate({ hairOrderId: selectedOrderId, clientId, appointmentId: appointmentId ?? null })
+              onCreate({
+                hairOrderId: selectedOrderId,
+                clientId,
+                appointmentId: appointmentId ?? null,
+                ...(isIndividualSale ? { soldAt: dayjs(soldAt).toDate() } : {}),
+              })
             }
           >
             Assign

--- a/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/create-hair-assigned-dialog.tsx
@@ -1,6 +1,4 @@
 import { Button, Group, Modal, Radio, Stack, Table, Text } from "@mantine/core"
-import { DateInput } from "@mantine/dates"
-import dayjs from "dayjs"
 import { useState } from "react"
 
 type CreateHairAssignedDialogProps = {
@@ -24,7 +22,6 @@ type CreateHairAssignedSubmit = {
   hairOrderId: string
   clientId: string
   appointmentId: string | null
-  soldAt?: Date
 }
 
 export function CreateHairAssignedDialog({
@@ -38,12 +35,9 @@ export function CreateHairAssignedDialog({
   availableOrdersLoading = false,
 }: CreateHairAssignedDialogProps) {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
-  const [soldAt, setSoldAt] = useState(() => dayjs().format("YYYY-MM-DD"))
-  const isIndividualSale = !appointmentId
 
   const handleClose = () => {
     setSelectedOrderId(null)
-    setSoldAt(dayjs().format("YYYY-MM-DD"))
     onOpenChange(false)
   }
 
@@ -53,15 +47,6 @@ export function CreateHairAssignedDialog({
         <Text size="sm" c="dimmed">
           Select a hair order with available stock.
         </Text>
-        {isIndividualSale && (
-          <DateInput
-            label="Date"
-            valueFormat="DD MMM YYYY"
-            value={soldAt}
-            onChange={(value) => setSoldAt(value ?? "")}
-            required
-          />
-        )}
         {availableOrdersLoading ? (
           <Text size="sm" c="dimmed">
             Loading…
@@ -103,7 +88,7 @@ export function CreateHairAssignedDialog({
             Cancel
           </Button>
           <Button
-            disabled={!selectedOrderId || (isIndividualSale && !soldAt)}
+            disabled={!selectedOrderId}
             loading={loading}
             onClick={() =>
               selectedOrderId &&
@@ -111,7 +96,6 @@ export function CreateHairAssignedDialog({
                 hairOrderId: selectedOrderId,
                 clientId,
                 appointmentId: appointmentId ?? null,
-                ...(isIndividualSale ? { soldAt: dayjs(soldAt).toDate() } : {}),
               })
             }
           >

--- a/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
+++ b/apps/web/src/components/hair-assigned/edit-hair-assigned-dialog.tsx
@@ -1,10 +1,19 @@
 import { Button, Group, Modal, NumberInput, Stack } from "@mantine/core"
+import { DateInput } from "@mantine/dates"
 import { useForm } from "@mantine/form"
+import dayjs from "dayjs"
 
 type EditHairAssignedDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  hairAssigned: { id: string; weightInGrams: number; soldFor: number; hairOrder?: { id: string } | null }
+  hairAssigned: {
+    id: string
+    appointmentId?: string | null
+    weightInGrams: number
+    soldFor: number
+    soldAt?: string | Date
+    hairOrder?: { id: string } | null
+  }
   loading?: boolean
   onUpdate: (values: EditHairAssignedSubmit) => void | Promise<void>
 }
@@ -13,6 +22,7 @@ type EditHairAssignedSubmit = {
   id: string
   weightInGrams: number
   soldFor: number
+  soldAt?: Date
 }
 
 export function EditHairAssignedDialog({
@@ -22,15 +32,21 @@ export function EditHairAssignedDialog({
   loading,
   onUpdate,
 }: EditHairAssignedDialogProps) {
+  const isIndividualSale = !hairAssigned.appointmentId
   const form = useForm({
-    initialValues: { weightInGrams: hairAssigned.weightInGrams, soldFor: hairAssigned.soldFor / 100 },
+    initialValues: {
+      weightInGrams: hairAssigned.weightInGrams,
+      soldFor: hairAssigned.soldFor / 100,
+      soldAt: hairAssigned.soldAt ? dayjs(hairAssigned.soldAt).format("YYYY-MM-DD") : dayjs().format("YYYY-MM-DD"),
+    },
   })
 
-  const handleSubmit = async (values: { weightInGrams: number; soldFor: number }) => {
+  const handleSubmit = async (values: { weightInGrams: number; soldFor: number; soldAt: string }) => {
     await onUpdate({
       id: hairAssigned.id,
       weightInGrams: values.weightInGrams,
       soldFor: Math.round(values.soldFor * 100),
+      ...(isIndividualSale ? { soldAt: dayjs(values.soldAt).toDate() } : {}),
     })
   }
 
@@ -38,6 +54,15 @@ export function EditHairAssignedDialog({
     <Modal opened={open} onClose={() => onOpenChange(false)} title="Edit Hair Assigned">
       <form onSubmit={form.onSubmit(handleSubmit)}>
         <Stack>
+          {isIndividualSale && (
+            <DateInput
+              label="Date"
+              valueFormat="DD MMM YYYY"
+              required
+              {...form.getInputProps("soldAt")}
+              onChange={(value) => form.setFieldValue("soldAt", value ?? "")}
+            />
+          )}
           <NumberInput label="Weight (grams)" min={0} {...form.getInputProps("weightInGrams")} />
           <NumberInput label="Sold For" min={0} decimalScale={2} step={0.01} {...form.getInputProps("soldFor")} />
           <Group justify="flex-end">

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.test.ts
@@ -5,6 +5,8 @@ import { createElement, Fragment } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vite-plus/test"
 
+import { LocaleProvider } from "@/lib/locale-context"
+
 import { getHairAssignedSource } from "./hair-assigned-source"
 import { HairAssignedTable } from "./hair-assigned-table"
 
@@ -16,6 +18,7 @@ const hairAssignedRows = [
     soldFor: 3400,
     profit: 1200,
     pricePerGram: 283,
+    soldAt: "2026-07-14T00:00:00.000Z",
     client: null,
     hairOrder: null,
   },
@@ -27,9 +30,13 @@ function renderHairAssignedTable(children: ReactNode) {
       MantineProvider,
       null,
       createElement(
-        HairAssignedTable,
-        { items: hairAssignedRows } as ComponentProps<typeof HairAssignedTable>,
-        children,
+        LocaleProvider,
+        { value: { locale: "en-GB", timeZone: "UTC" } },
+        createElement(
+          HairAssignedTable,
+          { items: hairAssignedRows } as ComponentProps<typeof HairAssignedTable>,
+          children,
+        ),
       ),
     ),
   )
@@ -76,6 +83,7 @@ describe("hair assigned table compound columns", () => {
         createElement(HairAssignedTable.Client),
         createElement(HairAssignedTable.Source),
         createElement(HairAssignedTable.HairOrder),
+        createElement(HairAssignedTable.SoldAt),
         createElement(HairAssignedTable.Actions, { onEdit: () => {}, onDelete: () => {} }),
       ),
     )
@@ -83,6 +91,8 @@ describe("hair assigned table compound columns", () => {
     expect(markup).toContain("Client")
     expect(markup).toContain("Source")
     expect(markup).toContain("Hair Order")
+    expect(markup).toContain("Sold At")
+    expect(markup).toContain("14/07/2026")
   })
 
   it("omits columns that are not declared", () => {

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -21,6 +21,7 @@ export type HairAssignedRow = {
   soldFor: number
   profit: number
   pricePerGram: number
+  soldAt?: string | Date
   client?: { id: string; name: string } | null
   hairOrder?: { id: string; uid: number } | null
 }

--- a/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
+++ b/apps/web/src/components/hair-assigned/hair-assigned-table.tsx
@@ -5,6 +5,7 @@ import { IconPencil, IconTrash } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 import { createContext, useContext } from "react"
 
+import { ClientDate } from "@/components/client-date"
 import {
   type CompoundTableColumnComponent,
   getCompoundTableColumns,
@@ -57,6 +58,7 @@ type HairAssignedTableComponent = ((props: HairAssignedTableRootProps) => ReactE
   Client: HairAssignedColumnComponent
   Source: HairAssignedColumnComponent
   HairOrder: HairAssignedColumnComponent
+  SoldAt: HairAssignedColumnComponent
   Weight: HairAssignedColumnComponent
   SoldFor: HairAssignedColumnComponent
   Profit: HairAssignedColumnComponent
@@ -226,6 +228,11 @@ const HairOrder = createColumn("hair-order", "Hair Order", () => {
   )
 })
 
+const SoldAt = createColumn("sold-at", "Sold At", () => {
+  const row = useHairAssignedRow()
+  return <Table.Td>{row.soldAt ? <ClientDate date={row.soldAt} /> : "—"}</Table.Td>
+})
+
 const Weight = createColumn("weight", "Weight", () => {
   const row = useHairAssignedRow()
   return <Table.Td>{row.weightInGrams}g</Table.Td>
@@ -250,6 +257,7 @@ export const HairAssignedTable = Object.assign(HairAssignedTableRoot, {
   Client,
   Source,
   HairOrder,
+  SoldAt,
   Weight,
   SoldFor,
   Profit,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,70 +9,66 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
-import { Route as AuthenticatedProfileRouteImport } from './routes/_authenticated/profile'
-import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
-import { Route as AuthenticatedCashRouteImport } from './routes/_authenticated/cash'
-import { Route as AuthenticatedCalendarRouteImport } from './routes/_authenticated/calendar'
-import { Route as AuthenticatedHairSalesRouteRouteImport } from './routes/_authenticated/hair-sales/route'
-import { Route as AuthenticatedHairOrdersRouteRouteImport } from './routes/_authenticated/hair-orders/route'
-import { Route as AuthenticatedDocumentsRouteRouteImport } from './routes/_authenticated/documents/route'
-import { Route as AuthenticatedCustomersRouteRouteImport } from './routes/_authenticated/customers/route'
+import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedAppointmentsRouteRouteImport } from './routes/_authenticated/appointments/route'
-import { Route as AuthenticatedSalonsIndexRouteImport } from './routes/_authenticated/salons/index'
-import { Route as AuthenticatedLegalEntitiesIndexRouteImport } from './routes/_authenticated/legal-entities/index'
-import { Route as AuthenticatedHairSalesIndexRouteImport } from './routes/_authenticated/hair-sales/index'
-import { Route as AuthenticatedHairOrdersIndexRouteImport } from './routes/_authenticated/hair-orders/index'
-import { Route as AuthenticatedDocumentsIndexRouteImport } from './routes/_authenticated/documents/index'
-import { Route as AuthenticatedCustomersIndexRouteImport } from './routes/_authenticated/customers/index'
-import { Route as AuthenticatedSalonsSalonIdRouteImport } from './routes/_authenticated/salons/$salonId'
-import { Route as AuthenticatedHairSalesHairSaleIdRouteImport } from './routes/_authenticated/hair-sales/$hairSaleId'
-import { Route as AuthenticatedHairOrdersHairOrderIdRouteImport } from './routes/_authenticated/hair-orders/$hairOrderId'
+import { Route as AuthenticatedCalendarRouteImport } from './routes/_authenticated/calendar'
+import { Route as AuthenticatedCashRouteImport } from './routes/_authenticated/cash'
+import { Route as AuthenticatedCustomersRouteRouteImport } from './routes/_authenticated/customers/route'
+import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
+import { Route as AuthenticatedDocumentsRouteRouteImport } from './routes/_authenticated/documents/route'
+import { Route as AuthenticatedHairOrdersRouteRouteImport } from './routes/_authenticated/hair-orders/route'
+import { Route as AuthenticatedHairSalesRouteRouteImport } from './routes/_authenticated/hair-sales/route'
+import { Route as AuthenticatedProfileRouteImport } from './routes/_authenticated/profile'
+import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as AuthenticatedAppointmentsAppointmentIdRouteImport } from './routes/_authenticated/appointments/$appointmentId'
-import { Route as AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/route'
+import { Route as AuthenticatedCustomersIndexRouteImport } from './routes/_authenticated/customers/index'
 import { Route as AuthenticatedCustomersCustomerIdRouteRouteImport } from './routes/_authenticated/customers/$customerId/route'
-import { Route as AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/index'
+import { Route as AuthenticatedDocumentsIndexRouteImport } from './routes/_authenticated/documents/index'
+import { Route as AuthenticatedHairOrdersIndexRouteImport } from './routes/_authenticated/hair-orders/index'
+import { Route as AuthenticatedHairOrdersHairOrderIdRouteImport } from './routes/_authenticated/hair-orders/$hairOrderId'
+import { Route as AuthenticatedHairSalesIndexRouteImport } from './routes/_authenticated/hair-sales/index'
+import { Route as AuthenticatedHairSalesHairSaleIdRouteImport } from './routes/_authenticated/hair-sales/$hairSaleId'
+import { Route as AuthenticatedLegalEntitiesIndexRouteImport } from './routes/_authenticated/legal-entities/index'
+import { Route as AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/route'
+import { Route as AuthenticatedSalonsIndexRouteImport } from './routes/_authenticated/salons/index'
+import { Route as AuthenticatedSalonsSalonIdRouteImport } from './routes/_authenticated/salons/$salonId'
 import { Route as AuthenticatedCustomersCustomerIdIndexRouteImport } from './routes/_authenticated/customers/$customerId/index'
-import { Route as AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/salons'
-import { Route as AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/reports'
-import { Route as AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/overview'
-import { Route as AuthenticatedDocumentsDocumentIdMatchRouteImport } from './routes/_authenticated/documents/$documentId/match'
-import { Route as AuthenticatedCustomersCustomerIdNotesRouteImport } from './routes/_authenticated/customers/$customerId/notes'
-import { Route as AuthenticatedCustomersCustomerIdHairSalesRouteImport } from './routes/_authenticated/customers/$customerId/hair-sales'
 import { Route as AuthenticatedCustomersCustomerIdAppointmentsRouteImport } from './routes/_authenticated/customers/$customerId/appointments'
+import { Route as AuthenticatedCustomersCustomerIdHairSalesRouteImport } from './routes/_authenticated/customers/$customerId/hair-sales'
+import { Route as AuthenticatedCustomersCustomerIdNotesRouteImport } from './routes/_authenticated/customers/$customerId/notes'
+import { Route as AuthenticatedDocumentsDocumentIdMatchRouteImport } from './routes/_authenticated/documents/$documentId/match'
+import { Route as AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/index'
+import { Route as AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/overview'
+import { Route as AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/reports'
+import { Route as AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/salons'
 import { Route as AuthenticatedLegalEntitiesLegalEntityIdBankAccountsIndexRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/index'
 import { Route as AuthenticatedLegalEntitiesLegalEntityIdBankAccountsBankAccountIdRouteImport } from './routes/_authenticated/legal-entities/$legalEntityId/bank-accounts/$bankAccountId'
 
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => AuthenticatedRouteRoute,
-} as any)
-const AuthenticatedProfileRoute = AuthenticatedProfileRouteImport.update({
-  id: '/profile',
-  path: '/profile',
-  getParentRoute: () => AuthenticatedRouteRoute,
-} as any)
-const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
+const AuthenticatedAppointmentsRouteRoute =
+  AuthenticatedAppointmentsRouteRouteImport.update({
+    id: '/appointments',
+    path: '/appointments',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedCalendarRoute = AuthenticatedCalendarRouteImport.update({
+  id: '/calendar',
+  path: '/calendar',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
 const AuthenticatedCashRoute = AuthenticatedCashRouteImport.update({
@@ -80,15 +76,21 @@ const AuthenticatedCashRoute = AuthenticatedCashRouteImport.update({
   path: '/cash',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
-const AuthenticatedCalendarRoute = AuthenticatedCalendarRouteImport.update({
-  id: '/calendar',
-  path: '/calendar',
+const AuthenticatedCustomersRouteRoute =
+  AuthenticatedCustomersRouteRouteImport.update({
+    id: '/customers',
+    path: '/customers',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
-const AuthenticatedHairSalesRouteRoute =
-  AuthenticatedHairSalesRouteRouteImport.update({
-    id: '/hair-sales',
-    path: '/hair-sales',
+const AuthenticatedDocumentsRouteRoute =
+  AuthenticatedDocumentsRouteRouteImport.update({
+    id: '/documents',
+    path: '/documents',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedHairOrdersRouteRoute =
@@ -97,22 +99,80 @@ const AuthenticatedHairOrdersRouteRoute =
     path: '/hair-orders',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedDocumentsRouteRoute =
-  AuthenticatedDocumentsRouteRouteImport.update({
-    id: '/documents',
-    path: '/documents',
+const AuthenticatedHairSalesRouteRoute =
+  AuthenticatedHairSalesRouteRouteImport.update({
+    id: '/hair-sales',
+    path: '/hair-sales',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedCustomersRouteRoute =
-  AuthenticatedCustomersRouteRouteImport.update({
-    id: '/customers',
-    path: '/customers',
+const AuthenticatedProfileRoute = AuthenticatedProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const AuthenticatedAppointmentsAppointmentIdRoute =
+  AuthenticatedAppointmentsAppointmentIdRouteImport.update({
+    id: '/$appointmentId',
+    path: '/$appointmentId',
+    getParentRoute: () => AuthenticatedAppointmentsRouteRoute,
+  } as any)
+const AuthenticatedCustomersIndexRoute =
+  AuthenticatedCustomersIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedCustomersRouteRoute,
+  } as any)
+const AuthenticatedCustomersCustomerIdRouteRoute =
+  AuthenticatedCustomersCustomerIdRouteRouteImport.update({
+    id: '/$customerId',
+    path: '/$customerId',
+    getParentRoute: () => AuthenticatedCustomersRouteRoute,
+  } as any)
+const AuthenticatedDocumentsIndexRoute =
+  AuthenticatedDocumentsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedDocumentsRouteRoute,
+  } as any)
+const AuthenticatedHairOrdersIndexRoute =
+  AuthenticatedHairOrdersIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedHairOrdersRouteRoute,
+  } as any)
+const AuthenticatedHairOrdersHairOrderIdRoute =
+  AuthenticatedHairOrdersHairOrderIdRouteImport.update({
+    id: '/$hairOrderId',
+    path: '/$hairOrderId',
+    getParentRoute: () => AuthenticatedHairOrdersRouteRoute,
+  } as any)
+const AuthenticatedHairSalesIndexRoute =
+  AuthenticatedHairSalesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
+  } as any)
+const AuthenticatedHairSalesHairSaleIdRoute =
+  AuthenticatedHairSalesHairSaleIdRouteImport.update({
+    id: '/$hairSaleId',
+    path: '/$hairSaleId',
+    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
+  } as any)
+const AuthenticatedLegalEntitiesIndexRoute =
+  AuthenticatedLegalEntitiesIndexRouteImport.update({
+    id: '/legal-entities/',
+    path: '/legal-entities/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedAppointmentsRouteRoute =
-  AuthenticatedAppointmentsRouteRouteImport.update({
-    id: '/appointments',
-    path: '/appointments',
+const AuthenticatedLegalEntitiesLegalEntityIdRouteRoute =
+  AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport.update({
+    id: '/legal-entities/$legalEntityId',
+    path: '/legal-entities/$legalEntityId',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedSalonsIndexRoute =
@@ -121,77 +181,11 @@ const AuthenticatedSalonsIndexRoute =
     path: '/salons/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedLegalEntitiesIndexRoute =
-  AuthenticatedLegalEntitiesIndexRouteImport.update({
-    id: '/legal-entities/',
-    path: '/legal-entities/',
-    getParentRoute: () => AuthenticatedRouteRoute,
-  } as any)
-const AuthenticatedHairSalesIndexRoute =
-  AuthenticatedHairSalesIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
-  } as any)
-const AuthenticatedHairOrdersIndexRoute =
-  AuthenticatedHairOrdersIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedHairOrdersRouteRoute,
-  } as any)
-const AuthenticatedDocumentsIndexRoute =
-  AuthenticatedDocumentsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedDocumentsRouteRoute,
-  } as any)
-const AuthenticatedCustomersIndexRoute =
-  AuthenticatedCustomersIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedCustomersRouteRoute,
-  } as any)
 const AuthenticatedSalonsSalonIdRoute =
   AuthenticatedSalonsSalonIdRouteImport.update({
     id: '/salons/$salonId',
     path: '/salons/$salonId',
     getParentRoute: () => AuthenticatedRouteRoute,
-  } as any)
-const AuthenticatedHairSalesHairSaleIdRoute =
-  AuthenticatedHairSalesHairSaleIdRouteImport.update({
-    id: '/$hairSaleId',
-    path: '/$hairSaleId',
-    getParentRoute: () => AuthenticatedHairSalesRouteRoute,
-  } as any)
-const AuthenticatedHairOrdersHairOrderIdRoute =
-  AuthenticatedHairOrdersHairOrderIdRouteImport.update({
-    id: '/$hairOrderId',
-    path: '/$hairOrderId',
-    getParentRoute: () => AuthenticatedHairOrdersRouteRoute,
-  } as any)
-const AuthenticatedAppointmentsAppointmentIdRoute =
-  AuthenticatedAppointmentsAppointmentIdRouteImport.update({
-    id: '/$appointmentId',
-    path: '/$appointmentId',
-    getParentRoute: () => AuthenticatedAppointmentsRouteRoute,
-  } as any)
-const AuthenticatedLegalEntitiesLegalEntityIdRouteRoute =
-  AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport.update({
-    id: '/legal-entities/$legalEntityId',
-    path: '/legal-entities/$legalEntityId',
-    getParentRoute: () => AuthenticatedRouteRoute,
-  } as any)
-const AuthenticatedCustomersCustomerIdRouteRoute =
-  AuthenticatedCustomersCustomerIdRouteRouteImport.update({
-    id: '/$customerId',
-    path: '/$customerId',
-    getParentRoute: () => AuthenticatedCustomersRouteRoute,
-  } as any)
-const AuthenticatedLegalEntitiesLegalEntityIdIndexRoute =
-  AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
   } as any)
 const AuthenticatedCustomersCustomerIdIndexRoute =
   AuthenticatedCustomersCustomerIdIndexRouteImport.update({
@@ -199,34 +193,10 @@ const AuthenticatedCustomersCustomerIdIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedCustomersCustomerIdRouteRoute,
   } as any)
-const AuthenticatedLegalEntitiesLegalEntityIdSalonsRoute =
-  AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport.update({
-    id: '/salons',
-    path: '/salons',
-    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
-  } as any)
-const AuthenticatedLegalEntitiesLegalEntityIdReportsRoute =
-  AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport.update({
-    id: '/reports',
-    path: '/reports',
-    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
-  } as any)
-const AuthenticatedLegalEntitiesLegalEntityIdOverviewRoute =
-  AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport.update({
-    id: '/overview',
-    path: '/overview',
-    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
-  } as any)
-const AuthenticatedDocumentsDocumentIdMatchRoute =
-  AuthenticatedDocumentsDocumentIdMatchRouteImport.update({
-    id: '/$documentId/match',
-    path: '/$documentId/match',
-    getParentRoute: () => AuthenticatedDocumentsRouteRoute,
-  } as any)
-const AuthenticatedCustomersCustomerIdNotesRoute =
-  AuthenticatedCustomersCustomerIdNotesRouteImport.update({
-    id: '/notes',
-    path: '/notes',
+const AuthenticatedCustomersCustomerIdAppointmentsRoute =
+  AuthenticatedCustomersCustomerIdAppointmentsRouteImport.update({
+    id: '/appointments',
+    path: '/appointments',
     getParentRoute: () => AuthenticatedCustomersCustomerIdRouteRoute,
   } as any)
 const AuthenticatedCustomersCustomerIdHairSalesRoute =
@@ -235,11 +205,41 @@ const AuthenticatedCustomersCustomerIdHairSalesRoute =
     path: '/hair-sales',
     getParentRoute: () => AuthenticatedCustomersCustomerIdRouteRoute,
   } as any)
-const AuthenticatedCustomersCustomerIdAppointmentsRoute =
-  AuthenticatedCustomersCustomerIdAppointmentsRouteImport.update({
-    id: '/appointments',
-    path: '/appointments',
+const AuthenticatedCustomersCustomerIdNotesRoute =
+  AuthenticatedCustomersCustomerIdNotesRouteImport.update({
+    id: '/notes',
+    path: '/notes',
     getParentRoute: () => AuthenticatedCustomersCustomerIdRouteRoute,
+  } as any)
+const AuthenticatedDocumentsDocumentIdMatchRoute =
+  AuthenticatedDocumentsDocumentIdMatchRouteImport.update({
+    id: '/$documentId/match',
+    path: '/$documentId/match',
+    getParentRoute: () => AuthenticatedDocumentsRouteRoute,
+  } as any)
+const AuthenticatedLegalEntitiesLegalEntityIdIndexRoute =
+  AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
+  } as any)
+const AuthenticatedLegalEntitiesLegalEntityIdOverviewRoute =
+  AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport.update({
+    id: '/overview',
+    path: '/overview',
+    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
+  } as any)
+const AuthenticatedLegalEntitiesLegalEntityIdReportsRoute =
+  AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport.update({
+    id: '/reports',
+    path: '/reports',
+    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
+  } as any)
+const AuthenticatedLegalEntitiesLegalEntityIdSalonsRoute =
+  AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport.update({
+    id: '/salons',
+    path: '/salons',
+    getParentRoute: () => AuthenticatedLegalEntitiesLegalEntityIdRouteRoute,
   } as any)
 const AuthenticatedLegalEntitiesLegalEntityIdBankAccountsIndexRoute =
   AuthenticatedLegalEntitiesLegalEntityIdBankAccountsIndexRouteImport.update({
@@ -480,11 +480,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated': {
@@ -494,39 +494,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/settings': {
-      id: '/_authenticated/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof AuthenticatedSettingsRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/profile': {
-      id: '/_authenticated/profile'
-      path: '/profile'
-      fullPath: '/profile'
-      preLoaderRoute: typeof AuthenticatedProfileRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/dashboard': {
-      id: '/_authenticated/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof AuthenticatedDashboardRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/cash': {
-      id: '/_authenticated/cash'
-      path: '/cash'
-      fullPath: '/cash'
-      preLoaderRoute: typeof AuthenticatedCashRouteImport
+    '/_authenticated/appointments': {
+      id: '/_authenticated/appointments'
+      path: '/appointments'
+      fullPath: '/appointments'
+      preLoaderRoute: typeof AuthenticatedAppointmentsRouteRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/calendar': {
@@ -536,25 +515,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCalendarRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
-    '/_authenticated/hair-sales': {
-      id: '/_authenticated/hair-sales'
-      path: '/hair-sales'
-      fullPath: '/hair-sales'
-      preLoaderRoute: typeof AuthenticatedHairSalesRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/hair-orders': {
-      id: '/_authenticated/hair-orders'
-      path: '/hair-orders'
-      fullPath: '/hair-orders'
-      preLoaderRoute: typeof AuthenticatedHairOrdersRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/documents': {
-      id: '/_authenticated/documents'
-      path: '/documents'
-      fullPath: '/documents'
-      preLoaderRoute: typeof AuthenticatedDocumentsRouteRouteImport
+    '/_authenticated/cash': {
+      id: '/_authenticated/cash'
+      path: '/cash'
+      fullPath: '/cash'
+      preLoaderRoute: typeof AuthenticatedCashRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/customers': {
@@ -564,11 +529,116 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCustomersRouteRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
-    '/_authenticated/appointments': {
-      id: '/_authenticated/appointments'
-      path: '/appointments'
-      fullPath: '/appointments'
-      preLoaderRoute: typeof AuthenticatedAppointmentsRouteRouteImport
+    '/_authenticated/dashboard': {
+      id: '/_authenticated/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof AuthenticatedDashboardRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/documents': {
+      id: '/_authenticated/documents'
+      path: '/documents'
+      fullPath: '/documents'
+      preLoaderRoute: typeof AuthenticatedDocumentsRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/hair-orders': {
+      id: '/_authenticated/hair-orders'
+      path: '/hair-orders'
+      fullPath: '/hair-orders'
+      preLoaderRoute: typeof AuthenticatedHairOrdersRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/hair-sales': {
+      id: '/_authenticated/hair-sales'
+      path: '/hair-sales'
+      fullPath: '/hair-sales'
+      preLoaderRoute: typeof AuthenticatedHairSalesRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/profile': {
+      id: '/_authenticated/profile'
+      path: '/profile'
+      fullPath: '/profile'
+      preLoaderRoute: typeof AuthenticatedProfileRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/settings': {
+      id: '/_authenticated/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthenticatedSettingsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/appointments/$appointmentId': {
+      id: '/_authenticated/appointments/$appointmentId'
+      path: '/$appointmentId'
+      fullPath: '/appointments/$appointmentId'
+      preLoaderRoute: typeof AuthenticatedAppointmentsAppointmentIdRouteImport
+      parentRoute: typeof AuthenticatedAppointmentsRouteRoute
+    }
+    '/_authenticated/customers/': {
+      id: '/_authenticated/customers/'
+      path: '/'
+      fullPath: '/customers/'
+      preLoaderRoute: typeof AuthenticatedCustomersIndexRouteImport
+      parentRoute: typeof AuthenticatedCustomersRouteRoute
+    }
+    '/_authenticated/customers/$customerId': {
+      id: '/_authenticated/customers/$customerId'
+      path: '/$customerId'
+      fullPath: '/customers/$customerId'
+      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdRouteRouteImport
+      parentRoute: typeof AuthenticatedCustomersRouteRoute
+    }
+    '/_authenticated/documents/': {
+      id: '/_authenticated/documents/'
+      path: '/'
+      fullPath: '/documents/'
+      preLoaderRoute: typeof AuthenticatedDocumentsIndexRouteImport
+      parentRoute: typeof AuthenticatedDocumentsRouteRoute
+    }
+    '/_authenticated/hair-orders/': {
+      id: '/_authenticated/hair-orders/'
+      path: '/'
+      fullPath: '/hair-orders/'
+      preLoaderRoute: typeof AuthenticatedHairOrdersIndexRouteImport
+      parentRoute: typeof AuthenticatedHairOrdersRouteRoute
+    }
+    '/_authenticated/hair-orders/$hairOrderId': {
+      id: '/_authenticated/hair-orders/$hairOrderId'
+      path: '/$hairOrderId'
+      fullPath: '/hair-orders/$hairOrderId'
+      preLoaderRoute: typeof AuthenticatedHairOrdersHairOrderIdRouteImport
+      parentRoute: typeof AuthenticatedHairOrdersRouteRoute
+    }
+    '/_authenticated/hair-sales/': {
+      id: '/_authenticated/hair-sales/'
+      path: '/'
+      fullPath: '/hair-sales/'
+      preLoaderRoute: typeof AuthenticatedHairSalesIndexRouteImport
+      parentRoute: typeof AuthenticatedHairSalesRouteRoute
+    }
+    '/_authenticated/hair-sales/$hairSaleId': {
+      id: '/_authenticated/hair-sales/$hairSaleId'
+      path: '/$hairSaleId'
+      fullPath: '/hair-sales/$hairSaleId'
+      preLoaderRoute: typeof AuthenticatedHairSalesHairSaleIdRouteImport
+      parentRoute: typeof AuthenticatedHairSalesRouteRoute
+    }
+    '/_authenticated/legal-entities/': {
+      id: '/_authenticated/legal-entities/'
+      path: '/legal-entities'
+      fullPath: '/legal-entities/'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/legal-entities/$legalEntityId': {
+      id: '/_authenticated/legal-entities/$legalEntityId'
+      path: '/legal-entities/$legalEntityId'
+      fullPath: '/legal-entities/$legalEntityId'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/salons/': {
@@ -578,89 +648,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSalonsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
-    '/_authenticated/legal-entities/': {
-      id: '/_authenticated/legal-entities/'
-      path: '/legal-entities'
-      fullPath: '/legal-entities/'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesIndexRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/hair-sales/': {
-      id: '/_authenticated/hair-sales/'
-      path: '/'
-      fullPath: '/hair-sales/'
-      preLoaderRoute: typeof AuthenticatedHairSalesIndexRouteImport
-      parentRoute: typeof AuthenticatedHairSalesRouteRoute
-    }
-    '/_authenticated/hair-orders/': {
-      id: '/_authenticated/hair-orders/'
-      path: '/'
-      fullPath: '/hair-orders/'
-      preLoaderRoute: typeof AuthenticatedHairOrdersIndexRouteImport
-      parentRoute: typeof AuthenticatedHairOrdersRouteRoute
-    }
-    '/_authenticated/documents/': {
-      id: '/_authenticated/documents/'
-      path: '/'
-      fullPath: '/documents/'
-      preLoaderRoute: typeof AuthenticatedDocumentsIndexRouteImport
-      parentRoute: typeof AuthenticatedDocumentsRouteRoute
-    }
-    '/_authenticated/customers/': {
-      id: '/_authenticated/customers/'
-      path: '/'
-      fullPath: '/customers/'
-      preLoaderRoute: typeof AuthenticatedCustomersIndexRouteImport
-      parentRoute: typeof AuthenticatedCustomersRouteRoute
-    }
     '/_authenticated/salons/$salonId': {
       id: '/_authenticated/salons/$salonId'
       path: '/salons/$salonId'
       fullPath: '/salons/$salonId'
       preLoaderRoute: typeof AuthenticatedSalonsSalonIdRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/hair-sales/$hairSaleId': {
-      id: '/_authenticated/hair-sales/$hairSaleId'
-      path: '/$hairSaleId'
-      fullPath: '/hair-sales/$hairSaleId'
-      preLoaderRoute: typeof AuthenticatedHairSalesHairSaleIdRouteImport
-      parentRoute: typeof AuthenticatedHairSalesRouteRoute
-    }
-    '/_authenticated/hair-orders/$hairOrderId': {
-      id: '/_authenticated/hair-orders/$hairOrderId'
-      path: '/$hairOrderId'
-      fullPath: '/hair-orders/$hairOrderId'
-      preLoaderRoute: typeof AuthenticatedHairOrdersHairOrderIdRouteImport
-      parentRoute: typeof AuthenticatedHairOrdersRouteRoute
-    }
-    '/_authenticated/appointments/$appointmentId': {
-      id: '/_authenticated/appointments/$appointmentId'
-      path: '/$appointmentId'
-      fullPath: '/appointments/$appointmentId'
-      preLoaderRoute: typeof AuthenticatedAppointmentsAppointmentIdRouteImport
-      parentRoute: typeof AuthenticatedAppointmentsRouteRoute
-    }
-    '/_authenticated/legal-entities/$legalEntityId': {
-      id: '/_authenticated/legal-entities/$legalEntityId'
-      path: '/legal-entities/$legalEntityId'
-      fullPath: '/legal-entities/$legalEntityId'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/customers/$customerId': {
-      id: '/_authenticated/customers/$customerId'
-      path: '/$customerId'
-      fullPath: '/customers/$customerId'
-      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdRouteRouteImport
-      parentRoute: typeof AuthenticatedCustomersRouteRoute
-    }
-    '/_authenticated/legal-entities/$legalEntityId/': {
-      id: '/_authenticated/legal-entities/$legalEntityId/'
-      path: '/'
-      fullPath: '/legal-entities/$legalEntityId/'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport
-      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
     }
     '/_authenticated/customers/$customerId/': {
       id: '/_authenticated/customers/$customerId/'
@@ -669,39 +662,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCustomersCustomerIdIndexRouteImport
       parentRoute: typeof AuthenticatedCustomersCustomerIdRouteRoute
     }
-    '/_authenticated/legal-entities/$legalEntityId/salons': {
-      id: '/_authenticated/legal-entities/$legalEntityId/salons'
-      path: '/salons'
-      fullPath: '/legal-entities/$legalEntityId/salons'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport
-      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
-    }
-    '/_authenticated/legal-entities/$legalEntityId/reports': {
-      id: '/_authenticated/legal-entities/$legalEntityId/reports'
-      path: '/reports'
-      fullPath: '/legal-entities/$legalEntityId/reports'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport
-      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
-    }
-    '/_authenticated/legal-entities/$legalEntityId/overview': {
-      id: '/_authenticated/legal-entities/$legalEntityId/overview'
-      path: '/overview'
-      fullPath: '/legal-entities/$legalEntityId/overview'
-      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport
-      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
-    }
-    '/_authenticated/documents/$documentId/match': {
-      id: '/_authenticated/documents/$documentId/match'
-      path: '/$documentId/match'
-      fullPath: '/documents/$documentId/match'
-      preLoaderRoute: typeof AuthenticatedDocumentsDocumentIdMatchRouteImport
-      parentRoute: typeof AuthenticatedDocumentsRouteRoute
-    }
-    '/_authenticated/customers/$customerId/notes': {
-      id: '/_authenticated/customers/$customerId/notes'
-      path: '/notes'
-      fullPath: '/customers/$customerId/notes'
-      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdNotesRouteImport
+    '/_authenticated/customers/$customerId/appointments': {
+      id: '/_authenticated/customers/$customerId/appointments'
+      path: '/appointments'
+      fullPath: '/customers/$customerId/appointments'
+      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdAppointmentsRouteImport
       parentRoute: typeof AuthenticatedCustomersCustomerIdRouteRoute
     }
     '/_authenticated/customers/$customerId/hair-sales': {
@@ -711,12 +676,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCustomersCustomerIdHairSalesRouteImport
       parentRoute: typeof AuthenticatedCustomersCustomerIdRouteRoute
     }
-    '/_authenticated/customers/$customerId/appointments': {
-      id: '/_authenticated/customers/$customerId/appointments'
-      path: '/appointments'
-      fullPath: '/customers/$customerId/appointments'
-      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdAppointmentsRouteImport
+    '/_authenticated/customers/$customerId/notes': {
+      id: '/_authenticated/customers/$customerId/notes'
+      path: '/notes'
+      fullPath: '/customers/$customerId/notes'
+      preLoaderRoute: typeof AuthenticatedCustomersCustomerIdNotesRouteImport
       parentRoute: typeof AuthenticatedCustomersCustomerIdRouteRoute
+    }
+    '/_authenticated/documents/$documentId/match': {
+      id: '/_authenticated/documents/$documentId/match'
+      path: '/$documentId/match'
+      fullPath: '/documents/$documentId/match'
+      preLoaderRoute: typeof AuthenticatedDocumentsDocumentIdMatchRouteImport
+      parentRoute: typeof AuthenticatedDocumentsRouteRoute
+    }
+    '/_authenticated/legal-entities/$legalEntityId/': {
+      id: '/_authenticated/legal-entities/$legalEntityId/'
+      path: '/'
+      fullPath: '/legal-entities/$legalEntityId/'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdIndexRouteImport
+      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
+    }
+    '/_authenticated/legal-entities/$legalEntityId/overview': {
+      id: '/_authenticated/legal-entities/$legalEntityId/overview'
+      path: '/overview'
+      fullPath: '/legal-entities/$legalEntityId/overview'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdOverviewRouteImport
+      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
+    }
+    '/_authenticated/legal-entities/$legalEntityId/reports': {
+      id: '/_authenticated/legal-entities/$legalEntityId/reports'
+      path: '/reports'
+      fullPath: '/legal-entities/$legalEntityId/reports'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdReportsRouteImport
+      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
+    }
+    '/_authenticated/legal-entities/$legalEntityId/salons': {
+      id: '/_authenticated/legal-entities/$legalEntityId/salons'
+      path: '/salons'
+      fullPath: '/legal-entities/$legalEntityId/salons'
+      preLoaderRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdSalonsRouteImport
+      parentRoute: typeof AuthenticatedLegalEntitiesLegalEntityIdRouteRoute
     }
     '/_authenticated/legal-entities/$legalEntityId/bank-accounts/': {
       id: '/_authenticated/legal-entities/$legalEntityId/bank-accounts/'

--- a/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/-components/appointment-detail-page.tsx
@@ -367,6 +367,7 @@ export function AppointmentDetailPage({
           <HairAssignedTable items={hairAssigned}>
             <HairAssignedTable.Client />
             <HairAssignedTable.HairOrder />
+            <HairAssignedTable.SoldAt />
             <HairAssignedTable.Weight />
             <HairAssignedTable.SoldFor />
             <HairAssignedTable.Profit />

--- a/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
+++ b/apps/web/src/routes/_authenticated/customers/$customerId/-components/hair-sales-page.tsx
@@ -97,6 +97,7 @@ export function HairSalesPage({
               <HairAssignedTable.Client />
               <HairAssignedTable.Source />
               <HairAssignedTable.HairOrder />
+              <HairAssignedTable.SoldAt />
               <HairAssignedTable.Weight />
               <HairAssignedTable.SoldFor />
               <HairAssignedTable.Profit />

--- a/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-orders/-components/hair-order-id-page.tsx
@@ -175,6 +175,7 @@ export function HairOrderDetailPage({
           >
             <HairAssignedTable items={hairOrder.hairAssigned ?? []}>
               <HairAssignedTable.Client />
+              <HairAssignedTable.SoldAt />
               <HairAssignedTable.Weight />
               <HairAssignedTable.SoldFor />
               <HairAssignedTable.Profit />

--- a/apps/web/src/routes/_authenticated/hair-sales/-components/hair-sale-id-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/-components/hair-sale-id-page.tsx
@@ -12,6 +12,7 @@ const formatCents = (cents: number) => `€${(cents / 100).toFixed(2)}`
 type HairSaleDetail = {
   id: string
   appointmentId: string | null
+  soldAt: string | Date
   createdAt: string | Date
   weightInGrams: number
   soldFor: number
@@ -122,12 +123,12 @@ export function HairSaleDetailPage({ sale }: { sale: HairSaleDetail | undefined 
                     />
                   )}
                 >
-                  <ClientDate date={sale.appointment?.startsAt ?? sale.createdAt} />
+                  <ClientDate date={sale.soldAt} />
                 </Anchor>
               </Group>
             ) : (
               <Text size="sm" c="dimmed">
-                Direct sale created <ClientDate date={sale.createdAt} />.
+                Direct sale sold <ClientDate date={sale.soldAt} />.
               </Text>
             )}
           </Stack>

--- a/apps/web/src/routes/_authenticated/hair-sales/-components/index-page.tsx
+++ b/apps/web/src/routes/_authenticated/hair-sales/-components/index-page.tsx
@@ -25,7 +25,7 @@ import { type HairSalesSource, PAGE_SIZE } from "../-data/index-data"
 type HairSale = {
   id: string
   appointmentId?: string | null
-  createdAt: string | Date
+  soldAt: string | Date
   weightInGrams: number
   soldFor: number
   profit: number
@@ -154,7 +154,7 @@ export function HairSalesPage({
                   <Table.Td>{formatCents(sale.soldFor)}</Table.Td>
                   <Table.Td>{formatCents(sale.profit)}</Table.Td>
                   <Table.Td>
-                    <ClientDate date={sale.appointment?.startsAt ?? sale.createdAt} />
+                    <ClientDate date={sale.soldAt} />
                   </Table.Td>
                   <Table.Td>
                     <Button

--- a/packages/api/src/routers/hair-assigned.ts
+++ b/packages/api/src/routers/hair-assigned.ts
@@ -53,7 +53,6 @@ export const hairAssignedRouter = router({
         hairOrderId: z.string().min(1),
         clientId: z.string().min(1),
         appointmentId: z.string().nullish(),
-        soldAt: z.coerce.date().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -62,7 +61,6 @@ export const hairAssignedRouter = router({
           hairOrderId: input.hairOrderId,
           clientId: input.clientId,
           appointmentId: input.appointmentId ?? null,
-          soldAt: input.soldAt,
           createdById: ctx.session.user.id,
         })
       } catch (error) {

--- a/packages/api/src/routers/hair-assigned.ts
+++ b/packages/api/src/routers/hair-assigned.ts
@@ -53,6 +53,7 @@ export const hairAssignedRouter = router({
         hairOrderId: z.string().min(1),
         clientId: z.string().min(1),
         appointmentId: z.string().nullish(),
+        soldAt: z.coerce.date().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -61,6 +62,7 @@ export const hairAssignedRouter = router({
           hairOrderId: input.hairOrderId,
           clientId: input.clientId,
           appointmentId: input.appointmentId ?? null,
+          soldAt: input.soldAt,
           createdById: ctx.session.user.id,
         })
       } catch (error) {
@@ -74,6 +76,7 @@ export const hairAssignedRouter = router({
         id: z.string().min(1),
         weightInGrams: z.number().int().min(0),
         soldFor: z.number().int().min(0),
+        soldAt: z.coerce.date().optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -82,6 +85,7 @@ export const hairAssignedRouter = router({
           id: input.id,
           weightInGrams: input.weightInGrams,
           soldFor: input.soldFor,
+          soldAt: input.soldAt,
         })
       } catch (error) {
         throw toTrpcError(error)

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -144,7 +144,7 @@ describe("resource read routers", () => {
     expect(servicesMock.getHairAssigned).toHaveBeenCalledWith("hair-sale-1")
   })
 
-  it("creates a hair sale with the selected event date", async () => {
+  it("creates a hair sale without accepting a selected event date", async () => {
     const caller = hairAssignedRouter.createCaller(ctx)
     const hairSale = { id: "hair-sale-1", clientId: "customer-1" }
     const soldAt = new Date("2026-07-14T00:00:00.000Z")
@@ -156,13 +156,12 @@ describe("resource read routers", () => {
         clientId: "customer-1",
         appointmentId: null,
         soldAt,
-      }),
+      } as never),
     ).resolves.toBe(hairSale)
     expect(servicesMock.createHairAssigned).toHaveBeenCalledWith({
       hairOrderId: "hair-order-1",
       clientId: "customer-1",
       appointmentId: null,
-      soldAt,
       createdById: "user-1",
     })
   })

--- a/packages/api/src/routers/resource-reads.test.ts
+++ b/packages/api/src/routers/resource-reads.test.ts
@@ -19,6 +19,8 @@ const servicesMock = vi.hoisted(() => ({
   createBankAccount: vi.fn(),
   getBankAccount: vi.fn(),
   getHairAssigned: vi.fn(),
+  createHairAssigned: vi.fn(),
+  updateHairAssigned: vi.fn(),
   updateBankAccount: vi.fn(),
   listHairAssigned: vi.fn(),
   listHairOrders: vi.fn(),
@@ -140,6 +142,51 @@ describe("resource read routers", () => {
 
     await expect(caller.get({ id: "hair-sale-1" })).resolves.toBe(hairSale)
     expect(servicesMock.getHairAssigned).toHaveBeenCalledWith("hair-sale-1")
+  })
+
+  it("creates a hair sale with the selected event date", async () => {
+    const caller = hairAssignedRouter.createCaller(ctx)
+    const hairSale = { id: "hair-sale-1", clientId: "customer-1" }
+    const soldAt = new Date("2026-07-14T00:00:00.000Z")
+    servicesMock.createHairAssigned.mockResolvedValue(hairSale)
+
+    await expect(
+      caller.create({
+        hairOrderId: "hair-order-1",
+        clientId: "customer-1",
+        appointmentId: null,
+        soldAt,
+      }),
+    ).resolves.toBe(hairSale)
+    expect(servicesMock.createHairAssigned).toHaveBeenCalledWith({
+      hairOrderId: "hair-order-1",
+      clientId: "customer-1",
+      appointmentId: null,
+      soldAt,
+      createdById: "user-1",
+    })
+  })
+
+  it("updates a hair sale with the selected event date", async () => {
+    const caller = hairAssignedRouter.createCaller(ctx)
+    const hairSale = { id: "hair-sale-1", clientId: "customer-1" }
+    const soldAt = new Date("2026-07-15T00:00:00.000Z")
+    servicesMock.updateHairAssigned.mockResolvedValue(hairSale)
+
+    await expect(
+      caller.update({
+        id: "hair-sale-1",
+        weightInGrams: 80,
+        soldFor: 12000,
+        soldAt,
+      }),
+    ).resolves.toBe(hairSale)
+    expect(servicesMock.updateHairAssigned).toHaveBeenCalledWith({
+      id: "hair-sale-1",
+      weightInGrams: 80,
+      soldFor: 12000,
+      soldAt,
+    })
   })
 
   it("lists customers with page offset applied", async () => {

--- a/packages/application/src/services/hair.test.ts
+++ b/packages/application/src/services/hair.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+const dbMock = vi.hoisted(() => ({
+  query: {
+    appointment: {
+      findFirst: vi.fn(),
+    },
+  },
+  transaction: vi.fn(),
+}))
+
+const repositoryMock = vi.hoisted(() => ({
+  createHairAssigned: vi.fn(),
+  updateHairAssigned: vi.fn(),
+}))
+
+vi.mock("@prive-admin-tanstack/db", () => ({
+  db: dbMock,
+  createHairAssigned: repositoryMock.createHairAssigned,
+  updateHairAssigned: repositoryMock.updateHairAssigned,
+}))
+
+import { createHairAssigned, updateHairAssigned } from "./hair"
+
+describe("hair service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("creates an individual hair sale with the selected sale date", async () => {
+    repositoryMock.createHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
+
+    await createHairAssigned({
+      hairOrderId: "hair-order-1",
+      clientId: "customer-1",
+      appointmentId: null,
+      soldAt: new Date("2026-07-14T00:00:00.000Z"),
+      createdById: "user-1",
+    })
+
+    expect(repositoryMock.createHairAssigned).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        appointmentId: null,
+        soldAt: new Date("2026-07-14T00:00:00.000Z"),
+      }),
+    )
+  })
+
+  it("uses the appointment start date when assigning hair through an appointment", async () => {
+    dbMock.query.appointment.findFirst.mockResolvedValue({ startsAt: new Date("2026-07-21T09:30:00.000Z") })
+    repositoryMock.createHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
+
+    await createHairAssigned({
+      hairOrderId: "hair-order-1",
+      clientId: "customer-1",
+      appointmentId: "appointment-1",
+      soldAt: new Date("2026-07-14T00:00:00.000Z"),
+      createdById: "user-1",
+    })
+
+    expect(repositoryMock.createHairAssigned).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        appointmentId: "appointment-1",
+        soldAt: new Date("2026-07-21T09:30:00.000Z"),
+      }),
+    )
+  })
+
+  it("updates an individual hair sale with the selected sale date", async () => {
+    const tx = {
+      query: {
+        hairAssigned: {
+          findFirst: vi.fn().mockResolvedValue({
+            appointmentId: null,
+            hairOrderId: "hair-order-1",
+            weightInGrams: 40,
+          }),
+        },
+      },
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            for: vi
+              .fn()
+              .mockResolvedValue([{ id: "hair-order-1", weightReceived: 100, weightUsed: 40, pricePerGram: 50 }]),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+    }
+    dbMock.transaction = vi.fn(async (callback) => callback(tx))
+    repositoryMock.updateHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
+
+    await updateHairAssigned({
+      id: "hair-assigned-1",
+      weightInGrams: 50,
+      soldFor: 6000,
+      soldAt: new Date("2026-07-15T00:00:00.000Z"),
+    })
+
+    expect(repositoryMock.updateHairAssigned).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        id: "hair-assigned-1",
+        soldAt: new Date("2026-07-15T00:00:00.000Z"),
+      }),
+    )
+  })
+})

--- a/packages/application/src/services/hair.test.ts
+++ b/packages/application/src/services/hair.test.ts
@@ -27,22 +27,26 @@ describe("hair service", () => {
     vi.clearAllMocks()
   })
 
-  it("creates an individual hair sale with the selected sale date", async () => {
+  it("creates an individual hair sale without overriding the sale date", async () => {
     repositoryMock.createHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
 
     await createHairAssigned({
       hairOrderId: "hair-order-1",
       clientId: "customer-1",
       appointmentId: null,
-      soldAt: new Date("2026-07-14T00:00:00.000Z"),
       createdById: "user-1",
     })
 
     expect(repositoryMock.createHairAssigned).toHaveBeenCalledWith(
       undefined,
+      expect.not.objectContaining({
+        soldAt: expect.any(Date),
+      }),
+    )
+    expect(repositoryMock.createHairAssigned).toHaveBeenCalledWith(
+      undefined,
       expect.objectContaining({
         appointmentId: null,
-        soldAt: new Date("2026-07-14T00:00:00.000Z"),
       }),
     )
   })
@@ -55,7 +59,6 @@ describe("hair service", () => {
       hairOrderId: "hair-order-1",
       clientId: "customer-1",
       appointmentId: "appointment-1",
-      soldAt: new Date("2026-07-14T00:00:00.000Z"),
       createdById: "user-1",
     })
 

--- a/packages/application/src/services/hair.ts
+++ b/packages/application/src/services/hair.ts
@@ -11,6 +11,7 @@ import {
   updateHairOrder as patchHairOrder,
 } from "@prive-admin-tanstack/db"
 import { db } from "@prive-admin-tanstack/db"
+import { appointment } from "@prive-admin-tanstack/db/schema/appointment"
 import { hairAssigned, hairOrder } from "@prive-admin-tanstack/db/schema/hair"
 import { eq, sql } from "drizzle-orm"
 
@@ -133,18 +134,29 @@ export async function createHairAssigned(input: {
   hairOrderId: string
   clientId: string
   appointmentId?: string | null
+  soldAt?: Date
   createdById: string
 }) {
-  const result = await insertHairAssigned(undefined, input)
+  const soldAt = input.appointmentId ? await appointmentStartsAt(input.appointmentId) : input.soldAt
+  const result = await insertHairAssigned(undefined, { ...input, soldAt })
   if (!result) throw unexpectedError("Failed to create hair assignment")
   return result
 }
 
-export async function updateHairAssigned(input: { id: string; weightInGrams: number; soldFor: number }) {
+async function appointmentStartsAt(appointmentId: string) {
+  const result = await db.query.appointment.findFirst({
+    where: eq(appointment.id, appointmentId),
+    columns: { startsAt: true },
+  })
+  if (!result) throw notFound("Appointment not found")
+  return result.startsAt
+}
+
+export async function updateHairAssigned(input: { id: string; weightInGrams: number; soldFor: number; soldAt?: Date }) {
   return await db.transaction(async (tx) => {
     const existing = await tx.query.hairAssigned.findFirst({
       where: eq(hairAssigned.id, input.id),
-      columns: { hairOrderId: true, weightInGrams: true },
+      columns: { appointmentId: true, hairOrderId: true, weightInGrams: true },
     })
     if (!existing) throw notFound("Hair assigned not found")
 
@@ -158,6 +170,7 @@ export async function updateHairAssigned(input: { id: string; weightInGrams: num
 
     const pricePerGram = input.weightInGrams > 0 ? Math.round(input.soldFor / input.weightInGrams) : 0
     const profit = input.soldFor - input.weightInGrams * parentOrder.pricePerGram
+    const soldAt = existing.appointmentId ? await appointmentStartsAt(existing.appointmentId) : input.soldAt
 
     const updated = await patchHairAssigned(tx as any, {
       id: input.id,
@@ -165,6 +178,7 @@ export async function updateHairAssigned(input: { id: string; weightInGrams: num
       soldFor: input.soldFor,
       pricePerGram,
       profit,
+      soldAt,
     })
     if (!updated) throw unexpectedError("Failed to update hair assignment")
 

--- a/packages/application/src/services/hair.ts
+++ b/packages/application/src/services/hair.ts
@@ -134,10 +134,9 @@ export async function createHairAssigned(input: {
   hairOrderId: string
   clientId: string
   appointmentId?: string | null
-  soldAt?: Date
   createdById: string
 }) {
-  const soldAt = input.appointmentId ? await appointmentStartsAt(input.appointmentId) : input.soldAt
+  const soldAt = input.appointmentId ? await appointmentStartsAt(input.appointmentId) : undefined
   const result = await insertHairAssigned(undefined, { ...input, soldAt })
   if (!result) throw unexpectedError("Failed to create hair assignment")
   return result

--- a/packages/db/src/migrations/0008_little_callisto.sql
+++ b/packages/db/src/migrations/0008_little_callisto.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "hair_assigned" ADD COLUMN "sold_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "hair_assigned"
+SET "sold_at" = coalesce("appointment"."starts_at", "hair_assigned"."created_at")
+FROM "appointment"
+WHERE "hair_assigned"."appointment_id" = "appointment"."id";
+--> statement-breakpoint
+UPDATE "hair_assigned"
+SET "sold_at" = "created_at"
+WHERE "sold_at" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "hair_assigned" ALTER COLUMN "sold_at" SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "hair_assigned" ALTER COLUMN "sold_at" SET NOT NULL;

--- a/packages/db/src/migrations/meta/0008_snapshot.json
+++ b/packages/db/src/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2040 @@
+{
+  "id": "d50a54b4-ff14-424a-9618-8be19eb7c710",
+  "prevId": "14f09c25-b5e9-4b6d-b2f1-bf5d3421b78f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salon_id": {
+          "name": "salon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_client_id_customer_id_fk": {
+          "name": "appointment_client_id_customer_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "appointment_master_id_customer_id_fk": {
+          "name": "appointment_master_id_customer_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "appointment_salon_id_salon_id_fk": {
+          "name": "appointment_salon_id_salon_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "salon",
+          "columnsFrom": [
+            "salon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_personnel": {
+      "name": "appointment_personnel",
+      "schema": "",
+      "columns": {
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personnel_id": {
+          "name": "personnel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_personnel_appointment_id_appointment_id_fk": {
+          "name": "appointment_personnel_appointment_id_appointment_id_fk",
+          "tableFrom": "appointment_personnel",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "appointment_personnel_personnel_id_customer_id_fk": {
+          "name": "appointment_personnel_personnel_id_customer_id_fk",
+          "tableFrom": "appointment_personnel",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "personnel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "appointment_personnel_personnel_id_appointment_id_pk": {
+          "name": "appointment_personnel_personnel_id_appointment_id_pk",
+          "columns": [
+            "personnel_id",
+            "appointment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_account": {
+      "name": "bank_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legal_entity_id": {
+          "name": "legal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swift": {
+          "name": "swift",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_account_legal_entity_id_legal_entity_id_fk": {
+          "name": "bank_account_legal_entity_id_legal_entity_id_fk",
+          "tableFrom": "bank_account",
+          "tableTo": "legal_entity",
+          "columnsFrom": [
+            "legal_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_account_iban_unique": {
+          "name": "bank_account_iban_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iban"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_statement_attachment": {
+      "name": "bank_statement_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_statement_entry_id": {
+          "name": "bank_statement_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_statement_attachment_bank_statement_entry_id_bank_statement_entry_id_fk": {
+          "name": "bank_statement_attachment_bank_statement_entry_id_bank_statement_entry_id_fk",
+          "tableFrom": "bank_statement_attachment",
+          "tableTo": "bank_statement_entry",
+          "columnsFrom": [
+            "bank_statement_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_statement_attachment_uploaded_by_id_users_id_fk": {
+          "name": "bank_statement_attachment_uploaded_by_id_users_id_fk",
+          "tableFrom": "bank_statement_attachment",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_statement_attachment_r2_key_unique": {
+          "name": "bank_statement_attachment_r2_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "r2_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_statement_entry": {
+      "name": "bank_statement_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_number": {
+          "name": "doc_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_name": {
+          "name": "counterparty_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_iban": {
+          "name": "counterparty_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_bank": {
+          "name": "counterparty_bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swift": {
+          "name": "swift",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_statement_entry_bank_account_id_bank_account_id_fk": {
+          "name": "bank_statement_entry_bank_account_id_bank_account_id_fk",
+          "tableFrom": "bank_statement_entry",
+          "tableTo": "bank_account",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bank_statement_entry_account_ref_unique": {
+          "name": "bank_statement_entry_account_ref_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bank_account_id",
+            "external_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cash_transaction": {
+      "name": "cash_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cash_transaction_created_at_id_idx": {
+          "name": "cash_transaction_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cash_transaction_customer_id_idx": {
+          "name": "cash_transaction_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cash_transaction_currency_created_at_idx": {
+          "name": "cash_transaction_currency_created_at_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cash_transaction_customer_id_customer_id_fk": {
+          "name": "cash_transaction_customer_id_customer_id_fk",
+          "tableFrom": "cash_transaction",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cash_transaction_created_by_id_users_id_fk": {
+          "name": "cash_transaction_created_by_id_users_id_fk",
+          "tableFrom": "cash_transaction",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer": {
+      "name": "customer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_name_unique": {
+          "name": "customer_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hair_assigned": {
+      "name": "hair_assigned",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hair_order_id": {
+          "name": "hair_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_in_grams": {
+          "name": "weight_in_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sold_for": {
+          "name": "sold_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profit": {
+          "name": "profit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "price_per_gram": {
+          "name": "price_per_gram",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hair_assigned_appointment_id_appointment_id_fk": {
+          "name": "hair_assigned_appointment_id_appointment_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_hair_order_id_hair_order_id_fk": {
+          "name": "hair_assigned_hair_order_id_hair_order_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "hair_order",
+          "columnsFrom": [
+            "hair_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_client_id_customer_id_fk": {
+          "name": "hair_assigned_client_id_customer_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_assigned_created_by_id_users_id_fk": {
+          "name": "hair_assigned_created_by_id_users_id_fk",
+          "tableFrom": "hair_assigned",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hair_order": {
+      "name": "hair_order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "weight_received": {
+          "name": "weight_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weight_used": {
+          "name": "weight_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "price_per_gram": {
+          "name": "price_per_gram",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hair_order_customer_id_customer_id_fk": {
+          "name": "hair_order_customer_id_customer_id_fk",
+          "tableFrom": "hair_order",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hair_order_created_by_id_users_id_fk": {
+          "name": "hair_order_created_by_id_users_id_fk",
+          "tableFrom": "hair_order",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hair_order_uid_unique": {
+          "name": "hair_order_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_currency": {
+          "name": "preferred_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant": {
+      "name": "product_variant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_variant_product_id_product_id_fk": {
+          "name": "product_variant_product_id_product_id_fk",
+          "tableFrom": "product_variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_variant_product_id_size_unique": {
+          "name": "product_variant_product_id_size_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "product_id",
+            "size"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PURCHASE'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_customer_id_customer_id_fk": {
+          "name": "order_customer_id_customer_id_fk",
+          "tableFrom": "order",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_item": {
+      "name": "order_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_item_order_id_order_id_fk": {
+          "name": "order_item_order_id_order_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_item_product_variant_id_product_variant_id_fk": {
+          "name": "order_item_product_variant_id_product_variant_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "product_variant",
+          "columnsFrom": [
+            "product_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_item_order_id_product_variant_id_unique": {
+          "name": "order_item_order_id_product_variant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order_id",
+            "product_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_customer_id_customer_id_fk": {
+          "name": "transaction_customer_id_customer_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_order_id_order_id_fk": {
+          "name": "transaction_order_id_order_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_appointment_id_appointment_id_fk": {
+          "name": "transaction_appointment_id_appointment_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legal_entity": {
+      "name": "legal_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.salon": {
+      "name": "salon",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hair_order_id": {
+          "name": "hair_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_customer_id_customer_id_fk": {
+          "name": "note_customer_id_customer_id_fk",
+          "tableFrom": "note",
+          "tableTo": "customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_appointment_id_appointment_id_fk": {
+          "name": "note_appointment_id_appointment_id_fk",
+          "tableFrom": "note",
+          "tableTo": "appointment",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_hair_order_id_hair_order_id_fk": {
+          "name": "note_hair_order_id_hair_order_id_fk",
+          "tableFrom": "note",
+          "tableTo": "hair_order",
+          "columnsFrom": [
+            "hair_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_created_by_id_users_id_fk": {
+          "name": "note_created_by_id_users_id_fk",
+          "tableFrom": "note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783001514529,
       "tag": "0007_parched_shiva",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785605973476,
+      "tag": "0008_little_callisto",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/dashboard.test.ts
+++ b/packages/db/src/repositories/dashboard.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test"
 import { appointment } from "../schema/appointment"
 import { hairAssigned } from "../schema/hair"
 import { transaction } from "../schema/transaction"
-import { transactionMonthlyRows } from "./dashboard"
+import { hairAssignedMonthlyRows, transactionMonthlyRows } from "./dashboard"
 
 vi.mock("../index", () => ({ db: {} }))
 
@@ -38,5 +38,38 @@ describe("dashboard repository", () => {
     expect(calls.innerJoin?.table).toBe(appointment)
     expect(monthExpressionChunks).toContain(appointment.startsAt)
     expect(monthExpressionChunks).not.toContain(hairAssigned.soldAt)
+  })
+
+  it("builds appointment hair dashboard stats from hair sale dates", async () => {
+    let fromTable: unknown
+    let selectShape: { month: unknown } | undefined
+    let groupByExpression: unknown
+    const builder = {
+      from: vi.fn((table: unknown) => {
+        fromTable = table
+        return builder
+      }),
+      groupBy: vi.fn(async (expression: unknown) => {
+        groupByExpression = expression
+        return []
+      }),
+      where: vi.fn(() => builder),
+    }
+    const database = {
+      select: vi.fn((shape: { month: unknown }) => {
+        selectShape = shape
+        return builder
+      }),
+    }
+
+    await hairAssignedMonthlyRows(database as never, { year: 2026 })
+
+    const monthExpression = selectShape?.month as { queryChunks?: unknown[] } | undefined
+    const monthExpressionChunks = monthExpression?.queryChunks ?? []
+    const groupByExpressionChunks = (groupByExpression as { queryChunks?: unknown[] }).queryChunks ?? []
+    expect(fromTable).toBe(hairAssigned)
+    expect(monthExpressionChunks).toContain(hairAssigned.soldAt)
+    expect(monthExpressionChunks).not.toContain(appointment.startsAt)
+    expect(groupByExpressionChunks).toContain(hairAssigned.soldAt)
   })
 })

--- a/packages/db/src/repositories/dashboard.test.ts
+++ b/packages/db/src/repositories/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test"
 
 import { appointment } from "../schema/appointment"
+import { hairAssigned } from "../schema/hair"
 import { transaction } from "../schema/transaction"
 import { transactionMonthlyRows } from "./dashboard"
 
@@ -9,6 +10,7 @@ vi.mock("../index", () => ({ db: {} }))
 describe("dashboard repository", () => {
   it("builds transaction dashboard stats from appointment-linked transaction rows", async () => {
     const calls: { from?: unknown; innerJoin?: { table: unknown; condition: unknown } } = {}
+    let selectShape: { month: unknown } | undefined
     const builder = {
       from: vi.fn((table: unknown) => {
         calls.from = table
@@ -22,12 +24,19 @@ describe("dashboard repository", () => {
       where: vi.fn(() => builder),
     }
     const database = {
-      select: vi.fn(() => builder),
+      select: vi.fn((shape: { month: unknown }) => {
+        selectShape = shape
+        return builder
+      }),
     }
 
     await transactionMonthlyRows(database as never, { year: 2026 })
 
+    const monthExpression = selectShape?.month as { queryChunks?: unknown[] } | undefined
+    const monthExpressionChunks = monthExpression?.queryChunks ?? []
     expect(calls.from).toBe(transaction)
     expect(calls.innerJoin?.table).toBe(appointment)
+    expect(monthExpressionChunks).toContain(appointment.startsAt)
+    expect(monthExpressionChunks).not.toContain(hairAssigned.soldAt)
   })
 })

--- a/packages/db/src/repositories/dashboard.ts
+++ b/packages/db/src/repositories/dashboard.ts
@@ -11,7 +11,7 @@ export async function transactionMonthlyRows(database: Db = db, input: { year: n
   return database
     .select({
       currency: transaction.currency,
-      month: sql<number>`extract(month from ${appointment.startsAt})::int`,
+      month: sql<number>`extract(month from ${hairAssigned.soldAt})::int`,
       sum: sql<number>`coalesce(sum(${transaction.amount}), 0)::int`,
     })
     .from(transaction)
@@ -38,9 +38,10 @@ export async function hairAssignedMonthlyRows(database: Db = db, input: { year: 
       pricePerGram: sql<number>`coalesce(avg(${hairAssigned.pricePerGram}), 0)::int`,
     })
     .from(hairAssigned)
-    .innerJoin(appointment, eq(hairAssigned.appointmentId, appointment.id))
-    .where(and(gte(appointment.startsAt, yearStart), lt(appointment.startsAt, yearEnd)))
-    .groupBy(sql`extract(month from ${appointment.startsAt})`)
+    .where(
+      and(isNotNull(hairAssigned.appointmentId), gte(hairAssigned.soldAt, yearStart), lt(hairAssigned.soldAt, yearEnd)),
+    )
+    .groupBy(sql`extract(month from ${hairAssigned.soldAt})`)
 }
 
 export async function hairAssignedThroughSaleMonthlyRows(database: Db = db, input: { year: number }) {
@@ -48,7 +49,7 @@ export async function hairAssignedThroughSaleMonthlyRows(database: Db = db, inpu
   const yearEnd = new Date(Date.UTC(input.year + 1, 0, 1))
   return database
     .select({
-      month: sql<number>`extract(month from ${hairAssigned.createdAt})::int`,
+      month: sql<number>`extract(month from ${hairAssigned.soldAt})::int`,
       weight: sql<number>`coalesce(sum(${hairAssigned.weightInGrams}), 0)::int`,
       soldFor: sql<number>`coalesce(sum(${hairAssigned.soldFor}), 0)::int`,
       profit: sql<number>`coalesce(sum(${hairAssigned.profit}), 0)::int`,
@@ -56,11 +57,7 @@ export async function hairAssignedThroughSaleMonthlyRows(database: Db = db, inpu
     })
     .from(hairAssigned)
     .where(
-      and(
-        isNull(hairAssigned.appointmentId),
-        gte(hairAssigned.createdAt, yearStart),
-        lt(hairAssigned.createdAt, yearEnd),
-      ),
+      and(isNull(hairAssigned.appointmentId), gte(hairAssigned.soldAt, yearStart), lt(hairAssigned.soldAt, yearEnd)),
     )
-    .groupBy(sql`extract(month from ${hairAssigned.createdAt})`)
+    .groupBy(sql`extract(month from ${hairAssigned.soldAt})`)
 }

--- a/packages/db/src/repositories/dashboard.ts
+++ b/packages/db/src/repositories/dashboard.ts
@@ -31,7 +31,7 @@ export async function hairAssignedMonthlyRows(database: Db = db, input: { year: 
   const yearEnd = new Date(Date.UTC(input.year + 1, 0, 1))
   return database
     .select({
-      month: sql<number>`extract(month from ${appointment.startsAt})::int`,
+      month: sql<number>`extract(month from ${hairAssigned.soldAt})::int`,
       weight: sql<number>`coalesce(sum(${hairAssigned.weightInGrams}), 0)::int`,
       soldFor: sql<number>`coalesce(sum(${hairAssigned.soldFor}), 0)::int`,
       profit: sql<number>`coalesce(sum(${hairAssigned.profit}), 0)::int`,

--- a/packages/db/src/repositories/dashboard.ts
+++ b/packages/db/src/repositories/dashboard.ts
@@ -11,7 +11,7 @@ export async function transactionMonthlyRows(database: Db = db, input: { year: n
   return database
     .select({
       currency: transaction.currency,
-      month: sql<number>`extract(month from ${hairAssigned.soldAt})::int`,
+      month: sql<number>`extract(month from ${appointment.startsAt})::int`,
       sum: sql<number>`coalesce(sum(${transaction.amount}), 0)::int`,
     })
     .from(transaction)

--- a/packages/db/src/repositories/hair.test.ts
+++ b/packages/db/src/repositories/hair.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vite-plus/test"
+
+import { createHairAssigned, updateHairAssigned } from "./hair"
+
+describe("hair repository", () => {
+  it("stores an explicit hair sale event date", async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: "hair-assigned-1" }])
+    const values = vi.fn(() => ({ returning }))
+    const database = {
+      insert: vi.fn(() => ({ values })),
+    } as never
+    const soldAt = new Date("2026-07-14T00:00:00.000Z")
+
+    await createHairAssigned(database, {
+      hairOrderId: "hair-order-1",
+      clientId: "customer-1",
+      appointmentId: null,
+      soldAt,
+      createdById: "user-1",
+    })
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appointmentId: null,
+        soldAt,
+      }),
+    )
+  })
+
+  it("updates an explicit hair sale event date", async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: "hair-assigned-1" }])
+    const where = vi.fn(() => ({ returning }))
+    const set = vi.fn(() => ({ where }))
+    const database = {
+      update: vi.fn(() => ({ set })),
+    } as never
+    const soldAt = new Date("2026-07-15T00:00:00.000Z")
+
+    await updateHairAssigned(database, {
+      id: "hair-assigned-1",
+      weightInGrams: 80,
+      soldFor: 12000,
+      pricePerGram: 150,
+      profit: 8000,
+      soldAt,
+    })
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        soldAt,
+      }),
+    )
+  })
+})

--- a/packages/db/src/repositories/hair.ts
+++ b/packages/db/src/repositories/hair.ts
@@ -20,26 +20,18 @@ function escapeLikePattern(value: string) {
   return value.replace(/[\\%_]/g, "\\$&")
 }
 
-function hairAssignedDateCondition(filter: Pick<HairAssignedFilter, "source" | "from" | "to">) {
+function hairAssignedDateCondition(filter: Pick<HairAssignedFilter, "from" | "to">) {
   if (!filter.from && !filter.to) return undefined
 
-  const appointmentDateChecks = [isNotNull(hairAssigned.appointmentId)]
-  const individualDateChecks = [isNull(hairAssigned.appointmentId)]
+  const dateChecks = []
   if (filter.from) {
-    appointmentDateChecks.push(gte(appointment.startsAt, filter.from))
-    individualDateChecks.push(gte(hairAssigned.createdAt, filter.from))
+    dateChecks.push(gte(hairAssigned.soldAt, filter.from))
   }
   if (filter.to) {
-    appointmentDateChecks.push(lt(appointment.startsAt, filter.to))
-    individualDateChecks.push(lt(hairAssigned.createdAt, filter.to))
+    dateChecks.push(lt(hairAssigned.soldAt, filter.to))
   }
 
-  const appointmentDateCondition = and(...appointmentDateChecks)
-  const individualDateCondition = and(...individualDateChecks)
-
-  if (filter.source === "appointment") return appointmentDateCondition
-  if (filter.source === "individual") return individualDateCondition
-  return or(appointmentDateCondition, individualDateCondition)
+  return and(...dateChecks)
 }
 
 export async function listHairAssigned(database: Db = db, filter: HairAssignedFilter) {
@@ -70,6 +62,7 @@ export async function listHairAssigned(database: Db = db, filter: HairAssignedFi
       soldFor: hairAssigned.soldFor,
       profit: hairAssigned.profit,
       pricePerGram: hairAssigned.pricePerGram,
+      soldAt: hairAssigned.soldAt,
       clientId: hairAssigned.clientId,
       createdById: hairAssigned.createdById,
       createdAt: hairAssigned.createdAt,
@@ -93,7 +86,7 @@ export async function listHairAssigned(database: Db = db, filter: HairAssignedFi
     .leftJoin(customer, eq(hairAssigned.clientId, customer.id))
     .leftJoin(hairOrder, eq(hairAssigned.hairOrderId, hairOrder.id))
     .where(where)
-    .orderBy(desc(hairAssigned.createdAt), desc(hairAssigned.id))
+    .orderBy(desc(hairAssigned.soldAt), desc(hairAssigned.id))
     .limit(filter.pageSize)
     .offset(filter.offset)
 
@@ -206,6 +199,7 @@ export async function createHairAssigned(
     hairOrderId: string
     clientId: string
     appointmentId?: string | null
+    soldAt?: Date
     createdById: string
   },
 ) {
@@ -215,6 +209,7 @@ export async function createHairAssigned(
       hairOrderId: input.hairOrderId,
       clientId: input.clientId,
       appointmentId: input.appointmentId ?? null,
+      ...(input.soldAt ? { soldAt: input.soldAt } : {}),
       createdById: input.createdById,
     })
     .returning()
@@ -223,7 +218,7 @@ export async function createHairAssigned(
 
 export async function updateHairAssigned(
   database: Db = db,
-  input: { id: string; weightInGrams: number; soldFor: number; pricePerGram: number; profit: number },
+  input: { id: string; weightInGrams: number; soldFor: number; pricePerGram: number; profit: number; soldAt?: Date },
 ) {
   const [updated] = await database
     .update(hairAssigned)
@@ -232,6 +227,7 @@ export async function updateHairAssigned(
       soldFor: input.soldFor,
       pricePerGram: input.pricePerGram,
       profit: input.profit,
+      ...(input.soldAt ? { soldAt: input.soldAt } : {}),
     })
     .where(eq(hairAssigned.id, input.id))
     .returning()

--- a/packages/db/src/schema/hair.ts
+++ b/packages/db/src/schema/hair.ts
@@ -37,6 +37,7 @@ export const hairAssigned = pgTable("hair_assigned", {
   soldFor: integer("sold_for").default(0).notNull(),
   profit: integer("profit").default(0).notNull(),
   pricePerGram: integer("price_per_gram").default(0).notNull(),
+  soldAt: timestamp("sold_at", { withTimezone: true }).defaultNow().notNull(),
   clientId: text("client_id")
     .notNull()
     .references(() => customer.id, { onDelete: "cascade" }),


### PR DESCRIPTION
## Summary
- Add a dedicated soldAt field for hair sale business dates while leaving createdAt as audit metadata
- Let individual/direct hair sales edit soldAt after creation, without choosing it in the create dialog
- Show soldAt in hair assigned tables across appointment, customer, and hair order views
- Set appointment-linked hair sale soldAt from the appointment start date
- Add a migration that backfills soldAt from appointment startsAt or existing createdAt, and update month filters/stats to use soldAt
- Add router, application service, repository, and table tests for soldAt behavior

## Verification
- vp check
- vp test
- vp run -r check-types
- vp dlx react-doctor@latest apps/web --scope changed --blocking warning --verbose