### PR TITLE
fix: avoid d1 transactions when editing hair assignments

### DIFF
--- a/packages/application/src/services/hair.test.ts
+++ b/packages/application/src/services/hair.test.ts
@@ -5,22 +5,33 @@ const dbMock = vi.hoisted(() => ({
     appointment: {
       findFirst: vi.fn(),
     },
+    hairAssigned: {
+      findFirst: vi.fn(),
+    },
   },
+  batch: vi.fn(),
+  delete: vi.fn(),
+  select: vi.fn(),
   transaction: vi.fn(),
+  update: vi.fn(),
 }))
 
 const repositoryMock = vi.hoisted(() => ({
   createHairAssigned: vi.fn(),
+  deleteHairAssigned: vi.fn(),
   updateHairAssigned: vi.fn(),
+  updateHairOrder: vi.fn(),
 }))
 
 vi.mock("@prive-admin-tanstack/db", () => ({
   db: dbMock,
   createHairAssigned: repositoryMock.createHairAssigned,
+  deleteHairAssigned: repositoryMock.deleteHairAssigned,
   updateHairAssigned: repositoryMock.updateHairAssigned,
+  updateHairOrder: repositoryMock.updateHairOrder,
 }))
 
-import { createHairAssigned, updateHairAssigned } from "./hair"
+import { createHairAssigned, deleteHairAssigned, updateHairAssigned, updateHairOrder } from "./hair"
 
 describe("hair service", () => {
   beforeEach(() => {
@@ -71,27 +82,60 @@ describe("hair service", () => {
     )
   })
 
+  it("updates a hair order without opening a database transaction", async () => {
+    const whereExistingOrder = vi.fn().mockResolvedValueOnce([{ id: "hair-order-1" }])
+    const whereAssignedTotal = vi.fn().mockResolvedValueOnce([{ total: 40 }])
+    const fromExistingOrder = vi.fn(() => ({ where: whereExistingOrder }))
+    const fromAssignedTotal = vi.fn(() => ({ where: whereAssignedTotal }))
+    dbMock.select = vi
+      .fn()
+      .mockReturnValueOnce({ from: fromExistingOrder })
+      .mockReturnValueOnce({ from: fromAssignedTotal })
+    dbMock.transaction = vi.fn(async () => {
+      throw new Error("failed query: begin params:")
+    })
+    repositoryMock.updateHairOrder.mockResolvedValue({ id: "hair-order-1" })
+
+    await updateHairOrder({
+      id: "hair-order-1",
+      placedAt: null,
+      arrivedAt: null,
+      status: "COMPLETED",
+      weightReceived: 100,
+      weightUsed: 0,
+      total: 10000,
+    })
+
+    expect(dbMock.transaction).not.toHaveBeenCalled()
+    expect(repositoryMock.updateHairOrder).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        id: "hair-order-1",
+        weightUsed: 40,
+      }),
+    )
+  })
+
   it("updates an individual hair sale with the selected sale date", async () => {
-    const tx = {
-      query: {
-        hairAssigned: {
-          findFirst: vi.fn().mockResolvedValue({
-            appointmentId: null,
-            hairOrderId: "hair-order-1",
-            weightInGrams: 40,
-          }),
-        },
-      },
-      select: vi.fn(() => ({
-        from: vi.fn(() => ({
-          where: vi
-            .fn()
-            .mockResolvedValue([{ id: "hair-order-1", weightReceived: 100, weightUsed: 40, pricePerGram: 50 }]),
-        })),
-      })),
-      update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+    const whereParentOrder = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "hair-order-1", weightReceived: 100, weightUsed: 40, pricePerGram: 50 }])
+    const fromParentOrder = vi.fn(() => ({ where: whereParentOrder }))
+    const updateHairAssignedSet = vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => "update-hair") })) }))
+    const updateHairOrderSet = vi.fn(() => ({ where: vi.fn(() => "update-order") }))
+    dbMock.query.hairAssigned = {
+      findFirst: vi.fn().mockResolvedValue({
+        appointmentId: null,
+        hairOrderId: "hair-order-1",
+        weightInGrams: 40,
+      }),
     }
-    dbMock.transaction = vi.fn(async (callback) => callback(tx))
+    dbMock.select = vi.fn().mockReturnValueOnce({ from: fromParentOrder })
+    dbMock.update = vi
+      .fn()
+      .mockReturnValueOnce({ set: updateHairAssignedSet })
+      .mockReturnValueOnce({ set: updateHairOrderSet })
+    dbMock.batch.mockResolvedValue([[{ id: "hair-assigned-1" }], {}])
     repositoryMock.updateHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
 
     await updateHairAssigned({
@@ -101,12 +145,79 @@ describe("hair service", () => {
       soldAt: new Date("2026-07-15T00:00:00.000Z"),
     })
 
-    expect(repositoryMock.updateHairAssigned).toHaveBeenCalledWith(
-      tx,
-      expect.objectContaining({
-        id: "hair-assigned-1",
-        soldAt: new Date("2026-07-15T00:00:00.000Z"),
-      }),
+    expect(updateHairAssignedSet).toHaveBeenCalledWith(
+      expect.objectContaining({ soldAt: new Date("2026-07-15T00:00:00.000Z") }),
     )
+    expect(updateHairOrderSet).toHaveBeenCalledWith({ weightUsed: 50 })
+    expect(dbMock.batch).toHaveBeenCalledWith(["update-hair", "update-order"])
+  })
+
+  it("updates a hair assignment without opening a database transaction", async () => {
+    const whereParentOrder = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "hair-order-1", weightReceived: 100, weightUsed: 40, pricePerGram: 50 }])
+    const fromParentOrder = vi.fn(() => ({ where: whereParentOrder }))
+    const updateHairAssignedSet = vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => "update-hair") })) }))
+    const updateHairOrderSet = vi.fn(() => ({ where: vi.fn(() => "update-order") }))
+    dbMock.query.appointment.findFirst.mockResolvedValue({ startsAt: new Date("2026-07-21T09:30:00.000Z") })
+    dbMock.query.hairAssigned = {
+      findFirst: vi.fn().mockResolvedValue({
+        appointmentId: "appointment-1",
+        hairOrderId: "hair-order-1",
+        weightInGrams: 40,
+      }),
+    }
+    dbMock.select = vi.fn().mockReturnValueOnce({ from: fromParentOrder })
+    dbMock.update = vi
+      .fn()
+      .mockReturnValueOnce({ set: updateHairAssignedSet })
+      .mockReturnValueOnce({ set: updateHairOrderSet })
+    dbMock.batch.mockResolvedValue([[{ id: "hair-assigned-1" }], {}])
+    dbMock.transaction = vi.fn(async () => {
+      throw new Error("failed query: begin params:")
+    })
+    repositoryMock.updateHairAssigned.mockResolvedValue({ id: "hair-assigned-1" })
+
+    await updateHairAssigned({
+      id: "hair-assigned-1",
+      weightInGrams: 50,
+      soldFor: 6000,
+    })
+
+    expect(dbMock.transaction).not.toHaveBeenCalled()
+    expect(updateHairAssignedSet).toHaveBeenCalledWith(
+      expect.objectContaining({ soldAt: new Date("2026-07-21T09:30:00.000Z") }),
+    )
+    expect(updateHairOrderSet).toHaveBeenCalledWith({ weightUsed: 50 })
+    expect(dbMock.batch).toHaveBeenCalledWith(["update-hair", "update-order"])
+  })
+
+  it("deletes a hair assignment without opening a database transaction", async () => {
+    const whereParentOrder = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "hair-order-1", weightReceived: 100, weightUsed: 50, pricePerGram: 50 }])
+    const fromParentOrder = vi.fn(() => ({ where: whereParentOrder }))
+    const deleteWhere = vi.fn(() => ({ returning: vi.fn(() => "delete-hair") }))
+    const updateHairOrderSet = vi.fn(() => ({ where: vi.fn(() => "update-order") }))
+    dbMock.query.hairAssigned = {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "hair-assigned-1",
+        hairOrderId: "hair-order-1",
+        weightInGrams: 20,
+      }),
+    }
+    dbMock.select = vi.fn().mockReturnValueOnce({ from: fromParentOrder })
+    dbMock.delete = vi.fn(() => ({ where: deleteWhere }))
+    dbMock.update = vi.fn(() => ({ set: updateHairOrderSet }))
+    dbMock.batch.mockResolvedValue([[{ id: "hair-assigned-1" }], {}])
+    dbMock.transaction = vi.fn(async () => {
+      throw new Error("failed query: begin params:")
+    })
+
+    await deleteHairAssigned("hair-assigned-1")
+
+    expect(dbMock.transaction).not.toHaveBeenCalled()
+    expect(updateHairOrderSet).toHaveBeenCalledWith({ weightUsed: 30 })
+    expect(dbMock.batch).toHaveBeenCalledWith(["delete-hair", "update-order"])
   })
 })

--- a/packages/application/src/services/hair.ts
+++ b/packages/application/src/services/hair.ts
@@ -1,13 +1,11 @@
 import {
   createHairAssigned as insertHairAssigned,
   createHairOrder as insertHairOrder,
-  deleteHairAssigned as removeHairAssigned,
   getHairAssigned as findHairAssigned,
   getHairOrder as findHairOrder,
   listHairAssigned as fetchHairAssigned,
   listHairOrders as fetchHairOrders,
   recalculateHairOrderPrices as recalculateHairOrderPricesRepo,
-  updateHairAssigned as patchHairAssigned,
   updateHairOrder as patchHairOrder,
 } from "@prive-admin-tanstack/db"
 import { db } from "@prive-admin-tanstack/db"
@@ -101,27 +99,25 @@ export async function updateHairOrder(input: {
     throw badRequest("Weight used cannot exceed weight received")
   }
 
-  return await db.transaction(async (tx) => {
-    const [existing] = await tx.select().from(hairOrder).where(eq(hairOrder.id, input.id))
-    if (!existing) throw notFound("Hair order not found")
+  const [existing] = await db.select().from(hairOrder).where(eq(hairOrder.id, input.id))
+  if (!existing) throw notFound("Hair order not found")
 
-    const assignedTotal = await assignedWeightTotal(tx, input.id)
-    if (assignedTotal > input.weightReceived) {
-      throw badRequest(`Weight received cannot be less than assigned weight (${assignedTotal}g assigned)`)
-    }
+  const assignedTotal = await assignedWeightTotal(db, input.id)
+  if (assignedTotal > input.weightReceived) {
+    throw badRequest(`Weight received cannot be less than assigned weight (${assignedTotal}g assigned)`)
+  }
 
-    const result = await patchHairOrder(tx as any, {
-      id: input.id,
-      placedAt: dateValue(input.placedAt),
-      arrivedAt: dateValue(input.arrivedAt),
-      status: input.status,
-      weightReceived: input.weightReceived,
-      weightUsed: assignedTotal,
-      total: input.total,
-    })
-    if (!result) throw unexpectedError("Failed to update hair order")
-    return result
+  const result = await patchHairOrder(undefined, {
+    id: input.id,
+    placedAt: dateValue(input.placedAt),
+    arrivedAt: dateValue(input.arrivedAt),
+    status: input.status,
+    weightReceived: input.weightReceived,
+    weightUsed: assignedTotal,
+    total: input.total,
   })
+  if (!result) throw unexpectedError("Failed to update hair order")
+  return result
 }
 
 export async function recalculateHairOrderPrices(hairOrderId: string) {
@@ -152,61 +148,60 @@ async function appointmentStartsAt(appointmentId: string) {
 }
 
 export async function updateHairAssigned(input: { id: string; weightInGrams: number; soldFor: number; soldAt?: Date }) {
-  return await db.transaction(async (tx) => {
-    const existing = await tx.query.hairAssigned.findFirst({
-      where: eq(hairAssigned.id, input.id),
-      columns: { appointmentId: true, hairOrderId: true, weightInGrams: true },
-    })
-    if (!existing) throw notFound("Hair assigned not found")
-
-    const [parentOrder] = await tx.select().from(hairOrder).where(eq(hairOrder.id, existing.hairOrderId))
-    if (!parentOrder) throw notFound("Hair order not found")
-
-    const availableWeight = parentOrder.weightReceived - parentOrder.weightUsed + existing.weightInGrams
-    if (input.weightInGrams > availableWeight) {
-      throw badRequest(`Weight exceeds available stock (${availableWeight}g available)`)
-    }
-
-    const pricePerGram = input.weightInGrams > 0 ? Math.round(input.soldFor / input.weightInGrams) : 0
-    const profit = input.soldFor - input.weightInGrams * parentOrder.pricePerGram
-    const soldAt = existing.appointmentId ? await appointmentStartsAt(existing.appointmentId) : input.soldAt
-
-    const updated = await patchHairAssigned(tx as any, {
-      id: input.id,
-      weightInGrams: input.weightInGrams,
-      soldFor: input.soldFor,
-      pricePerGram,
-      profit,
-      soldAt,
-    })
-    if (!updated) throw unexpectedError("Failed to update hair assignment")
-
-    const assignedTotal = await assignedWeightTotal(tx, parentOrder.id)
-    if (assignedTotal > parentOrder.weightReceived) {
-      throw badRequest(`Assigned weight cannot exceed weight received (${parentOrder.weightReceived}g received)`)
-    }
-
-    await tx.update(hairOrder).set({ weightUsed: assignedTotal }).where(eq(hairOrder.id, parentOrder.id))
-    return updated
+  const existing = await db.query.hairAssigned.findFirst({
+    where: eq(hairAssigned.id, input.id),
+    columns: { appointmentId: true, hairOrderId: true, weightInGrams: true },
   })
+  if (!existing) throw notFound("Hair assigned not found")
+
+  const [parentOrder] = await db.select().from(hairOrder).where(eq(hairOrder.id, existing.hairOrderId))
+  if (!parentOrder) throw notFound("Hair order not found")
+
+  const availableWeight = parentOrder.weightReceived - parentOrder.weightUsed + existing.weightInGrams
+  if (input.weightInGrams > availableWeight) {
+    throw badRequest(`Weight exceeds available stock (${availableWeight}g available)`)
+  }
+
+  const pricePerGram = input.weightInGrams > 0 ? Math.round(input.soldFor / input.weightInGrams) : 0
+  const profit = input.soldFor - input.weightInGrams * parentOrder.pricePerGram
+  const soldAt = existing.appointmentId ? await appointmentStartsAt(existing.appointmentId) : input.soldAt
+  const assignedTotal = parentOrder.weightUsed - existing.weightInGrams + input.weightInGrams
+
+  const [updatedRows] = await db.batch([
+    db
+      .update(hairAssigned)
+      .set({
+        weightInGrams: input.weightInGrams,
+        soldFor: input.soldFor,
+        pricePerGram,
+        profit,
+        ...(soldAt ? { soldAt } : {}),
+      })
+      .where(eq(hairAssigned.id, input.id))
+      .returning(),
+    db.update(hairOrder).set({ weightUsed: assignedTotal }).where(eq(hairOrder.id, parentOrder.id)),
+  ])
+  const updated = updatedRows[0]
+  if (!updated) throw unexpectedError("Failed to update hair assignment")
+  return updated
 }
 
 export async function deleteHairAssigned(id: string) {
-  return await db.transaction(async (tx) => {
-    const existing = await tx.query.hairAssigned.findFirst({
-      where: eq(hairAssigned.id, id),
-    })
-    if (!existing) throw notFound("Hair assigned not found")
-
-    const [parentOrder] = await tx.select().from(hairOrder).where(eq(hairOrder.id, existing.hairOrderId))
-    if (!parentOrder) throw notFound("Hair order not found")
-
-    const removed = await removeHairAssigned(tx as any, id)
-    if (!removed) throw unexpectedError("Failed to delete hair assignment")
-
-    const assignedTotal = await assignedWeightTotal(tx, parentOrder.id)
-    await tx.update(hairOrder).set({ weightUsed: assignedTotal }).where(eq(hairOrder.id, parentOrder.id))
-
-    return removed
+  const existing = await db.query.hairAssigned.findFirst({
+    where: eq(hairAssigned.id, id),
   })
+  if (!existing) throw notFound("Hair assigned not found")
+
+  const [parentOrder] = await db.select().from(hairOrder).where(eq(hairOrder.id, existing.hairOrderId))
+  if (!parentOrder) throw notFound("Hair order not found")
+
+  const assignedTotal = parentOrder.weightUsed - existing.weightInGrams
+  const [removedRows] = await db.batch([
+    db.delete(hairAssigned).where(eq(hairAssigned.id, id)).returning(),
+    db.update(hairOrder).set({ weightUsed: assignedTotal }).where(eq(hairOrder.id, parentOrder.id)),
+  ])
+  const removed = removedRows[0]
+  if (!removed) throw unexpectedError("Failed to delete hair assignment")
+
+  return removed
 }

--- a/packages/db/src/repositories/hair.test.ts
+++ b/packages/db/src/repositories/hair.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test"
 
-import { createHairAssigned, updateHairAssigned } from "./hair"
+import { createHairAssigned, recalculateHairOrderPrices, updateHairAssigned } from "./hair"
 
 describe("hair repository", () => {
   it("stores an explicit hair sale event date", async () => {
@@ -50,5 +50,40 @@ describe("hair repository", () => {
         soldAt,
       }),
     )
+  })
+
+  it("recalculates hair order prices without opening a database transaction", async () => {
+    const whereOrder = vi
+      .fn()
+      .mockResolvedValue([{ id: "hair-order-1", total: 12000, weightReceived: 100, pricePerGram: 100 }])
+    const whereAssignments = vi.fn().mockResolvedValue([
+      { id: "hair-assigned-1", weightInGrams: 40, soldFor: 6000, profit: 1000 },
+      { id: "hair-assigned-2", weightInGrams: 20, soldFor: 2500, profit: 100 },
+    ])
+    const fromOrder = vi.fn(() => ({ where: whereOrder }))
+    const fromAssignments = vi.fn(() => ({ where: whereAssignments }))
+    const updateOrderSet = vi.fn(() => ({ where: vi.fn(() => "update-order") }))
+    const updateAssignmentSet = vi
+      .fn()
+      .mockReturnValueOnce({ where: vi.fn(() => "update-assignment-1") })
+      .mockReturnValueOnce({ where: vi.fn(() => "update-assignment-2") })
+    const database = {
+      batch: vi.fn().mockResolvedValue([{}, {}, {}]),
+      select: vi.fn().mockReturnValueOnce({ from: fromOrder }).mockReturnValueOnce({ from: fromAssignments }),
+      transaction: vi.fn(async () => {
+        throw new Error("failed query: begin params:")
+      }),
+      update: vi.fn().mockReturnValueOnce({ set: updateOrderSet }).mockReturnValue({
+        set: updateAssignmentSet,
+      }),
+    } as never
+
+    await recalculateHairOrderPrices(database, "hair-order-1")
+
+    expect((database as any).transaction).not.toHaveBeenCalled()
+    expect(updateOrderSet).toHaveBeenCalledWith({ pricePerGram: 120 })
+    expect(updateAssignmentSet).toHaveBeenCalledWith({ profit: 1200 })
+    expect(updateAssignmentSet).toHaveBeenCalledTimes(1)
+    expect((database as any).batch).toHaveBeenCalledWith(["update-order", "update-assignment-1"])
   })
 })

--- a/packages/db/src/repositories/hair.ts
+++ b/packages/db/src/repositories/hair.ts
@@ -248,27 +248,30 @@ export async function deleteHairAssigned(database: Db = db, id: string) {
 }
 
 export async function recalculateHairOrderPrices(database: Db = db, hairOrderId: string) {
-  return database.transaction(async (tx) => {
-    const [order] = await tx.select().from(hairOrder).where(eq(hairOrder.id, hairOrderId))
-    if (!order) return null
+  const [order] = await database.select().from(hairOrder).where(eq(hairOrder.id, hairOrderId))
+  if (!order) return null
 
-    const assignments = await tx.select().from(hairAssigned).where(eq(hairAssigned.hairOrderId, hairOrderId))
+  const assignments = await database.select().from(hairAssigned).where(eq(hairAssigned.hairOrderId, hairOrderId))
 
-    const pricePerGram =
-      order.total === 0 || order.weightReceived === 0 ? 0 : Math.abs(Math.round(order.total / order.weightReceived))
+  const pricePerGram =
+    order.total === 0 || order.weightReceived === 0 ? 0 : Math.abs(Math.round(order.total / order.weightReceived))
 
-    if (order.pricePerGram !== pricePerGram) {
-      await tx.update(hairOrder).set({ pricePerGram }).where(eq(hairOrder.id, hairOrderId))
+  const updates = []
+  if (order.pricePerGram !== pricePerGram) {
+    updates.push(database.update(hairOrder).set({ pricePerGram }).where(eq(hairOrder.id, hairOrderId)))
+  }
+
+  for (const ha of assignments) {
+    const total = pricePerGram === 0 ? 0 : Math.round(pricePerGram * ha.weightInGrams)
+    const profit = ha.soldFor - total
+    if (ha.profit !== profit) {
+      updates.push(database.update(hairAssigned).set({ profit }).where(eq(hairAssigned.id, ha.id)))
     }
+  }
 
-    for (const ha of assignments) {
-      const total = pricePerGram === 0 ? 0 : Math.round(pricePerGram * ha.weightInGrams)
-      const profit = ha.soldFor - total
-      if (ha.profit !== profit) {
-        await tx.update(hairAssigned).set({ profit }).where(eq(hairAssigned.id, ha.id))
-      }
-    }
+  if (updates.length > 0) {
+    await database.batch(updates as never)
+  }
 
-    return { pricePerGram }
-  })
+  return { pricePerGram }
 }


### PR DESCRIPTION
## Summary
- replace the hair assignment edit transaction with a D1-supported batch write
- keep appointment-linked hair assignment dates derived from the appointment start time
- add regression coverage for the D1 BEGIN failure path

## Validation
- vp check
- vp test
- vp run check-types