### PR TITLE
fix: store attachments under stable uploads prefix

### DIFF
--- a/packages/application/src/services/bank-statement-attachments.test.ts
+++ b/packages/application/src/services/bank-statement-attachments.test.ts
@@ -87,9 +87,15 @@ describe("bank statement attachment service", () => {
       body: new Uint8Array([1, 2, 3]),
     })
 
-    const [key] = r2Mock.put.mock.calls[0]
+    const putCall = r2Mock.put.mock.calls[0]
+    expect(putCall).toBeDefined()
+
+    const [key] = putCall!
     expect(key).toMatch(/^statement_uploads\/2025\/03\/[0-9a-f-]+-Bank_receipt\.pdf$/)
-    expect(dbMock.createBankStatementAttachment.mock.calls[0][1].r2Key).toBe(key)
+
+    const createCall = dbMock.createBankStatementAttachment.mock.calls[0]
+    expect(createCall).toBeDefined()
+    expect(createCall![1].r2Key).toBe(key)
   })
 
   it("moves an unassigned upload to the matched statement entry date folder when assigned", async () => {

--- a/packages/application/src/services/bank-statement-attachments.test.ts
+++ b/packages/application/src/services/bank-statement-attachments.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import {
   assignBankStatementAttachment,
@@ -30,10 +30,6 @@ vi.mock("../r2", () => ({ r2: r2Mock }))
 describe("bank statement attachment service", () => {
   beforeEach(() => {
     vi.resetAllMocks()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it("forwards document paging and legal entity scope to the database layer", async () => {
@@ -69,9 +65,7 @@ describe("bank statement attachment service", () => {
     })
   })
 
-  it("uses the matched statement entry date for the upload storage folder", async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"))
+  it("stores uploaded documents under a stable uploads prefix", async () => {
     dbMock.getBankStatementEntry.mockResolvedValue({
       id: "entry-1",
       date: "2025-03-14",
@@ -91,48 +85,29 @@ describe("bank statement attachment service", () => {
     expect(putCall).toBeDefined()
 
     const [key] = putCall!
-    expect(key).toMatch(/^statement_uploads\/2025\/03\/[0-9a-f-]+-Bank_receipt\.pdf$/)
+    expect(key).toMatch(/^uploads\/[0-9a-f-]+-Bank_receipt\.pdf$/)
 
     const createCall = dbMock.createBankStatementAttachment.mock.calls[0]
     expect(createCall).toBeDefined()
     expect(createCall![1].r2Key).toBe(key)
   })
 
-  it("moves an unassigned upload to the matched statement entry date folder when assigned", async () => {
-    const body = new ReadableStream()
-    dbMock.getBankStatementAttachment.mockResolvedValue({
-      id: "attachment-1",
-      bankStatementEntryId: null,
-      r2Key: "statement_uploads/2026/08/attachment-1-Bank_receipt.pdf",
-      originalName: "Bank receipt.pdf",
-      contentType: "application/pdf",
-      size: 3,
-      uploadedById: "user-1",
-    })
-    dbMock.getBankStatementEntry.mockResolvedValue({
-      id: "entry-1",
-      date: "2025-03-14",
-    })
-    r2Mock.get.mockResolvedValue({ body })
+  it("assigns an upload without moving its stored object", async () => {
     dbMock.assignBankStatementAttachment.mockImplementation((_, input) =>
       Promise.resolve({
         id: input.id,
         bankStatementEntryId: input.entryId,
-        r2Key: input.r2Key,
       }),
     )
 
     await assignBankStatementAttachment({ id: "attachment-1", entryId: "entry-1" })
 
-    expect(r2Mock.get).toHaveBeenCalledWith("statement_uploads/2026/08/attachment-1-Bank_receipt.pdf")
-    expect(r2Mock.put).toHaveBeenCalledWith("statement_uploads/2025/03/attachment-1-Bank_receipt.pdf", body, {
-      httpMetadata: { contentType: "application/pdf" },
-    })
     expect(dbMock.assignBankStatementAttachment).toHaveBeenCalledWith(undefined, {
       id: "attachment-1",
       entryId: "entry-1",
-      r2Key: "statement_uploads/2025/03/attachment-1-Bank_receipt.pdf",
     })
-    expect(r2Mock.delete).toHaveBeenCalledWith("statement_uploads/2026/08/attachment-1-Bank_receipt.pdf")
+    expect(r2Mock.get).not.toHaveBeenCalled()
+    expect(r2Mock.put).not.toHaveBeenCalled()
+    expect(r2Mock.delete).not.toHaveBeenCalled()
   })
 })

--- a/packages/application/src/services/bank-statement-attachments.test.ts
+++ b/packages/application/src/services/bank-statement-attachments.test.ts
@@ -1,16 +1,39 @@
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
-import { listBankStatementAttachments } from "./bank-statement-attachments"
+import {
+  assignBankStatementAttachment,
+  listBankStatementAttachments,
+  uploadBankStatementAttachment,
+} from "./bank-statement-attachments"
 
 const dbMock = vi.hoisted(() => ({
+  assignBankStatementAttachment: vi.fn(),
+  countBankStatementAttachments: vi.fn(),
+  createBankStatementAttachment: vi.fn(),
+  deleteBankStatementAttachment: vi.fn(),
+  getBankStatementAttachment: vi.fn(),
+  getBankStatementEntry: vi.fn(),
+  listBankStatementAttachmentExportRows: vi.fn(),
   listBankStatementAttachments: vi.fn(),
+  unassignBankStatementAttachment: vi.fn(),
+}))
+
+const r2Mock = vi.hoisted(() => ({
+  delete: vi.fn(),
+  get: vi.fn(),
+  put: vi.fn(),
 }))
 
 vi.mock("@prive-admin-tanstack/db", () => dbMock)
+vi.mock("../r2", () => ({ r2: r2Mock }))
 
 describe("bank statement attachment service", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("forwards document paging and legal entity scope to the database layer", async () => {
@@ -44,5 +67,66 @@ describe("bank statement attachment service", () => {
       pageSize: 50,
       offset: 100,
     })
+  })
+
+  it("uses the matched statement entry date for the upload storage folder", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"))
+    dbMock.getBankStatementEntry.mockResolvedValue({
+      id: "entry-1",
+      date: "2025-03-14",
+    })
+    dbMock.createBankStatementAttachment.mockImplementation((_, input) => Promise.resolve(input))
+
+    await uploadBankStatementAttachment({
+      entryId: "entry-1",
+      fileName: "Bank receipt.pdf",
+      contentType: "application/pdf",
+      size: 3,
+      uploadedById: "user-1",
+      body: new Uint8Array([1, 2, 3]),
+    })
+
+    const [key] = r2Mock.put.mock.calls[0]
+    expect(key).toMatch(/^statement_uploads\/2025\/03\/[0-9a-f-]+-Bank_receipt\.pdf$/)
+    expect(dbMock.createBankStatementAttachment.mock.calls[0][1].r2Key).toBe(key)
+  })
+
+  it("moves an unassigned upload to the matched statement entry date folder when assigned", async () => {
+    const body = new ReadableStream()
+    dbMock.getBankStatementAttachment.mockResolvedValue({
+      id: "attachment-1",
+      bankStatementEntryId: null,
+      r2Key: "statement_uploads/2026/08/attachment-1-Bank_receipt.pdf",
+      originalName: "Bank receipt.pdf",
+      contentType: "application/pdf",
+      size: 3,
+      uploadedById: "user-1",
+    })
+    dbMock.getBankStatementEntry.mockResolvedValue({
+      id: "entry-1",
+      date: "2025-03-14",
+    })
+    r2Mock.get.mockResolvedValue({ body })
+    dbMock.assignBankStatementAttachment.mockImplementation((_, input) =>
+      Promise.resolve({
+        id: input.id,
+        bankStatementEntryId: input.entryId,
+        r2Key: input.r2Key,
+      }),
+    )
+
+    await assignBankStatementAttachment({ id: "attachment-1", entryId: "entry-1" })
+
+    expect(r2Mock.get).toHaveBeenCalledWith("statement_uploads/2026/08/attachment-1-Bank_receipt.pdf")
+    expect(r2Mock.put).toHaveBeenCalledWith("statement_uploads/2025/03/attachment-1-Bank_receipt.pdf", body, {
+      httpMetadata: { contentType: "application/pdf" },
+    })
+    expect(dbMock.assignBankStatementAttachment).toHaveBeenCalledWith(undefined, {
+      id: "attachment-1",
+      entryId: "entry-1",
+      r2Key: "statement_uploads/2025/03/attachment-1-Bank_receipt.pdf",
+    })
+    expect(r2Mock.delete).toHaveBeenCalledWith("statement_uploads/2026/08/attachment-1-Bank_receipt.pdf")
   })
 })

--- a/packages/application/src/services/bank-statement-attachments.ts
+++ b/packages/application/src/services/bank-statement-attachments.ts
@@ -43,14 +43,6 @@ function readableFromR2Object(object: R2ObjectBody) {
   return Readable.fromWeb(object.body as unknown as NodeReadableStream)
 }
 
-function dateFolder(date: string) {
-  return `${date.slice(0, 4)}/${date.slice(5, 7)}`
-}
-
-function attachmentObjectName(key: string) {
-  return key.split("/").at(-1) ?? key
-}
-
 export async function listBankStatementAttachments(input: {
   assignmentStatus?: "assigned" | "unassigned" | "all"
   pageSize: number
@@ -94,20 +86,14 @@ export async function uploadBankStatementAttachment(input: {
     throw new Error(`File exceeds ${MAX_ATTACHMENT_BYTES} bytes`)
   }
 
-  let folderDate: string | null = null
   if (input.entryId) {
     const entry = await findBankStatementEntry(undefined, input.entryId)
     if (!entry) throw notFound("Statement entry not found")
-    folderDate = entry.date
   }
 
   const safeName = input.fileName.replace(/[^\w.-]+/g, "_")
-  const now = new Date()
-  const folder = folderDate
-    ? dateFolder(folderDate)
-    : `${now.getUTCFullYear()}/${String(now.getUTCMonth() + 1).padStart(2, "0")}`
   const attachmentId = randomUUID()
-  const key = `statement_uploads/${folder}/${attachmentId}-${safeName}`
+  const key = `uploads/${attachmentId}-${safeName}`
 
   try {
     await r2.put(key, input.body, { httpMetadata: { contentType: input.contentType } })
@@ -159,35 +145,8 @@ export async function getBankStatementAttachmentPreviewResponse(id: string) {
 }
 
 export async function assignBankStatementAttachment(input: { id: string; entryId: string }) {
-  const attachment = await findBankStatementAttachment(undefined, input.id)
-  if (!attachment) throw notFound("Attachment not found")
-
-  const entry = await findBankStatementEntry(undefined, input.entryId)
-  if (!entry) throw notFound("Entry not found")
-
-  const r2Key = `statement_uploads/${dateFolder(entry.date)}/${attachmentObjectName(attachment.r2Key)}`
-  if (r2Key !== attachment.r2Key) {
-    const object = await r2.get(attachment.r2Key)
-    if (!object) throw notFound("Attachment file not found")
-
-    try {
-      await r2.put(r2Key, object.body, { httpMetadata: { contentType: attachment.contentType } })
-    } catch (error) {
-      throw unexpectedError("Failed to move bank statement attachment file", error)
-    }
-  }
-
-  const row = await patchAssignBankStatementAttachment(undefined, { ...input, r2Key })
-  if (!row) throw notFound("Attachment not found")
-
-  if (r2Key !== attachment.r2Key) {
-    try {
-      await r2.delete(attachment.r2Key)
-    } catch (error) {
-      console.warn("[statement-attachment move cleanup]", error)
-    }
-  }
-
+  const row = await patchAssignBankStatementAttachment(undefined, input)
+  if (!row) throw notFound("Entry not found")
   return row
 }
 

--- a/packages/application/src/services/bank-statement-attachments.ts
+++ b/packages/application/src/services/bank-statement-attachments.ts
@@ -43,6 +43,14 @@ function readableFromR2Object(object: R2ObjectBody) {
   return Readable.fromWeb(object.body as unknown as NodeReadableStream)
 }
 
+function dateFolder(date: string) {
+  return `${date.slice(0, 4)}/${date.slice(5, 7)}`
+}
+
+function attachmentObjectName(key: string) {
+  return key.split("/").at(-1) ?? key
+}
+
 export async function listBankStatementAttachments(input: {
   assignmentStatus?: "assigned" | "unassigned" | "all"
   pageSize: number
@@ -86,17 +94,20 @@ export async function uploadBankStatementAttachment(input: {
     throw new Error(`File exceeds ${MAX_ATTACHMENT_BYTES} bytes`)
   }
 
+  let folderDate: string | null = null
   if (input.entryId) {
     const entry = await findBankStatementEntry(undefined, input.entryId)
     if (!entry) throw notFound("Statement entry not found")
+    folderDate = entry.date
   }
 
   const safeName = input.fileName.replace(/[^\w.-]+/g, "_")
   const now = new Date()
-  const yyyy = now.getUTCFullYear()
-  const mm = String(now.getUTCMonth() + 1).padStart(2, "0")
+  const folder = folderDate
+    ? dateFolder(folderDate)
+    : `${now.getUTCFullYear()}/${String(now.getUTCMonth() + 1).padStart(2, "0")}`
   const attachmentId = randomUUID()
-  const key = `statement_uploads/${yyyy}/${mm}/${attachmentId}-${safeName}`
+  const key = `statement_uploads/${folder}/${attachmentId}-${safeName}`
 
   try {
     await r2.put(key, input.body, { httpMetadata: { contentType: input.contentType } })
@@ -148,8 +159,35 @@ export async function getBankStatementAttachmentPreviewResponse(id: string) {
 }
 
 export async function assignBankStatementAttachment(input: { id: string; entryId: string }) {
-  const row = await patchAssignBankStatementAttachment(undefined, input)
-  if (!row) throw notFound("Entry not found")
+  const attachment = await findBankStatementAttachment(undefined, input.id)
+  if (!attachment) throw notFound("Attachment not found")
+
+  const entry = await findBankStatementEntry(undefined, input.entryId)
+  if (!entry) throw notFound("Entry not found")
+
+  const r2Key = `statement_uploads/${dateFolder(entry.date)}/${attachmentObjectName(attachment.r2Key)}`
+  if (r2Key !== attachment.r2Key) {
+    const object = await r2.get(attachment.r2Key)
+    if (!object) throw notFound("Attachment file not found")
+
+    try {
+      await r2.put(r2Key, object.body, { httpMetadata: { contentType: attachment.contentType } })
+    } catch (error) {
+      throw unexpectedError("Failed to move bank statement attachment file", error)
+    }
+  }
+
+  const row = await patchAssignBankStatementAttachment(undefined, { ...input, r2Key })
+  if (!row) throw notFound("Attachment not found")
+
+  if (r2Key !== attachment.r2Key) {
+    try {
+      await r2.delete(attachment.r2Key)
+    } catch (error) {
+      console.warn("[statement-attachment move cleanup]", error)
+    }
+  }
+
   return row
 }
 

--- a/packages/db/src/repositories/bank-statement-attachments.ts
+++ b/packages/db/src/repositories/bank-statement-attachments.ts
@@ -111,10 +111,7 @@ export async function countBankStatementAttachments(database: Db = db) {
   return Object.fromEntries(counts)
 }
 
-export async function assignBankStatementAttachment(
-  database: Db = db,
-  input: { id: string; entryId: string; r2Key?: string },
-) {
+export async function assignBankStatementAttachment(database: Db = db, input: { id: string; entryId: string }) {
   const entry = await database.query.bankStatementEntry.findFirst({
     where: eq(bankStatementEntry.id, input.entryId),
     columns: { id: true },
@@ -122,7 +119,7 @@ export async function assignBankStatementAttachment(
   if (!entry) return null
   const [row] = await database
     .update(bankStatementAttachment)
-    .set({ bankStatementEntryId: input.entryId, ...(input.r2Key ? { r2Key: input.r2Key } : {}) })
+    .set({ bankStatementEntryId: input.entryId })
     .where(eq(bankStatementAttachment.id, input.id))
     .returning()
   return row

--- a/packages/db/src/repositories/bank-statement-attachments.ts
+++ b/packages/db/src/repositories/bank-statement-attachments.ts
@@ -111,7 +111,10 @@ export async function countBankStatementAttachments(database: Db = db) {
   return Object.fromEntries(counts)
 }
 
-export async function assignBankStatementAttachment(database: Db = db, input: { id: string; entryId: string }) {
+export async function assignBankStatementAttachment(
+  database: Db = db,
+  input: { id: string; entryId: string; r2Key?: string },
+) {
   const entry = await database.query.bankStatementEntry.findFirst({
     where: eq(bankStatementEntry.id, input.entryId),
     columns: { id: true },
@@ -119,7 +122,7 @@ export async function assignBankStatementAttachment(database: Db = db, input: { 
   if (!entry) return null
   const [row] = await database
     .update(bankStatementAttachment)
-    .set({ bankStatementEntryId: input.entryId })
+    .set({ bankStatementEntryId: input.entryId, ...(input.r2Key ? { r2Key: input.r2Key } : {}) })
     .where(eq(bankStatementAttachment.id, input.id))
     .returning()
   return row


### PR DESCRIPTION
## Summary
- store bank statement attachment objects under a stable uploads prefix
- keep assignment as a database relationship instead of moving R2 objects
- add regression coverage for stable upload keys and assignment without object moves

## Verification
- vp check
- vp run check-types
- vp test

Closes #275