### PR TITLE
fix: retain postgres backups for 30 days

### DIFF
--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -82,3 +82,18 @@ jobs:
           s3cmd put "${FILE_NAME}" "s3://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"
           s3cmd info "s3://${R2_BUCKET_NAME}" || true
           echo "Uploaded ${FILE_NAME} to r2://${R2_BUCKET_NAME}/postgres_backup/${FILE_NAME}"
+
+      - name: Prune Cloudflare R2 backups older than 30 days
+        run: |
+          set -euo pipefail
+          CUTOFF_TS=$(date -u -d '30 days ago' +"%Y-%m-%d_%H-%M-%S")
+
+          s3cmd ls "s3://${R2_BUCKET_NAME}/postgres_backup/" | while read -r _ _ _ URI; do
+            FILE_NAME="${URI##*/}"
+            if [[ "${FILE_NAME}" =~ ^postgres_backup_([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}).*\.sql$ ]]; then
+              BACKUP_TS="${BASH_REMATCH[1]}"
+              if [[ "${BACKUP_TS}" < "${CUTOFF_TS}" ]]; then
+                s3cmd del "${URI}"
+              fi
+            fi
+          done

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -17,8 +17,8 @@ fi
 
 mkdir -p "${BACKUP_DIR}"
 
-# Prune backups older than 14 days
-find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +14 -delete
+# Prune backups older than 30 days
+find "${BACKUP_DIR}" -name "postgres_backup_*.sql" -type f -mtime +30 -delete
 
 if [[ -n "${BACKUP_LABEL}" ]]; then
   # Timestamp first so directory/object listings sort chronologically


### PR DESCRIPTION
## Summary
- keep local VPS Postgres backups for 30 days instead of 14
- prune Cloudflare R2 Postgres backup objects older than 30 days after successful uploads

## Verification
- bash -n scripts/backup_postgres.sh
- git diff --check
- vp test
- pre-push vp check and vp test