### PR TITLE
perf(auth): optimize Better Auth performance

### DIFF
--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+const betterAuth = vi.fn((options: unknown) => ({ options }))
+
+vi.mock("better-auth/minimal", () => ({ betterAuth }))
+vi.mock("better-auth/adapters/drizzle", () => ({
+  drizzleAdapter: vi.fn(() => "drizzle-adapter"),
+}))
+vi.mock("@prive-admin-tanstack/db/client", () => ({
+  createDb: vi.fn(() => "db"),
+}))
+vi.mock("@prive-admin-tanstack/env/server", () => ({
+  env: {
+    BETTER_AUTH_SECRET: "test-secret",
+    BETTER_AUTH_URL: "http://localhost:3000",
+    CORS_ORIGIN: "http://localhost:3001",
+  },
+}))
+
+describe("createAuth", () => {
+  beforeEach(() => {
+    betterAuth.mockClear()
+  })
+
+  it("enables short-lived cookie caching for session reads", async () => {
+    const { createAuth } = await import("./index")
+
+    createAuth()
+
+    expect(betterAuth).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session: {
+          cookieCache: {
+            enabled: true,
+            maxAge: 5 * 60,
+          },
+        },
+      }),
+    )
+  })
+})

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,8 +1,8 @@
 import { createDb } from "@prive-admin-tanstack/db/client"
 import * as schema from "@prive-admin-tanstack/db/schema/auth"
 import { env } from "@prive-admin-tanstack/env/server"
-import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
+import { betterAuth } from "better-auth/minimal"
 
 export function createAuth() {
   const db = createDb()
@@ -16,6 +16,12 @@ export function createAuth() {
     emailAndPassword: {
       enabled: true,
       disableSignUp: true,
+    },
+    session: {
+      cookieCache: {
+        enabled: true,
+        maxAge: 5 * 60,
+      },
     },
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,


### PR DESCRIPTION
## Summary
- enable short-lived Better Auth session cookie caching to reduce repeated session DB reads
- switch server auth import to better-auth/minimal for the Drizzle adapter path
- add a focused auth config test for cookie cache settings

## Verification
- vp test
- vp check and vp test via pre-push hook
- vp run -r build

## Build size
- server .mjs chunks before minimal import: 2,445,561 bytes
- server .mjs chunks after minimal import: 1,919,467 bytes
- reduction: 526,094 bytes